### PR TITLE
[BREAKING] Require Node.js >= 10

### DIFF
--- a/docs/pages/CLI.md
+++ b/docs/pages/CLI.md
@@ -1,7 +1,7 @@
 # UI5 CLI
 ## Installing the UI5 CLI
 ### Requirements
--   [Node.js](https://nodejs.org/) (**version 8.5 or higher** ⚠️)
+-   [Node.js](https://nodejs.org/) (**version 10 or higher** ⚠️)
 
 ### Installation
 ```sh

--- a/docs/pages/GettingStarted.md
+++ b/docs/pages/GettingStarted.md
@@ -1,7 +1,7 @@
 # Getting Started
 ## Installing the UI5 CLI
 ### Requirements
-- [Node.js](https://nodejs.org/) (**version 8.5 or higher** ⚠️)
+- [Node.js](https://nodejs.org/) (**version 10 or higher** ⚠️)
 
 ### Installation
 ```sh

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"tool"
 	],
 	"engines": {
-		"node": ">= 8.5",
+		"node": ">= 10",
 		"npm": ">= 5"
 	},
 	"scripts": {


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js releases has been dropped.
Only Node.js v10 or higher is supported.