### PR TITLE
[INTERNAL] Add specification version 1.1

### DIFF
--- a/docs/pages/Builder.md
+++ b/docs/pages/Builder.md
@@ -4,19 +4,28 @@ Types define how a project can be configured and how it is built. A type orchest
 
 Also see [UI5 Project: Configuration](https://sap.github.io/ui5-tooling/pages/Configuration/#root62)
 
-### `application`
+### application
 Projects of type `application` are typically the main or root project. In a projects dependency tree, there should only be one project of type `application`. If multiple are found, those further away from the root are ignored.
 
 The source directory of an application (typically named `webapp`) is mapped to the virtual root path `/`.
 
 An applications source directory may or may not contain a `Component.js` file. If it does, it must also contain a `manifest.json` file. If there is a `Component.js` file, an optimized `Component-preload.js` file will be generated during the build.
 
-### `library`
+### library
 UI5 libraries are often referred to as reuse-, custom- or [control libraries](https://github.com/SAP/openui5/blob/master/docs/controllibraries.md). They are a key component in sharing code across multiple projects in UI5.
 
-A project of type `library` must have a source directory (typically named `src`). It may also feature a "test" directory. These directories are mapped to the virtual directories `/resources` for the sources and `/test-resources` for the test resources. These directories should contain a directory structure representing the namespace of the library (e.g. `src/my/first/library`) to prevent name clashes between the resources of different libraries.
+A project of type `library` must have a source directory (typically named `src`). It may also feature a "test" directory. These directories are mapped to the virtual directories `/resources` for the sources and `/test-resources` for the test resources.
 
-### `module`
+These directories should contain a directory structure representing the namespace of the library (e.g. `src/my/first/library`) to prevent name clashes between the resources of different libraries.
+
+### theme-library
+UI5 theme libraries provide theming resources for the controls of one or multiple libraries.
+
+A project of type `theme-library` must have a source directory (typically named `src`). It may also feature a "test" directory. These directories are mapped to the virtual directories `/resources` for the sources and `/test-resources` for the test resources.
+
+The source directory must contain a directory structure representing the namespaces of the libraries it provides theme resources for. For example, a theme library named `my_custom_theme`, providing resources for a library named `my.library` should have these resources in a directory path `my/library/themes/my_custom_theme/`.
+
+### module
 The `module` type is meant for usage with non-UI5 resources like third party libraries. Their path mapping can be configured freely. During a build, their resources are copied without modifications.
 
 ## Tasks

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -1,13 +1,13 @@
 # Configuration
-This document describes the configuration of UI5 Tooling based projects and extensions. It represents **[Specification Version](#specification-versions) `1.0`**.
+This document describes the configuration of UI5 Tooling based projects and extensions. It represents **[Specification Version](#specification-versions) `1.1`**.
 
 A projects UI5 Tooling configuration is typically located in a [YAML](https://yaml.org/) file named `ui5.yaml`, located in the root directory.
 
 ## Example
 
 ````yaml
-specVersion: "1.0"
-type: application|library|module
+specVersion: "1.1"
+type: application|library|theme-library|module
 metadata:
   name: some.project.name
 ````
@@ -15,10 +15,10 @@ metadata:
 ## General Configuration
 A project must define a specification version (`specVersion`), to which its configuration is compatible to. Also see [Specification Versions](#specification-versions).
 
-In addition, a project must define a `type`. This can be either `application`, `library` or `module`. The type defines the default path mappings and build tasks. See [UI5 Builder: Types](./Builder.md#types) for details.
+In addition, a project must define a `type`. This can be either `application`, `library`, `theme-library` or `module`. The type defines the default path mappings and build tasks. See [UI5 Builder: Types](./Builder.md#types) for details.
 
 ````yaml
-specVersion: "1.0"
+specVersion: "1.1"
 type: library
 ````
 
@@ -46,7 +46,7 @@ Depending on the project type, the UI5 Tooling expects your projects source file
 **Type: application**  
 Default directory for runtime and test files: `webapp`
 
-**Type: library**  
+**Type: library and theme-library**  
 Default directory for runtime files: `src`  
 Default directory for test files: `test`
 
@@ -202,12 +202,12 @@ Extensions can be identified by the `kind: extension` configuration. Note that i
 
 ### Example
 ````yaml
-specVersion: "1.0"
+specVersion: "1.1"
 type: application
 metadata:
   name: my.application
 ---
-specVersion: "1.0"
+specVersion: "1.1"
 kind: extension
 type: project-shim
 metadata:
@@ -215,7 +215,7 @@ metadata:
 shims:
   configurations:
     lodash:
-      specVersion: "1.0"
+      specVersion: "1.1"
       type: module
       metadata:
         name: lodash
@@ -292,10 +292,11 @@ The specification version as configured in the `specVersion` property, defines t
 
 ## Compatibility Matrix
 
-Version | [UI5 CLI](https://github.com/SAP/ui5-cli) Release
+Version | UI5 CLI Release
 --- | ---
 **0.1** | v0.0.1+
 **1.0** | v1.0.0+
+**1.1** | v1.13.0+
 
 ## Specification Version 0.1
 Initial version.
@@ -306,3 +307,8 @@ Version 0.1 projects are compatible with [UI5 CLI](https://github.com/SAP/ui5-cl
 First stable release.
 
 Version 1.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v1.0.0 and above.
+
+### Specification Version 1.1
+Adds support for the `theme-library` type.
+
+Version 1.1 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v1.13.0 and above.

--- a/docs/pages/Project.md
+++ b/docs/pages/Project.md
@@ -76,7 +76,7 @@ Enhances a given dependency tree based on a projects [configuration](docs/Config
     "id": "projectA",
     "version": "1.0.0",
     "path": "/absolute/path/to/projectA",
-    "specVersion": "0.1",
+    "specVersion": "1.1",
     "type": "application",
     "metadata": {
         "name": "sap.projectA",
@@ -97,7 +97,7 @@ Enhances a given dependency tree based on a projects [configuration](docs/Config
             "id": "projectB",
             "version": "1.0.0",
             "path": "/path/to/projectB",
-            "specVersion": "0.1",
+            "specVersion": "1.1",
             "type": "library",
             "metadata": {
                 "name": "sap.ui.projectB"
@@ -119,7 +119,7 @@ Enhances a given dependency tree based on a projects [configuration](docs/Config
                     "id": "projectD",
                     "version": "1.0.0",
                     "path": "/path/to/different/projectD",
-                    "specVersion": "0.1",
+                    "specVersion": "1.1",
                     "type": "library",
                     "metadata": {
                         "name": "sap.ui.projectD"
@@ -144,7 +144,7 @@ Enhances a given dependency tree based on a projects [configuration](docs/Config
             "id": "projectD",
             "version": "1.0.0",
             "path": "/path/to/projectD",
-            "specVersion": "0.1",
+            "specVersion": "1.1",
             "type": "library",
             "metadata": {
                 "name": "sap.ui.projectD"

--- a/docs/pages/extensibility/CustomServerMiddleware.md
+++ b/docs/pages/extensibility/CustomServerMiddleware.md
@@ -9,7 +9,7 @@ A middleware may be executed before or after any other middleware.
 
 ### Example: Basic configuration
 ```yaml
-specVersion: "1.0"
+specVersion: "1.1"
 type: application
 metadata:
   name: my.application
@@ -39,7 +39,7 @@ A custom middleware extension consists of a `ui5.yaml` and a [custom middleware 
 ### Example: ui5.yaml
 
 ````yaml
-specVersion: "1.0"
+specVersion: "1.1"
 kind: extension
 type: server-middleware
 metadata:
@@ -59,7 +59,7 @@ The UI5 Server will detect the custom middleware configuration of the project an
 
 ````yaml
 # Project configuration for the above example
-specVersion: "1.0"
+specVersion: "1.1"
 kind: project
 type: application
 metadata:
@@ -70,7 +70,7 @@ server:
       beforeMiddleware: serveResources
 ---
 # Custom middleware extension as part of your project
-specVersion: "1.0"
+specVersion: "1.1"
 kind: extension
 type: server-middleware
 metadata:

--- a/docs/pages/extensibility/CustomTasks.md
+++ b/docs/pages/extensibility/CustomTasks.md
@@ -12,7 +12,7 @@ In the below example, when building the library `my.library` the `babel` task wi
 
 ````yaml
 # In this example configuration two custom tasks are defined: 'babel' and 'generateMarkdownFiles'.
-specVersion: "1.0"
+specVersion: "1.1"
 type: library
 metadata:
   name: my.library
@@ -32,7 +32,7 @@ You can also connect multiple custom task with each other. Please be aware that 
 
 ````yaml
 # In this example 'myCustomTask2' gets executed after 'myCustomTask1'.
-specVersion: "1.0"
+specVersion: "1.1"
 type: library
 metadata:
   name: my.library
@@ -51,7 +51,7 @@ A custom task extension consists of a `ui5.yaml` and a [task implementation](#ta
 ### Example: ui5.yaml
 
 ````yaml
-specVersion: "1.0"
+specVersion: "1.1"
 kind: extension
 type: task
 metadata:
@@ -71,7 +71,7 @@ The task extension will then be automatically collected and processed during the
 
 ````yaml
 # Project configuration for the above example
-specVersion: "1.0"
+specVersion: "1.1"
 kind: project
 type: library
 metadata:
@@ -84,7 +84,7 @@ builder:
         color: blue
 ---
 # Task extension as part of your project
-specVersion: "1.0"
+specVersion: "1.1"
 kind: extension
 type: task
 metadata:

--- a/docs/pages/extensibility/ProjectShims.md
+++ b/docs/pages/extensibility/ProjectShims.md
@@ -5,7 +5,7 @@ Also see [RFC 0002 Project Shims](https://github.com/SAP/ui5-tooling/blob/master
 
 #### Structure
 ```yaml
-specVersion: "1.0"
+specVersion: "1.1"
 kind: extension
 type: project-shim
 metadata:
@@ -13,12 +13,12 @@ metadata:
 shims:
   configurations:
     <module name (id)>:
-      specVersion: "1.0",
+      specVersion: "1.1",
       type: <project type>
       metadata:
         name: <project name>
     <module name (id)>:
-      specVersion: "1.0",
+      specVersion: "1.1",
       type: <project type>
       metadata:
         name: <project name>
@@ -61,12 +61,12 @@ An application "my-application" defines a npm dependency to [lodash](https://lod
 
 **ui5.yaml**
 ```yaml
-specVersion: "1.0"
+specVersion: "1.1"
 type: application
 metadata:
   name: my.application
 --- # Everything below this line could also be put into the ui5.yaml of a standalone extension module
-specVersion: "1.0"
+specVersion: "1.1"
 kind: extension
 type: project-shim
 metadata:
@@ -74,7 +74,7 @@ metadata:
 shims:
   configurations:
     lodash: # name as defined in package.json
-      specVersion: "1.0"
+      specVersion: "1.1"
       type: module # Use module type
       metadata:
         name: lodash
@@ -142,12 +142,12 @@ application-a/
 The shim defined in the application configures the legacy libraries and defines their dependencies. This shim might as well be a standalone module that is added to the applications dependencies. That would be the typical reuse scenario for shims.
 
 ```yaml
-specVersion: "1.0"
+specVersion: "1.1"
 type: application
 metadata:
   name: application.a
 ----
-specVersion: "1.0"
+specVersion: "1.1"
 kind: extension
 type: project-shim
 metadata:
@@ -155,17 +155,17 @@ metadata:
 shims:
   configurations:
     legacy-library-a:
-      specVersion: "1.0"
+      specVersion: "1.1"
       type: library
       metadata:
         name: legacy.library.a
     legacy-library-b:
-      specVersion: "1.0"
+      specVersion: "1.1"
       type: library
       metadata:
         name: legacy.library.b
     legacy-library-x:
-      specVersion: "1.0"
+      specVersion: "1.1"
       type: library
       metadata:
         name: legacy.library.x


### PR DESCRIPTION
The new type 'theme-library' requires this spec version 1.1.

See https://github.com/SAP/ui5-project/pull/252 and
https://github.com/SAP/ui5-builder/pull/285