### PR TITLE
[INTERNAL] add consuming SAPUI5 libraries page

### DIFF
--- a/docs/pages/ConsumingSAPUI5Libraries.md
+++ b/docs/pages/ConsumingSAPUI5Libraries.md
@@ -1,0 +1,3 @@
+# Consuming SAPUI5 libraries
+
+Coming soon


### PR DESCRIPTION
This page is linked in every SAPUI5 library's README.md.
It is a placeholder for the guide about how to consume
SAPUI5 libraries in the future.