### PR TITLE
[INTERNAL] JSDoc: Exclude @ui5/builder JSTokenizer

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -4,6 +4,7 @@
     },
     "source": {
         "include": ["docs/indexJsdoc.md"],
+        "exclude": ["node_modules/@ui5/builder/lib/lbt/utils/JSTokenizer.js"],
         "includePattern": "node_modules/@ui5/[^\/]*/(lib/.+|index)\\.js$",
         "excludePattern": "node_modules/@ui5/.*/node_modules/@ui5"
     },


### PR DESCRIPTION
See https://github.com/SAP/ui5-builder/pull/304