### PR TITLE
[INTERNAL] package.json: Add workaround for http downgrade of package-lock.json URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -293,8 +293,7 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"optional": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -303,7 +302,7 @@
 		},
 		"async": {
 			"version": "2.6.1",
-			"resolved": "http://registry.npmjs.org/async/-/async-2.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 			"requires": {
 				"lodash": "^4.17.10"
@@ -711,7 +710,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-			"optional": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -1016,8 +1014,7 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"optional": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -1446,8 +1443,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"optional": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"eyes": {
 			"version": "0.1.8",
@@ -1500,7 +1496,7 @@
 		},
 		"finalhandler": {
 			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"requires": {
 				"debug": "2.6.9",
@@ -1616,7 +1612,7 @@
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
@@ -1669,7 +1665,7 @@
 		},
 		"got": {
 			"version": "6.7.1",
-			"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"requires": {
 				"create-error-class": "^3.0.0",
@@ -1773,7 +1769,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
 				"depd": "~1.1.2",
@@ -2009,7 +2005,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-path-inside": {
@@ -2358,7 +2354,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
@@ -2512,7 +2508,7 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
@@ -2579,7 +2575,7 @@
 		},
 		"ncp": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
 			"integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
 		},
 		"negotiator": {
@@ -2785,7 +2781,7 @@
 				},
 				"get-stream": {
 					"version": "4.1.0",
-					"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"requires": {
 						"pump": "^3.0.0"
@@ -2805,7 +2801,7 @@
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
 			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
@@ -3047,7 +3043,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -3138,6 +3134,25 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"replace": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/replace/-/replace-1.0.1.tgz",
+			"integrity": "sha512-Qh0XcLMb3LYa6fs7V30zQHACbJTQJUERl22lVjaq0dJp6B5q1t/vARXDauS1ywpIs3ZkT3APj4EA6aOoHoaHDA==",
+			"dev": true,
+			"requires": {
+				"colors": "1.2.4",
+				"minimatch": "3.0.4",
+				"yargs": "12.0.5"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.4.tgz",
+					"integrity": "sha512-6Y+iBnWmXL+AWtlOp2Vr6R2w5MUlNJRwR0ShVFaAb1CqWzhPOpQg4L0jxD+xpw/Nc8QJwaq3KM79QUCriY8CWQ==",
+					"dev": true
+				}
+			}
 		},
 		"replacestream": {
 			"version": "4.0.3",
@@ -3652,7 +3667,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
@@ -3991,7 +4006,7 @@
 			"dependencies": {
 				"async": {
 					"version": "0.9.2",
-					"resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
 					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
 				}
 			}
@@ -4099,7 +4114,7 @@
 		},
 		"winston": {
 			"version": "2.1.1",
-			"resolved": "http://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
 			"integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
 			"requires": {
 				"async": "~1.0.0",
@@ -4113,7 +4128,7 @@
 			"dependencies": {
 				"async": {
 					"version": "1.0.0",
-					"resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
 					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
 				},
 				"colors": {
@@ -4135,7 +4150,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
@@ -4173,7 +4188,7 @@
 		},
 		"xmlbuilder": {
 			"version": "9.0.7",
-			"resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
 			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		},
 		"xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 	"scripts": {
 		"test": "npm run jsdoc-generate",
 		"jsdoc": "npm run jsdoc-generate && opn jsdocs/index.html",
-		"jsdoc-generate": "node_modules/.bin/jsdoc -c ./jsdoc.json ./ && cp -R ./docs ./jsdocs || (echo 'Error during JSDoc generation! Check log.' && exit 1)"
+		"jsdoc-generate": "node_modules/.bin/jsdoc -c ./jsdoc.json ./ && cp -R ./docs ./jsdocs || (echo 'Error during JSDoc generation! Check log.' && exit 1)",
+		"postshrinkwrap": "replace --silent 'http://' 'https://' ./package-lock.json"
 	},
 	"repository": {
 		"type": "git",
@@ -37,6 +38,7 @@
 	"devDependencies": {
 		"docdash": "^1.0.2",
 		"jsdoc": "^3.5.5",
-		"opn-cli": "^4.0.0"
+		"opn-cli": "^4.0.0",
+		"replace": "^1.0.1"
 	}
 }


### PR DESCRIPTION
See https://npm.community/t/some-packages-have-dist-tarball-as-http-and-not-https/285/44 and https://npm.community/t/npm-install-downgrading-resolved-packages-from-https-to-http-registry-in-package-lock-json/1818/16