### PR TITLE
[INTERNAL] JSDoc: Set wrap option and add openGraph meta data

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -20,6 +20,13 @@
         "cleverLinks": false,
         "monospaceLinks": false
     },
+    "openGraph": {
+        "title": "UI5 Build and Development Tooling - API Reference",
+        "type": "website",
+        "image": "https://sap.github.io/ui5-tooling/docs/images/UI5_logo_wide.png",
+        "site_name": "UI5 Build and Development Tooling - API Reference",
+        "url": "https://sap.github.io/ui5-tooling/"
+    },
     "docdash": {
         "sectionOrder": [
             "Modules",
@@ -32,11 +39,12 @@
             "Interfaces"
         ],
         "meta": {
-            "title": "UI5 Tooling JSDoc",
-            "description": "UI5 Build and Development Tooling",
-            "keyword": "openui5 sapui5 ui5 build development tool"
+            "title": "UI5 Build and Development Tooling - API Reference",
+            "description": "UI5 Build and Development Tooling - API Reference",
+            "keyword": "openui5 sapui5 ui5 build development tool api reference"
         },
         "search": true,
+        "wrap": true,
         "menu": {
             "GitHub": {
                 "href": "https://github.com/SAP/ui5-tooling",

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -18,7 +18,10 @@
     },
     "templates": {
         "cleverLinks": false,
-        "monospaceLinks": false
+        "monospaceLinks": false,
+        "default": {
+            "useLongnameInNav": true
+        }
     },
     "openGraph": {
         "title": "UI5 Build and Development Tooling - API Reference",
@@ -30,10 +33,10 @@
     "docdash": {
         "sectionOrder": [
             "Modules",
+            "Namespaces",
             "Classes",
             "Externals",
             "Events",
-            "Namespaces",
             "Mixins",
             "Tutorials",
             "Interfaces"

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -4,7 +4,7 @@
     },
     "source": {
         "include": ["README.md"],
-        "includePattern": "node_modules/@ui5/[^\/]*/lib/.+\\.js$",
+        "includePattern": "node_modules/@ui5/[^\/]*/(lib/.+|index)\\.js$",
         "excludePattern": "node_modules/@ui5/.*/node_modules/@ui5"
     },
     "plugins": [],


### PR DESCRIPTION
Wrapping navigation names is necessary because our module names are very
long.