### PR TITLE
[RFC] 0007 Properties File Encoding

### DIFF
--- a/rfcs/0006-properties-file-encoding.md
+++ b/rfcs/0006-properties-file-encoding.md
@@ -1,0 +1,81 @@
+- Start Date: 2019-07-15
+- RFC PR: -
+- Issue: [#161](https://github.com/SAP/ui5-tooling/issues/161)
+- Affected components
+    + [x] [ui5-builder](https://github.com/SAP/ui5-builder)
+    + [x] [ui5-server](https://github.com/SAP/ui5-server)
+    + [ ] [ui5-cli](https://github.com/SAP/ui5-cli)
+    + [ ] [ui5-fs](https://github.com/SAP/ui5-fs)
+    + [ ] [ui5-project](https://github.com/SAP/ui5-project)
+    + [ ] [ui5-logger](https://github.com/SAP/ui5-logger)
+
+
+# RFC 0006 Properties File Encoding
+## Summary
+Properties files (`*.properties`) should be encoded in UTF-8 such that the client properly can consume it.
+
+## Motivation
+Currently the properties files are encoded in ISO-8859-1 but served as UTF-8 which leads to the problem that special characters are not displayed correctly.
+The user wants to be able to use properties files with ISO-8859-1 encoding and also have the option to specify the encoding.
+
+## Detailed design
+### Configuration
+A configuration for the task/server should be provided such that the source encoding can be specified.
+There should be 2 options:
+* `ISO-8859-1` (non ASCII characters will be escaped with the unicode sequence `\uXXXX`)
+* `UTF-8` (no character escaping will take place)
+
+The default is `ISO-8859-1` for compatibility reasons.
+
+Umlaut Example:
+
+| Umlaut   |	Unicode         |
+|----------|--------------------|
+| `Ä`, `ä` | `\u00c4`, `\u00e4` |
+| `Ö`, `ö` | `\u00d6`, `\u00f6` |
+| `Ü`, `ü` | `\u00dc`, `\u00fc` |
+| `ß` 	   | `\u00df `          |
+
+This should be configured within the .ui5.yml file.
+
+Example:
+```yaml
+specVersion: "1.0"
+type: application
+metadata:
+  name: my.application
+resources:
+  propertiesFiles:
+    - encoding: "UTF-8"
+```
+
+The resources section within the configuration can be consumed by `ui5-builder` and `ui5-server`.
+
+### Build Task
+The `ui5-builder` should offer a task called `encodePropertiesFiles` which escapes all special characters in unicode using the unicode escape sequence `\uXXXX`.
+It should use a processor called `stringEscaper` which escapes special characters in files and is used within the task to operate only on `*.properties` files.
+The processor offers a function called `escapeNonAsciiAsUnicode` which performs the unicode escaping.
+The task should be run first (before `replaceCopyright`) for all types.
+This ensures that the properties files can always be consumed.
+Each build output contains then the escaped properties files.
+This task should automatically be integrated into the build process and can be reused by the server.
+
+### Server part
+The `ui5-server` offers the capability to re-use the ui5-builder processor `stringEscaper` used by the build task to escape these characters.
+The served content can always be interpreted as UTF-8 and therefore be properly consumed.
+There should be a special treatment in [serveResources](https://github.com/SAP/ui5-server/blob/master/lib/middleware/serveResources.js#L42) middleware which uses the configuration and the processor to serve properties files such that they can be interpreted as UTF-8 encoded files.
+
+
+## How we teach this
+- Documentation about how to specify the properties files encoding option
+- Explanation of the Escaping with examples
+
+## Drawbacks
+
+
+## Alternatives
+ - Check the file contents and guess its encoding
+   - Use response content-type header attribute
+   - Only escape if required
+
+## Unresolved Questions and Bikeshedding

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -84,18 +84,16 @@ A static function (`nonAsciiEscaper.getEncodingFromAlias`) should be added to ma
 
 ### Task
 
-A new task `escapeNonAsciiCharacters` should be added which receives the source encoding and a pattern to glob files within the workspace.
+A task `escapeNonAsciiCharacters` should be added which receives the source encoding and a pattern to glob files within the workspace.
 It uses the `nonAsciiEscaper.getEncodingFromAlias` function to map the source encoding (based on the project configuration values) to a valid encoding for the processor.
 
 ### Types
 
-The task operates on `*.properties` files using the processor.
-The task should run first (before `replaceCopyright`) for all types.
+Both `application` and `library` types should be enhanced.
 
-This ensures that the properties files can always be consumed independent of the source encoding.
-Each build output should contain the escaped properties files.
+The formatters should take the [configuration](#Configuration) into account and apply the default.
 
-The new standard task should automatically be integrated into the build process and the underlaying processor can be reused by the `ui5-server`.
+The builders should execute the `escapeNonAsciiCharacters` task as the very first task and pass the propertiesFileSourceEncoding from the project configuration. The pattern should include all properties files (`/**/*.properties`).
 
 ### Server
 

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -39,9 +39,9 @@ But as there are existing tools and server middleware which explicitly expect th
 A configuration for the `ui5-builder` tasks and the `ui5-server` should be provided such that the source encoding of `*.properties` files can be specified.
 
 This configuration is set on project level, so that multiple projects with different encodings function idependently.
-Resources create as part of the project contain a reference to the project, which allows to read the expected source encoding for a single resource.
+Resources created as part of the project contain a reference to the project, which allows to read the expected source encoding for a single resource.
 
-Altought there are lots of different encodings, the configuration on projects only foresees the two relevant encodings.
+Altought there are lots of different encodings, the configuration of projects only foresees two relevant encodings.
 
 Supported values are: `UTF-8` and `ISO-8859-1`
 

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -44,7 +44,8 @@ type: application
 metadata:
   name: my.application
 resources:
-  propertiesFileEncoding: "UTF-8"
+  configuration:
+    propertiesFileEncoding: "UTF-8"
 ```
 
 The resources section within the configuration can be consumed by `ui5-builder` and `ui5-server`.

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -53,7 +53,7 @@ The resources section within the configuration can be consumed by `ui5-builder` 
 
 The `ui5-builder` should offer a new standard task called `escapeNonAsciiCharacters` which escapes all special characters in unicode using the unicode escape sequence `\uXXXX`.
 It should use a processor called `nonAsciiEscaper` which escapes non ascii characters (characters which are not within the 128 character ASCII range) within a given string.
-The processor `nonAsciiEscaper` should offer an encoding parameter and a method which provides valid values for this option (`nonAsciiEscaper#getEncodingFromNiceName`).
+The processor `nonAsciiEscaper` should offer an encoding parameter and a method which provides valid values for this option (`nonAsciiEscaper#getEncodingFromAlias`).
 
 
 Umlaut Example:

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -10,7 +10,7 @@
     + [ ] [ui5-logger](https://github.com/SAP/ui5-logger)
 
 
-# RFC 0006 Properties File Encoding
+# RFC 0007 Properties File Encoding
 ## Summary
 Properties files (`*.properties`) should be encoded in UTF-8 such that the client properly can consume it.
 

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -53,15 +53,14 @@ type: application
 metadata:
   name: my.application
 resources:
-  propertiesFiles:
-    - encoding: "UTF-8"
+  propertiesFileEncoding: "UTF-8"
 ```
 
 The resources section within the configuration can be consumed by `ui5-builder` and `ui5-server`.
 
 ### Build Task
 
-The `ui5-builder` should offer a new standard task called `escapePropertiesFiles` which escapes all special characters in unicode using the unicode escape sequence `\uXXXX`.
+The `ui5-builder` should offer a new standard task called `escapeNonAsciiCharacters` which escapes all special characters in unicode using the unicode escape sequence `\uXXXX`.
 It should use a processor called `stringEscaper` which escapes special characters in files and is used within the task to operate only on `*.properties` files.
 The task should be run first (before `replaceCopyright`) for all types.
 This ensures that the properties files can always be consumed.

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -18,8 +18,8 @@ Properties files (`*.properties`) should be encoded in pure ASCII when serving t
 ## Motivation
 
 Currently the properties files are mostly encoded in ISO-8859-1 (which is used by most existing SAP server platforms).
-By default the files are served as UTF-8 by the `ui5-server`. This will lead to the problem that special characters are not displayed correctly.
-The user wants to be able to use properties files with ISO-8859-1 encoding. Additionally the user wants have the option to specify the encoding.
+By default the files are served as UTF-8 by the `ui5-server`. This will lead to the problem that special characters are not displayed correctly because they are read using UTF-8 encoding.
+The user wants to be able to use properties files with ISO-8859-1 encoding. Additionally the user wants have the option to specify UTF-8 encoding if the properties file contain special characters.
 
 ## Detailed design
 
@@ -45,7 +45,7 @@ metadata:
   name: my.application
 resources:
   configuration:
-    propertiesFileEncoding: "UTF-8"
+    propertiesFileSourceEncoding: "UTF-8"
 ```
 
 The resources section within the configuration can be consumed by `ui5-builder` and `ui5-server`.

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -30,7 +30,7 @@ A configuration for the `ui5-builder` tasks and the `ui5-server` should be provi
 Encodings should be supported according to the [Encoding spec](https://encoding.spec.whatwg.org/).
 For more information check out: [Buffers and Character Encodings](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings)
 
-Sample values are: 'ascii', 'utf8', 'utf16le', 'latin1' ('ISO-8859-1'), ...
+Supported values are: `UTF-8` and `ISO-8859-1`
 
 The default is `ISO-8859-1` for compatibility reasons (set by the formatters).
 
@@ -52,7 +52,8 @@ The resources section within the configuration can be consumed by `ui5-builder` 
 ### Build Task
 
 The `ui5-builder` should offer a new standard task called `escapeNonAsciiCharacters` which escapes all special characters in unicode using the unicode escape sequence `\uXXXX`.
-It should use a processor called `stringEscaper` which escapes non ascii characters (characters which are not within the 128 character ASCII range) within a given string.
+It should use a processor called `nonAsciiEscaper` which escapes non ascii characters (characters which are not within the 128 character ASCII range) within a given string.
+The processor `nonAsciiEscaper` should offer an encoding parameter and a method which provides valid values for this option (`nonAsciiEscaper#getEncodingFromNiceName`).
 
 
 Umlaut Example:
@@ -76,7 +77,7 @@ The new standard task should automatically be integrated into the build process 
 
 The `ui5-server` should serve all resources using `UTF-8` [charset header](https://www.w3.org/International/articles/http-charset/index.en).
 
-The `ui5-server` should offer the capability to re-use the `ui5-builder` processor `stringEscaper` to escape characters in `*.properties` files.
+The `ui5-server` should offer the capability to re-use the `ui5-builder` processor `nonAsciiEscaper` to escape characters in `*.properties` files.
 Due to the pure ASCII representation now, the served content can always be interpreted and properly consumed as UTF-8.
 
 Technically, there should be a special treatment in [serveResources](https://github.com/SAP/ui5-server/blob/master/lib/middleware/serveResources.js#L42) middleware which uses the configuration and the processor to serve properties files such that they can be interpreted as `UTF-8` encoded content.

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -1,5 +1,5 @@
 - Start Date: 2019-07-15
-- RFC PR: -
+- RFC PR: [#168](https://github.com/SAP/ui5-tooling/pull/168)
 - Issue: [#161](https://github.com/SAP/ui5-tooling/issues/161)
 - Affected components
     + [x] [ui5-builder](https://github.com/SAP/ui5-builder)

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -1,44 +1,52 @@
+# RFC 0007 Properties File Encoding
+
 - Start Date: 2019-07-15
 - RFC PR: [#168](https://github.com/SAP/ui5-tooling/pull/168)
 - Issue: [#161](https://github.com/SAP/ui5-tooling/issues/161)
 - Affected components
-    + [x] [ui5-builder](https://github.com/SAP/ui5-builder)
-    + [x] [ui5-server](https://github.com/SAP/ui5-server)
-    + [ ] [ui5-cli](https://github.com/SAP/ui5-cli)
-    + [ ] [ui5-fs](https://github.com/SAP/ui5-fs)
-    + [ ] [ui5-project](https://github.com/SAP/ui5-project)
-    + [ ] [ui5-logger](https://github.com/SAP/ui5-logger)
+  - [x] [ui5-builder](https://github.com/SAP/ui5-builder)
+  - [x] [ui5-server](https://github.com/SAP/ui5-server)
+  - [ ] [ui5-cli](https://github.com/SAP/ui5-cli)
+  - [ ] [ui5-fs](https://github.com/SAP/ui5-fs)
+  - [ ] [ui5-project](https://github.com/SAP/ui5-project)
+  - [ ] [ui5-logger](https://github.com/SAP/ui5-logger)
 
-
-# RFC 0007 Properties File Encoding
 ## Summary
-Properties files (`*.properties`) should be encoded in UTF-8 such that the client properly can consume it.
+
+Properties files (`*.properties`) should be encoded in pure ASCII when serving them via the `ui5-server` or building an application/library with the `ui5-builder`.
 
 ## Motivation
-Currently the properties files are encoded in ISO-8859-1 but served as UTF-8 which leads to the problem that special characters are not displayed correctly.
-The user wants to be able to use properties files with ISO-8859-1 encoding and also have the option to specify the encoding.
+
+Currently the properties files are mostly encoded in ISO-8859-1 (which is used by most existing SAP server platforms).
+By default the files are served as UTF-8 by the `ui5-server`. This will lead to the problem that special characters are not displayed correctly.
+The user wants to be able to use properties files with ISO-8859-1 encoding. Additionally the user wants have the option to specify the encoding.
 
 ## Detailed design
+
 ### Configuration
-A configuration for the task/server should be provided such that the source encoding can be specified.
+
+A configuration for the `ui5-builder` tasks and the `ui5-server` should be provided such that the source encoding can be specified.
+
 There should be 2 options:
-* `ISO-8859-1` (non ASCII characters will be escaped with the unicode sequence `\uXXXX`)
-* `UTF-8` (no character escaping will take place)
+
+- `ISO-8859-1` (non ASCII characters will be escaped with the unicode sequence `\uXXXX`)
+- `UTF-8` (no character escaping will take place)
 
 The default is `ISO-8859-1` for compatibility reasons.
 
 Umlaut Example:
 
-| Umlaut   |	Unicode         |
+| Umlaut   | UTF-8              |
 |----------|--------------------|
 | `Ä`, `ä` | `\u00c4`, `\u00e4` |
 | `Ö`, `ö` | `\u00d6`, `\u00f6` |
 | `Ü`, `ü` | `\u00dc`, `\u00fc` |
-| `ß` 	   | `\u00df `          |
+| `ß`      | `\u00df`          |
 
-This should be configured within the .ui5.yml file.
+This should be configured within the `ui5.yaml` file.
 
 Example:
+
 ```yaml
 specVersion: "1.0"
 type: application
@@ -52,30 +60,36 @@ resources:
 The resources section within the configuration can be consumed by `ui5-builder` and `ui5-server`.
 
 ### Build Task
-The `ui5-builder` should offer a task called `encodePropertiesFiles` which escapes all special characters in unicode using the unicode escape sequence `\uXXXX`.
+
+The `ui5-builder` should offer a new standard task called `escapePropertiesFiles` which escapes all special characters in unicode using the unicode escape sequence `\uXXXX`.
 It should use a processor called `stringEscaper` which escapes special characters in files and is used within the task to operate only on `*.properties` files.
-The processor offers a function called `escapeNonAsciiAsUnicode` which performs the unicode escaping.
 The task should be run first (before `replaceCopyright`) for all types.
 This ensures that the properties files can always be consumed.
-Each build output contains then the escaped properties files.
-This task should automatically be integrated into the build process and can be reused by the server.
+Each build output should contain then the escaped properties files.
+This ensures taht the now purely ASCII based `*.properties` files can be used on other platforms too.
+
+The new standard task should automatically be integrated into the build process and can be reused by the server.
 
 ### Server part
-The `ui5-server` offers the capability to re-use the ui5-builder processor `stringEscaper` used by the build task to escape these characters.
-The served content can always be interpreted as UTF-8 and therefore be properly consumed.
-There should be a special treatment in [serveResources](https://github.com/SAP/ui5-server/blob/master/lib/middleware/serveResources.js#L42) middleware which uses the configuration and the processor to serve properties files such that they can be interpreted as UTF-8 encoded files.
 
+Currently the `ui5-server` serves all resources as UTF-8.
+
+The `ui5-server` should offer the capability to re-use the `ui5-builder` processor `stringEscaper` to also escape characters while serving `*.properties`.
+Due to the pure ASCII representation now, the served content can always be interpreted and properly consumed as UTF-8.
+
+Technically, there should be a special treatment in [serveResources](https://github.com/SAP/ui5-server/blob/master/lib/middleware/serveResources.js#L42) middleware which uses the configuration and the processor to serve properties files such that they can be interpreted as UTF-8 encoded files.
 
 ## How we teach this
+
 - Documentation about how to specify the properties files encoding option
 - Explanation of the Escaping with examples
 
 ## Drawbacks
 
-
 ## Alternatives
- - Check the file contents and guess its encoding
-   - Use response content-type header attribute
-   - Only escape if required
+
+- Check the file contents and guess its encoding
+  - Use response content-type header attribute
+  - Only escape if the file encoding and the transport encoding do not match, e.g. file is encoded as `ISO-8859-1` but will be served as `UTF-8`
 
 ## Unresolved Questions and Bikeshedding

--- a/rfcs/0007-properties-file-encoding.md
+++ b/rfcs/0007-properties-file-encoding.md
@@ -19,7 +19,8 @@ Properties files (`*.properties`) should be encoded in pure ASCII when serving t
 
 Currently the properties files are mostly encoded in ISO-8859-1 (which is used by most existing SAP server platforms).
 By default the files are served as UTF-8 by the `ui5-server`. This will lead to the problem that special characters are not displayed correctly because they are read using UTF-8 encoding.
-The user wants to be able to use properties files with ISO-8859-1 encoding. Additionally the user wants have the option to specify UTF-8 encoding if the properties file contain special characters.
+The user wants to be able to use properties files with ISO-8859-1 encoding. Additionally the user wants have the option to specify UTF-8 encoding 
+e.g. if a properties file contains special characters which are not present in ISO-8859-1.
 
 ## Detailed design
 


### PR DESCRIPTION
Add a fix for properties file encoding when they are part of a build or served such that they can always be interpreted as UTF-8 encoded files.

Read: [0007-properties-file-encoding.md](https://github.com/SAP/ui5-tooling/blob/rfc-properties-file-encoding/rfcs/0007-properties-file-encoding.md)