### PR TITLE
[INTERNAL] Travis: Use node lts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js # don't install any environment
 
 node_js:
-- "8"
-- "10"
+- "lts/*"
 
 script:
   - npm run lint


### PR DESCRIPTION
As this module does not execute any tests, the use of multiple node
versions is unnecessary. Also, this prevents duplicative JSDoc builds.