### PR TITLE
UI5 Tooling 2.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,9 +33,12 @@ type: application
 
 ```
 ❯ ui5 use SAPUI5@1.76.0
-================ OUTPUT TBD ================
-❯ ui5 add sap.ui.core sap.m themelib_sap_fiori_3 [...]
-================ OUTPUT TBD ================
+Updated configuration written to ui5.yaml
+This project is now using SAPUI5 version 1.76.0
+
+❯ ui5 add sap.ui.core sap.m themelib_sap_fiori_3
+Updated configuration written to ui5.yaml
+Added framework libraries sap.ui.core sap.m themelib_sap_fiori_3 as dependencies
 ```
 
 #### 🏄 Server

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ type: application
 #### 🚚 Add Dependencies
 
 ```
-❯ ui5 use SAPUI5@1.75.0
+❯ ui5 use SAPUI5@1.76.0
 ================ OUTPUT TBD ================
 ❯ ui5 add sap.ui.core sap.m themelib_sap_fiori_3 [...]
 ================ OUTPUT TBD ================

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,13 +23,22 @@ Configure your project for use with the UI5 Tooling.
 ❯ ui5 init
 Wrote ui5.yaml:
 
-specVersion: '1.0'
+specVersion: '2.0'
 metadata:
   name: my-app
 type: application
 ```
 
-#### 🏄‍♂️ Server
+#### 🚚 Add Dependencies
+
+```
+❯ ui5 use SAPUI5@1.75.0
+================ OUTPUT TBD ================
+❯ ui5 add sap.ui.core sap.m themelib_sap_fiori_3 [...]
+================ OUTPUT TBD ================
+```
+
+#### 🏄 Server
 Start a local development server.  
 *Also see the [Server Documentation](./pages/Server.md)*
 

--- a/docs/pages/Builder.md
+++ b/docs/pages/Builder.md
@@ -19,7 +19,7 @@ A project of type `library` must have a source directory (typically named `src`)
 These directories should contain a directory structure representing the namespace of the library (e.g. `src/my/first/library`) to prevent name clashes between the resources of different libraries.
 
 ### theme-library
-*Available since [Specification Version](https://sap.github.io/ui5-tooling/pages/Configuration/#specification-versions) 1.1*
+*Available since [Specification Version](./Configuration.md#specification-versions) 1.1*
 
 UI5 theme libraries provide theming resources for the controls of one or multiple libraries.
 

--- a/docs/pages/CLI.md
+++ b/docs/pages/CLI.md
@@ -61,6 +61,7 @@ Options:
     --dev-exclude-project      A list of specific projects to be excluded from dev mode (dev mode must be active for this to be effective)  [array]
     --include-task             A list of specific tasks to be included to the default/dev set  [array]
     --exclude-task             A list of specific tasks to be excluded from default/dev set  [array]
+    --framework-version        Overrides the framework version defined by the project  [string]
 
 Examples:
     ui5 build --all                                                                      Preload build for project and dependencies to "./dist"
@@ -89,6 +90,7 @@ Options:
     --key                         Path to the private key  [string] [default: "$HOME/.ui5/server/server.key"]
     --cert                        Path to the certificate  [string] [default: "$HOME/.ui5/server/server.crt"]
     --sap-csp-policies            Always send content security policies 'sap-target-level-1' and 'sap-target-level-2' in report-only mode  [boolean] [default: false]
+    --framework-version           Overrides the framework version defined by the project  [string]
 
 
 Examples:

--- a/docs/pages/CLI.md
+++ b/docs/pages/CLI.md
@@ -17,16 +17,29 @@ ui5 --help
 Usage: ui5 <command> [options]
 
 Commands:
-  ui5 add [--development] [--optional] <framework-libraries..>  Add a SAPUI5/OpenUI5 framework library to the project
-                                                                configuration.
-  ui5 build                 Build project in current directory
-  ui5 init                  Initialize the UI5 Tooling configuration for an application or
-                              library project.
-  ui5 serve                 Start a web server for the current project
-  ui5 tree                  Outputs the dependency tree of the current project to stdout. It
-                              takes all relevant parameters of ui5 build into account.
-  ui5 use <framework-info>  Initialize or update the UI5 Tooling framework configuration.
-  ui5 versions              Shows the versions of all UI5 Tooling modules
+  ui5 add [--development] [--optional] <framework-libraries..>
+      Add SAPUI5/OpenUI5 framework libraries to the project
+        configuration.
+  
+  ui5 build
+      Build project in current directory
+  
+  ui5 init
+      Initialize the UI5 Tooling configuration for an application or
+        library project.
+  
+  ui5 serve
+      Start a web server for the current project
+  
+  ui5 tree
+      Outputs the dependency tree of the current project to stdout. It
+        takes all relevant parameters of ui5 build into account.
+  
+  ui5 use <framework-info>
+      Initialize or update the project's framework configuration.
+  
+  ui5 versions
+      Shows the versions of all UI5 Tooling modules
 
 Options:
   --help, -h               Show help  [boolean]
@@ -37,9 +50,11 @@ Options:
   --loglevel, --log-level  Set the logging level (error|warn|info|verbose|silly).  [string] [default: "info"]
 
 Examples:
-  ui5 <command> --translator static:/path/to/projectDependencies.yaml Execute command using a "static" translator with translator
-                                                                        parameters
-  ui5 <command> --config /path/to/ui5.yaml Execute command using a project configuration from custom path
+  ui5 <command> --translator static:/path/to/projectDependencies.yaml
+            Execute command using a "static" translator with translator
+              parameters
+  ui5 <command> --config /path/to/ui5.yaml
+            Execute command using a project configuration from custom path
 ```
 
 The CLI automatically checks for updates using [update-notifier](https://github.com/yeoman/update-notifier). While this is skipped in CI environments, you might also opt-out manually by following the steps described [here](https://github.com/yeoman/update-notifier/blob/master/readme.md#user-settings).
@@ -47,21 +62,26 @@ The CLI automatically checks for updates using [update-notifier](https://github.
 ### Commands
 #### add
 
-`ui5 add [--development] [--optional] <framework-libraries..>` adds a SAPUI5/OpenUI5 framework library to the project configuration.
+`ui5 add [--development] [--optional] <framework-libraries..>` adds SAPUI5/OpenUI5 framework libraries to the project configuration
 
 ```
 Positionals:
   framework-libraries  Framework library names  [array] [required] [default: []]
 
 Options:
-  --help, -h               Show help  [boolean]
-  --version, -v            Show version number  [boolean]
-  --config                 Path to configuration file  [string]
-  --translator, --t8r      Translator to use. Including optional colon separated translator parameters.  [string] [default: "npm"]
-  --verbose                Enable verbose logging  [boolean]
-  --loglevel, --log-level  Set the logging level (error|warn|info|verbose|silly)  [string] [default: "info"]
-  --development, -D        Add as development dependency  [boolean] [default: false]
-  --optional, -O           Add as optional dependency  [boolean] [default: false]
+  --help, -h                Show help  [boolean]
+  --version, -v             Show version number  [boolean]
+  --config                  Path to configuration file  [string]
+  --translator, --t8r       Translator to use. Including optional colon separated translator parameters.  [string] [default: "npm"]
+  --verbose                 Enable verbose logging  [boolean]
+  --loglevel, --log-level   Set the logging level (error|warn|info|verbose|silly)  [string] [default: "info"]
+  --development, -D, --dev  Add as development dependency  [boolean] [default: false]
+  --optional, -O            Add as optional dependency  [boolean] [default: false]
+
+Examples:
+  ui5 add sap.ui.core sap.m                Add the framework libraries sap.ui.core and sap.m as dependencies
+  ui5 add -D sap.ui.support                Add the framework library sap.ui.support as development dependency
+  ui5 add --optional themelib_sap_fiori_3  Add the framework library themelib_sap_fiori_3 as optional dependency
 ```
 
 #### build
@@ -166,11 +186,13 @@ Examples:
 
 #### use
 
-`ui5 use <framework-info>` initializes or updates the UI5 Tooling [framework configuration](./Configuration.md#framework-configuration).
+`ui5 use <framework-info>` initializes or updates the project's [framework configuration](./Configuration.md#framework-configuration).
 
 ```
 Positionals:
-  framework-info  Framework name, version or both  [string] [required]
+  framework-info  Framework name, version or both (name@version).
+                  Name can be "SAPUI5" or "OpenUI5" (case-insensitive).
+                  Version can be "latest", "1.xx" or "1.xx.x".  [string] [required]
 
 Options:
   --help, -h               Show help   [boolean]
@@ -179,6 +201,12 @@ Options:
   --translator, --t8r      Translator to use. Including optional colon separated translator parameters.  [string] [default: "npm"]
   --verbose                Enable verbose logging.  [boolean]
   --loglevel, --log-level  Set the logging level (error|warn|info|verbose|silly).  [string] [default: "info"]
+
+Examples:
+  ui5 use sapui5@latest  Use SAPUI5 in the latest available version
+  ui5 use openui5@1.76   Use OpenUI5 in the latest available 1.76 patch version
+  ui5 use latest         Use the latest available version of the configured framework
+  ui5 use openui5        Use OpenUI5 without a version (or use existing version)
 ```
 
 #### versions

--- a/docs/pages/CLI.md
+++ b/docs/pages/CLI.md
@@ -1,7 +1,7 @@
 # UI5 CLI
 ## Installing the UI5 CLI
 ### Requirements
--   [Node.js](https://nodejs.org/) (**version 8.5 or higher** ⚠️)
+-   [Node.js](https://nodejs.org/) (**version 10 or higher** ⚠️)
 
 ### Installation
 ```sh

--- a/docs/pages/CLI.md
+++ b/docs/pages/CLI.md
@@ -17,27 +17,53 @@ ui5 --help
 Usage: ui5 <command> [options]
 
 Commands:
-    build  Build project in current directory
-    serve  Start a webserver for the current project
-    tree   Outputs the dependency tree of the current project to stdout. It takes all relevant parameters of ui5 build into account.
-    init   Initializes the UI5 Tooling configuration for an application or library project
+  ui5 add [--development] [--optional] <framework-libraries..>  Add a SAPUI5/OpenUI5 framework library to the project
+                                                                configuration.
+  ui5 build                 Build project in current directory
+  ui5 init                  Initialize the UI5 Tooling configuration for an application or
+                              library project.
+  ui5 serve                 Start a web server for the current project
+  ui5 tree                  Outputs the dependency tree of the current project to stdout. It
+                              takes all relevant parameters of ui5 build into account.
+  ui5 use <framework-info>  Initialize or update the UI5 Tooling framework configuration.
+  ui5 versions              Shows the versions of all UI5 Tooling modules
 
 Options:
-    --help, -h                Show help  [boolean]
-    --version, -v             Show version number  [boolean]
-    --config                  Path to config file  [string]
-    --translator, --t8r       Translator to use. Including optional colon separated translator parameters.  [string] [default: "npm"]
-    --verbose                 Enable verbose logging. [boolean]
-    --loglevel, --log-level   Set the logging level (error|warn|info|verbose|silly).  [string] [default: "info"]
+  --help, -h               Show help  [boolean]
+  --version, -v            Show version number  [boolean]
+  --config                 Path to configuration file  [string]
+  --translator, --t8r      Translator to use. Including optional colon separated translator parameters.  [string] [default: "npm"]
+  --verbose                Enable verbose logging.[boolean]
+  --loglevel, --log-level  Set the logging level (error|warn|info|verbose|silly).  [string] [default: "info"]
 
 Examples:
-    ui5 <command> --translator static:/path/to/projectDependencies.yaml  Execute command using a "static" translator with translator parameters
-    ui5 <command> --config /path/to/ui5.yaml                         Execute command using a project configuration from custom path
+  ui5 <command> --translator static:/path/to/projectDependencies.yaml Execute command using a "static" translator with translator
+                                                                        parameters
+  ui5 <command> --config /path/to/ui5.yaml Execute command using a project configuration from custom path
 ```
 
 The CLI automatically checks for updates using [update-notifier](https://github.com/yeoman/update-notifier). While this is skipped in CI environments, you might also opt-out manually by following the steps described [here](https://github.com/yeoman/update-notifier/blob/master/readme.md#user-settings).
 
 ### Commands
+#### add
+
+`ui5 add [--development] [--optional] <framework-libraries..>` adds a SAPUI5/OpenUI5 framework library to the project configuration.
+
+```
+Positionals:
+  framework-libraries  Framework library names  [array] [required] [default: []]
+
+Options:
+  --help, -h               Show help  [boolean]
+  --version, -v            Show version number  [boolean]
+  --config                 Path to configuration file  [string]
+  --translator, --t8r      Translator to use. Including optional colon separated translator parameters.  [string] [default: "npm"]
+  --verbose                Enable verbose logging  [boolean]
+  --loglevel, --log-level  Set the logging level (error|warn|info|verbose|silly)  [string] [default: "info"]
+  --development, -D        Add as development dependency  [boolean] [default: false]
+  --optional, -O           Add as optional dependency  [boolean] [default: false]
+```
+
 #### build
 `ui5 build [options]` builds the project in the current directory.
 
@@ -69,6 +95,19 @@ Examples:
     ui5 build --all --include-task=createDebugFiles --exclude-task=generateAppPreload    Build project and dependencies by applying all default tasks including the createDebugFiles task and excluding the generateAppPreload task
     ui5 build dev --all --dev-exclude-project=sap.ui.core sap.m                          Build project and dependencies in dev mode, except "sap.ui.core" and "sap.m" (useful in combination with --include-task)
     ui5 build dev                                                                        Build project and dependencies in dev mode. Only a set of essential tasks is executed.
+```
+
+#### init
+`ui5 init [options]` initializes the UI5 Tooling configuration for an application or library project.
+
+```
+Options:
+    --help, -h                Show help  [boolean]
+    --version, -v             Show version number  [boolean]
+    --config                  Path to config file  [string]
+    --translator, --t8r       Translator to use. Including optional colon separated translator parameters.  [string] [default: "npm"]
+    --verbose                 Enable verbose logging. [boolean]
+    --loglevel, --log-level   Set the logging level (error|warn|info|verbose|silly).  [string] [default: "info"]
 ```
 
 #### serve
@@ -125,17 +164,21 @@ Examples:
     ui5 tree --json --dedupe > tree.json  Pipes the dependency tree, excluding duplicates into a new file "tree.json"
 ```
 
-#### init
-`ui5 init [options]` initializes the UI5 Tooling configuration for an application or library project.
+#### use
+
+`ui5 use <framework-info>` initializes or updates the UI5 Tooling [framework configuration](./Configuration.md#framework-configuration).
 
 ```
+Positionals:
+  framework-info  Framework name, version or both  [string] [required]
+
 Options:
-    --help, -h                Show help  [boolean]
-    --version, -v             Show version number  [boolean]
-    --config                  Path to config file  [string]
-    --translator, --t8r       Translator to use. Including optional colon separated translator parameters.  [string] [default: "npm"]
-    --verbose                 Enable verbose logging. [boolean]
-    --loglevel, --log-level   Set the logging level (error|warn|info|verbose|silly).  [string] [default: "info"]
+  --help, -h               Show help   [boolean]
+  --version, -v            Show version number   [boolean]
+  --config                 Path to configuration file   [string]
+  --translator, --t8r      Translator to use. Including optional colon separated translator parameters.  [string] [default: "npm"]
+  --verbose                Enable verbose logging.  [boolean]
+  --loglevel, --log-level  Set the logging level (error|warn|info|verbose|silly).  [string] [default: "info"]
 ```
 
 #### versions

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -1,5 +1,5 @@
 # Configuration
-This document describes the configuration of UI5 Tooling based projects and extensions. It represents **[Specification Version](#specification-versions) `2.0`**.
+This document describes the configuration of UI5 Tooling based projects and extensions. It represents **[Specification Version](#specification-versions) 2.0**.
 
 A projects UI5 Tooling configuration is typically located in a [YAML](https://yaml.org/) file named `ui5.yaml`, located in the root directory.
 
@@ -101,7 +101,9 @@ resources:
 ````
 
 ### Encoding of `*.properties` files
-*Available since UI5 CLI [`v1.7.0`](https://github.com/SAP/ui5-cli/releases/tag/v1.7.0)*
+
+!!! info
+    This configuration is available since UI5 CLI [`v1.7.0`](https://github.com/SAP/ui5-cli/releases/tag/v1.7.0)
 
 By default, the UI5 Tooling expects `*.properties` files to be `ISO-8859-1` encoded. 
 
@@ -114,6 +116,118 @@ resources:
   configuration:
     propertiesFileSourceEncoding: UTF-8
 ````
+
+## Framework Configuration
+
+!!! info
+    This configuration is available since UI5 CLI [`v2.0.0`](https://github.com/SAP/ui5-cli/releases/tag/v2.0.0)
+    and applies only to projects defining [Specification Version](#specification-versions)
+    2.0 or higher.
+
+Define your projects framework dependencies.
+
+Your projects framework configuration you must define whether you want to use the OpenUI5 or the SAPUI5 framework. Also see our [documentation on the differences between OpenUI5 and SAPUI5](./SAPUI5.md#differences-between-openui5-and-sapui5).
+
+**SAPUI5**
+```yaml
+framework:
+  name: SAPUI5
+```
+
+**OpenUI5**
+```yaml
+framework:
+  name: OpenUI5
+```
+
+If you are not sure which framework is right for you, see our [documentation on the differences between OpenUI5 and SAPUI5](./SAPUI5.md#differences-between-openui5-and-sapui5).
+
+!!! warning
+    Projects that use the OpenUI5 framework can not depend on projects that use the SAPUI5 framework.
+
+If you want to execute UI5 CLI commands directly in your project you also need to specify the framework version you want to use. Whenever you execute a UI5 CLI command, the framework version of the current root project is used.
+
+```yaml
+framework:
+  name: SAPUI5
+  version: 1.76.0
+```
+
+You can find an overview of the available versions for each framework here:
+
+- [SAPUI5 Version Overview](http://ui5.sap.com/versionoverview.html) (**Note:** The UI5 Tooling can only consume SAPUI5 starting with version 1.76.0.)
+- [OpenUI5 Version Overview](https://openui5.hana.ondemand.com/versionoverview.html)
+
+### Dependencies
+
+All libraries required by your project should be listed in the libraries section of the framework configuration.
+
+```yaml
+framework:
+  name: SAPUI5
+  version: 1.76.0
+  libraries:
+    - name: sap.ui.core
+    - name: sap.m
+    - name: sap.ui.comp
+    - ...
+```
+
+#### Development Dependencies
+Development dependencies are only installed if the project defining them is the current root project.
+They are typically only required during the development of the project.
+
+```yaml
+  libraries:
+    - name: sap.ushell
+      development: true
+```
+
+Note that a development dependency can not be optional and vice versa.
+
+#### Optional Dependencies
+Optional dependencies are installed either if the project defining them is the current root project or if the dependency is already part current dependency tree. A typical use case is libraries defining optional dependencies to all theme libraries they support.
+The application that is consuming the library can then choose which theme library to use by declaring it as a non-optional dependency.
+
+```yaml
+  libraries:
+    - name: themelib_sap_fiori_3
+      optional: true
+```
+
+??? example
+    **my library**
+    ```yaml
+    specVersion: "2.0"
+    type: library
+    metadata:
+      name: some.library
+    framework:
+      name: SAPUI5
+      libraries:
+        - name: sap.ui.core
+        - name: themelib_sap_belize
+          optional: true
+        - name: themelib_sap_bluecrystal
+          optional: true
+        - name: themelib_sap_fiori_3
+          optional: true
+    ```
+
+    **my application (depending on my library)**
+    ```yaml
+    specVersion: "2.0"
+    type: application
+    metadata:
+      name: some.app
+    framework:
+      name: SAPUI5
+      libraries:
+        - name: sap.ui.core
+        - name: themelib_sap_fiori_3
+    ```
+
+    When building the application project, only the theme library `themelib_sap_fiori_3` will be installed and built.
 
 ## Build Configuration
 ### Build Resources
@@ -308,7 +422,7 @@ All changes are documented below.
 
 ### Compatibility Matrix
 
-Unless otherwise noted in the table below, the UI5 Tooling modules are backward compatible in the means that for example UI5 CLI v3.0.0 might still be able to handle a project that is using Specification Version `1.0`.
+Unless otherwise noted in the table below, the UI5 Tooling modules are backward compatible.
 
 Version | UI5 CLI Release
 --- | ---
@@ -334,7 +448,12 @@ Version 1.1 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) 
 
 ### Specification Version 2.0
 
-- Adds and enforces schema validation of ui5.yaml
-- Adds support for "framework" configuration to consume SAPUI5 libraries.
+**Breaking changes:**
+
+- Adds and enforces schema validation of the ui5.yaml
+
+**Features:**
+
+- Adds support for the ["framework"](#framework-configuration) configuration to consume SAPUI5 libraries.
 
 Version 2.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v.2.0.0 and above.

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -1,12 +1,12 @@
 # Configuration
-This document describes the configuration of UI5 Tooling based projects and extensions. It represents **[Specification Version](#specification-versions) `1.1`**.
+This document describes the configuration of UI5 Tooling based projects and extensions. It represents **[Specification Version](#specification-versions) `2.0`**.
 
 A projects UI5 Tooling configuration is typically located in a [YAML](https://yaml.org/) file named `ui5.yaml`, located in the root directory.
 
 ## Example
 
 ````yaml
-specVersion: "1.1"
+specVersion: "2.0"
 type: application|library|theme-library|module
 metadata:
   name: some.project.name
@@ -18,7 +18,7 @@ A project must define a specification version (`specVersion`), to which its conf
 In addition, a project must define a `type`. This can be either `application`, `library`, `theme-library` (since Specification Version 1.1) or `module`. The type defines the default path mappings and build tasks. See [UI5 Builder: Types](./Builder.md#types) for details.
 
 ````yaml
-specVersion: "1.1"
+specVersion: "2.0"
 type: library
 ````
 
@@ -204,12 +204,12 @@ Extensions can be identified by the `kind: extension` configuration. Note that i
 
 ### Example
 ````yaml
-specVersion: "1.1"
+specVersion: "2.0"
 type: application
 metadata:
   name: my.application
 ---
-specVersion: "1.1"
+specVersion: "2.0"
 kind: extension
 type: project-shim
 metadata:
@@ -217,7 +217,7 @@ metadata:
 shims:
   configurations:
     lodash:
-      specVersion: "1.1"
+      specVersion: "2.0"
       type: module
       metadata:
         name: lodash
@@ -293,7 +293,7 @@ A list of bundle definitions. A `bundleDefinition` contains of the following opt
 A project must define a Specification Version by setting the `specVersion` property. The UI5 Tooling uses this information to detect whether the currently installed version is compatible to a projects configuration.
 
 ````yaml
-specVersion: "1.1"
+specVersion: "2.0"
 [...]
 ````
 
@@ -308,13 +308,14 @@ All changes are documented below.
 
 ### Compatibility Matrix
 
-Unless otherwise noted in the table below, the UI5 Tooling modules are backward compatible in the means that for example UI5 CLI v2.0 will still be able to handle a project that is using Specification Version `1.0`.
+Unless otherwise noted in the table below, the UI5 Tooling modules are backward compatible in the means that for example UI5 CLI v3.0.0 might still be able to handle a project that is using Specification Version `1.0`.
 
 Version | UI5 CLI Release
 --- | ---
 **0.1** | v0.0.1+
 **1.0** | v1.0.0+
 **1.1** | v1.13.0+
+**2.0** | v2.0.0+
 
 ### Specification Version 0.1
 Initial version.
@@ -330,3 +331,10 @@ Version 1.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) 
 Adds support for the `theme-library` type.
 
 Version 1.1 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v1.13.0 and above.
+
+### Specification Version 2.0
+
+- Adds and enforces schema validation of ui5.yaml
+- Adds support for "framework" configuration to consume SAPUI5 libraries.
+
+Version 2.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v.2.0.0 and above.

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -25,7 +25,7 @@ type: library
 ### Metadata
 A project must have a `name` and might define a `copyright` string.
 
-In the UI5 Tooling, a project is typically identified by the configured `name`. It must be unique and should follow a namespace scheme like `company.businessarea.project`.
+In the UI5 Tooling, a project is typically identified by the configured `name`. It must be unique and should ideally follow a namespace scheme like `company.businessarea.project`.
 
 A given `copyright` string will be used to fill placeholders like `${copyright}` and `@copyright@` in a projects source code. `|-` is a way to define a multi line string in YAML. For details, please check the [YAML Specification](https://yaml.org/spec/1.2/spec.html#id2794534).  
 Inside the copyright string, you can use the placeholder `${currentYear}` which will be replaced with the current year.
@@ -114,7 +114,7 @@ Specification Version | Default propertiesFileSourceEncoding
 
 If your project uses a different encoding for `*.properties` files, you need to set the `propertiesFileSourceEncoding` configuration property.
 
-The UI5 Tooling will read the corresponding files of the project in the given encoding. Any non-ASCII characters will be replaced with the respective Unicode escape sequences. This allows you to deploy the resulting files to any environment, independent from how it expects `*.properties` files to be encoded. Please refer to [RFC 7](https://github.com/SAP/ui5-tooling/blob/master/rfcs/0007-properties-file-encoding.md) for details.
+The UI5 Tooling will read the corresponding files of the project in the given encoding. Any non-ASCII characters will be replaced with the respective Unicode escape sequences. This allows you to deploy the resulting files to any environment, independent of how it expects `*.properties` files to be encoded. Please refer to [RFC 7](https://github.com/SAP/ui5-tooling/blob/master/rfcs/0007-properties-file-encoding.md) for details.
 
 ````yaml
 resources:
@@ -310,7 +310,7 @@ server:
 ````
 
 ## Extension Configuration
-Extensions configuration can be added to any projects `ui5.yaml`. It should to be located *after* the projects configuration, separated by [three dashes](https://yaml.org/spec/1.2/spec.html#id2760395) "`---`".
+Extensions configuration can be added to any projects `ui5.yaml`. For better readability, it should to be located *after* the projects configuration, separated by [three dashes](https://yaml.org/spec/1.2/spec.html#id2760395) "`---`".
 
 In cases where an extension shall be reused across multiple projects you can make it a module itself and have its configuration in a standalone `ui5.yaml` located inside that module.
 
@@ -349,7 +349,7 @@ shims:
 
 ## Custom Bundling
 
-Custom bundles can be defined in the `ui5.yaml`. It should be located in the `builder` configuration. With the property `bundles` a list of `bundleDefinitions` can be described.
+Custom bundles can be defined in the `ui5.yaml`. Within the `builder/bundles` configuration a list of `bundleDefinitions` can be described.
 
 ````yaml
 builder:

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -105,7 +105,7 @@ resources:
 !!! info
     This configuration is available since UI5 CLI [`v1.7.0`](https://github.com/SAP/ui5-cli/releases/tag/v1.7.0)
 
-By default the UI5 Tooling expects different encodings for `*.properties` i18n files, depending on a projects specification version:
+By default the UI5 Tooling expects different encodings for `*.properties` i18n files, depending on the project's specification version:
 
 Specification Version | Default propertiesFileSourceEncoding
 --- | ---
@@ -129,9 +129,9 @@ resources:
     and applies only to projects defining [Specification Version](#specification-versions)
     2.0 or higher.
 
-Define your projects framework dependencies.
+Define your project's framework dependencies.
 
-Your projects framework configuration you must define whether you want to use the OpenUI5 or the SAPUI5 framework. Also see our [documentation on the differences between OpenUI5 and SAPUI5](./SAPUI5.md#differences-between-openui5-and-sapui5).
+In your project's framework configuration you must define whether you want to use the OpenUI5 or the SAPUI5 framework. For more information, see our [documentation on the differences between OpenUI5 and SAPUI5](./SAPUI5.md#differences-between-openui5-and-sapui5).
 
 **SAPUI5**
 ```yaml
@@ -148,7 +148,7 @@ framework:
 If you are not sure which framework is right for you, see our [documentation on the differences between OpenUI5 and SAPUI5](./SAPUI5.md#differences-between-openui5-and-sapui5).
 
 !!! warning
-    Projects that use the OpenUI5 framework can not depend on projects that use the SAPUI5 framework.
+   Projects that use the OpenUI5 framework cannot depend on projects that use the SAPUI5 framework.
 
 If you want to execute UI5 CLI commands directly in your project you also need to specify the framework version you want to use. Whenever you execute a UI5 CLI command, the framework version of the current root project is used.
 
@@ -160,12 +160,12 @@ framework:
 
 You can find an overview of the available versions for each framework here:
 
-- [SAPUI5 Version Overview](http://ui5.sap.com/versionoverview.html) (**Note:** The UI5 Tooling can only consume SAPUI5 starting with version 1.76.0.)
+- [SAPUI5 Version Overview](http://ui5.sap.com/versionoverview.html) (**Note:** The UI5 Tooling can only consume SAPUI5 starting with Version 1.76.0.)
 - [OpenUI5 Version Overview](https://openui5.hana.ondemand.com/versionoverview.html)
 
 ### Dependencies
 
-All libraries required by your project should be listed in the libraries section of the framework configuration.
+All libraries required by your project must be listed in the libraries section of the framework configuration.
 
 ```yaml
 framework:
@@ -188,11 +188,11 @@ They are typically only required during the development of the project.
       development: true
 ```
 
-Note that a development dependency can not be optional and vice versa.
+Note that a development dependency cannot be optional and vice versa.
 
 #### Optional Dependencies
-Optional dependencies are installed either if the project defining them is the current root project or if the dependency is already part current dependency tree. A typical use case is libraries defining optional dependencies to all theme libraries they support.
-The application that is consuming the library can then choose which theme library to use by declaring it as a non-optional dependency.
+Optional dependencies are installed either if the project defining them is the current root project or if the dependency is already part of the current dependency tree. A typical use case is libraries defining optional dependencies to all theme libraries they support.
+You can choose which theme library to use by the application that is consuming the library by declaring it as a non-optional dependency.
 
 ```yaml
   libraries:
@@ -456,7 +456,7 @@ Version 1.1 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) 
 **Breaking changes:**
 
 - Adds and enforces schema validation of the ui5.yaml
-- By default the encoding of `*.properties` files is expected to be `UTF-8` (opposed to `ISO-8859-1` in projects defining specification versions below 2.0)
+- By default the encoding of `*.properties` files is expected to be `UTF-8` (as opposed to `ISO-8859-1` in projects defining specification versions below 2.0)
     - A project can still explicitly configure the [encoding of its `*.properties` files](#encoding-of-properties-files)
 
 **Features:**

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -397,6 +397,7 @@ A list of bundle definitions. A `bundleDefinition` contains of the following opt
     - `filters`: List of resources as glob patterns that should be in- or excluded. A pattern either contains of a trailing slash `/` or single `*` and double `**` asterisks which denote an arbitrary number of characters or folder names. Exludes should be marked with a leading exclamation mark '!'. The order of filters is relevant, a later exclusion overrides an earlier inclusion and vice versa.
     - `resolve`: Setting resolve to `true` will also include all (transitive) dependencies of the files
     - `resolveConditional`: Whether conditional dependencies of modules should be resolved and added to the module set for this section. By default set to `false`
+    - `declareRawModules`: Whether raw modules should be declared after jQuery.sap.global became available. With the usage of the ui5loader, this flag should be set to 'false'. By default set to `false`
     - `renderer`: Whether renderers for controls should be added to the module set. By default set to `false`
     - `sort`:  By default, modules are sorted by their dependencies. The sorting can be suppressed by setting the option to `false`
 

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -30,6 +30,8 @@ In the UI5 Tooling, a project is typically identified by the configured `name`. 
 A given `copyright` string will be used to fill placeholders like `${copyright}` and `@copyright@` in a projects source code. `|-` is a way to define a multi line string in YAML. For details, please check the [YAML Specification](https://yaml.org/spec/1.2/spec.html#id2794534).  
 Inside the copyright string, you can use the placeholder `${currentYear}` which will be replaced with the current year.
 
+In case your project is deprecated you may also define a property `deprecated: true`. In projects that have a direct dependency to your project, the UI5 Tooling will then display a deprecation warning.
+
 ````yaml
 metadata:
   name: my.cool.project

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -96,8 +96,8 @@ However, it is recommended that modules include their namespace in the virtual p
 resources:
   configuration:
     paths:
-      "/resources/my/library/module-xy/": lib
-      "/resources/my/library/module-xy-min/": dist
+      /resources/my/library/module-xy/: lib
+      /resources/my/library/module-xy-min/: dist
 ````
 
 ### Encoding of `*.properties` files
@@ -105,16 +105,21 @@ resources:
 !!! info
     This configuration is available since UI5 CLI [`v1.7.0`](https://github.com/SAP/ui5-cli/releases/tag/v1.7.0)
 
-By default, the UI5 Tooling expects `*.properties` files to be `ISO-8859-1` encoded. 
+By default the UI5 Tooling expects different encodings for `*.properties` i18n files, depending on a projects specification version:
 
-If your project uses `UTF-8` encoding for these files (for example because it has been created in SAP WebIDE), you need to set the `propertiesFileSourceEncoding` configuration property.
+Specification Version | Default propertiesFileSourceEncoding
+--- | ---
+**0.1, 1.0 or 1.1** | `ISO-8859-1` 
+**2.0+** | `UTF-8`
 
-Your projects `*.properties` files will be read in the given encoding and any non-ASCII characters replaced with the respective unicode escape sequences. This allows you to deploy the resulting files to any environment, independent from how it expects `*.properties` files to be encoded. Please refer to [RFC 7](https://github.com/SAP/ui5-tooling/blob/master/rfcs/0007-properties-file-encoding.md) for details.
+If your project uses a different encoding for `*.properties` files, you need to set the `propertiesFileSourceEncoding` configuration property.
+
+The UI5 Tooling will read the corresponding files of the project in the given encoding. Any non-ASCII characters will be replaced with the respective Unicode escape sequences. This allows you to deploy the resulting files to any environment, independent from how it expects `*.properties` files to be encoded. Please refer to [RFC 7](https://github.com/SAP/ui5-tooling/blob/master/rfcs/0007-properties-file-encoding.md) for details.
 
 ````yaml
 resources:
   configuration:
-    propertiesFileSourceEncoding: UTF-8
+    propertiesFileSourceEncoding: UTF-8|ISO-8859-1
 ````
 
 ## Framework Configuration
@@ -451,6 +456,8 @@ Version 1.1 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) 
 **Breaking changes:**
 
 - Adds and enforces schema validation of the ui5.yaml
+- By default the encoding of `*.properties` files is expected to be `UTF-8` (opposed to `ISO-8859-1` in projects defining specification versions below 2.0)
+    - A project can still explicitly configure the [encoding of its `*.properties` files](#encoding-of-properties-files)
 
 **Features:**
 

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -109,8 +109,8 @@ By default the UI5 Tooling expects different encodings for `*.properties` i18n f
 
 Specification Version | Default propertiesFileSourceEncoding
 --- | ---
-**0.1, 1.0 or 1.1** | `ISO-8859-1` 
 **2.0+** | `UTF-8`
+**0.1, 1.0 or 1.1** | `ISO-8859-1`
 
 If your project uses a different encoding for `*.properties` files, you need to set the `propertiesFileSourceEncoding` configuration property.
 
@@ -148,7 +148,7 @@ framework:
 If you are not sure which framework is right for you, see our [documentation on the differences between OpenUI5 and SAPUI5](./SAPUI5.md#differences-between-openui5-and-sapui5).
 
 !!! warning
-   Projects that use the OpenUI5 framework cannot depend on projects that use the SAPUI5 framework.
+    Projects that use the OpenUI5 framework cannot depend on projects that use the SAPUI5 framework.
 
 If you want to execute UI5 CLI commands directly in your project you also need to specify the framework version you want to use. Whenever you execute a UI5 CLI command, the framework version of the current root project is used.
 
@@ -431,25 +431,10 @@ Unless otherwise noted in the table below, the UI5 Tooling modules are backward 
 
 Version | UI5 CLI Release
 --- | ---
-**0.1** | v0.0.1+
-**1.0** | v1.0.0+
-**1.1** | v1.13.0+
 **2.0** | v2.0.0+
-
-### Specification Version 0.1
-Initial version.
-
-Version 0.1 projects are compatible with [UI5 CLI](https://github.com/SAP/ui5-cli) v0.0.1 and above.
-
-### Specification Version 1.0
-First stable release.
-
-Version 1.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v1.0.0 and above.
-
-### Specification Version 1.1
-Adds support for the `theme-library` type.
-
-Version 1.1 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v1.13.0 and above.
+**1.1** | v1.13.0+
+**1.0** | v1.0.0+
+**0.1** | v0.0.1+
 
 ### Specification Version 2.0
 
@@ -464,3 +449,18 @@ Version 1.1 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) 
 - Adds support for the ["framework"](#framework-configuration) configuration to consume SAPUI5 libraries.
 
 Version 2.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v.2.0.0 and above.
+
+### Specification Version 1.1
+Adds support for the `theme-library` type.
+
+Version 1.1 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v1.13.0 and above.
+
+### Specification Version 1.0
+First stable release.
+
+Version 1.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v1.0.0 and above.
+
+### Specification Version 0.1
+Initial version.
+
+Version 0.1 projects are compatible with [UI5 CLI](https://github.com/SAP/ui5-cli) v0.0.1 and above.

--- a/docs/pages/GettingStarted.md
+++ b/docs/pages/GettingStarted.md
@@ -37,17 +37,17 @@ If your project is not set up for use with the UI5 Tooling yet, follow these ste
 
     **[OpenUI5](https://openui5.hana.ondemand.com/)**
     ```sh
-    ui5 use OpenUI5@latest
+    ui5 use openui5@latest
     ```
 
     **[SAPUI5](https://ui5.sap.com/)**
     ```sh
-    ui5 use SAPUI5@latest
+    ui5 use sapui5@latest
     ```
 
 1. Add required libraries
     ```sh
-    ui5 use sap.ui.core sap.m themelib_sap_fiori_3 [...]
+    ui5 add sap.ui.core sap.m themelib_sap_fiori_3 [...]
     ```
 
 1. If you are using Git or similar version control, commit `package.json` and `ui5.yaml` to your repository.

--- a/docs/pages/GettingStarted.md
+++ b/docs/pages/GettingStarted.md
@@ -21,7 +21,7 @@ This file (with some exceptions) is required for all projects and their dependen
 ### Setup
 If your project is not set up for use with the UI5 Tooling yet, follow these steps:
 
-1. **If** your project does not have a `package.json` file yet, let npm generate it:
+1. If your project does not have a `package.json` file, let npm generate it:
     ```sh
     npm init --yes
     ```
@@ -31,10 +31,27 @@ If your project is not set up for use with the UI5 Tooling yet, follow these ste
     ui5 init
     ```
 
-1. Install npm dependencies required for your project:
+1. Define the framework you want to use
+
+    You can choose between the OpenUI5 and the SAPUI5 Framework. Don't know which one to choose? Checkout our [documentation on the differences between OpenUI5 and SAPUI5](./SAPUI5.md#differences-between-openui5-and-sapui5).
+
+    **[OpenUI5](https://openui5.hana.ondemand.com/)**
     ```sh
-    npm install @openui5/sap.ui.core @openui5/themelib_sap_belize [...]
+    ui5 use OpenUI5@latest
     ```
-    For a full list of all available OpenUI5 libraries, see [www.npmjs.com/org/openui5](https://www.npmjs.com/org/openui5)
+
+    **[SAPUI5](https://ui5.sap.com/)**
+    ```sh
+    ui5 use SAPUI5@latest
+    ```
+
+1. Add required libraries
+    ```sh
+    ui5 use sap.ui.core sap.m themelib_sap_fiori_3 [...]
+    ```
 
 1. If you are using Git or similar version control, commit `package.json` and `ui5.yaml` to your repository.
+
+Hooray! 🎉 You can now use the UI5 Tooling in your project!
+
+Execute [`ui5 serve`](./pages/Server.md) to start a local development server or use [`ui5 build --all`](./pages/Builder.md) to create an optimized version of your project, including all of its dependencies which you can deploy from the created `./dist` directory.

--- a/docs/pages/GettingStarted.md
+++ b/docs/pages/GettingStarted.md
@@ -33,7 +33,7 @@ If your project is not set up for use with the UI5 Tooling yet, follow these ste
 
 1. Define the framework you want to use
 
-    You can choose between the OpenUI5 and the SAPUI5 Framework. Don't know which one to choose? Checkout our [documentation on the differences between OpenUI5 and SAPUI5](./SAPUI5.md#differences-between-openui5-and-sapui5).
+    You can choose between the OpenUI5 and the SAPUI5 Framework. Don't know which one to choose? Check out our [documentation on the differences between OpenUI5 and SAPUI5](./SAPUI5.md#differences-between-openui5-and-sapui5).
 
     **[OpenUI5](https://openui5.hana.ondemand.com/)**
     ```sh

--- a/docs/pages/GettingStarted.md
+++ b/docs/pages/GettingStarted.md
@@ -1,7 +1,7 @@
 # Getting Started
 ## Installing the UI5 CLI
 ### Requirements
-- [Node.js](https://nodejs.org/) (**version 8.5 or higher** ⚠️)
+- [Node.js](https://nodejs.org/) (**version 10 or higher** ⚠️)
 
 ### Installation
 ```sh

--- a/docs/pages/Project.md
+++ b/docs/pages/Project.md
@@ -76,7 +76,7 @@ Enhances a given dependency tree based on a projects [configuration](docs/Config
     "id": "projectA",
     "version": "1.0.0",
     "path": "/absolute/path/to/projectA",
-    "specVersion": "1.1",
+    "specVersion": "2.0",
     "type": "application",
     "metadata": {
         "name": "sap.projectA",
@@ -97,7 +97,7 @@ Enhances a given dependency tree based on a projects [configuration](docs/Config
             "id": "projectB",
             "version": "1.0.0",
             "path": "/path/to/projectB",
-            "specVersion": "1.1",
+            "specVersion": "2.0",
             "type": "library",
             "metadata": {
                 "name": "sap.ui.projectB"
@@ -119,7 +119,7 @@ Enhances a given dependency tree based on a projects [configuration](docs/Config
                     "id": "projectD",
                     "version": "1.0.0",
                     "path": "/path/to/different/projectD",
-                    "specVersion": "1.1",
+                    "specVersion": "2.0",
                     "type": "library",
                     "metadata": {
                         "name": "sap.ui.projectD"
@@ -144,7 +144,7 @@ Enhances a given dependency tree based on a projects [configuration](docs/Config
             "id": "projectD",
             "version": "1.0.0",
             "path": "/path/to/projectD",
-            "specVersion": "1.1",
+            "specVersion": "2.0",
             "type": "library",
             "metadata": {
                 "name": "sap.ui.projectD"

--- a/docs/pages/SAPUI5.md
+++ b/docs/pages/SAPUI5.md
@@ -10,7 +10,7 @@ SAPUI5 libraries are hosted on the public npm registry at `registry.npmjs.org`. 
 ## Usage
 Since Version 2.0 the UI5 CLI will automatically download all required framework dependencies of a project if they have been defined in the corresponding `ui5.yaml` configuration. They will be cached in a `.ui5` directory located in your users' home directory. This happens transparently whenever you execute the `ui5 serve` or `ui5 build` commands.
 
-All non-framework dependencies, such as reuse libraries or UI5 Tooling extensions, still need to be maintained as npm dependencies in the projects `package.json`. At the same time, framework dependencies listed in the `ui5.yaml` should not be listed in the `package.json`.
+All non-framework dependencies, such as reuse libraries or UI5 Tooling extensions, still need to be maintained as npm dependencies in the projects `package.json`. At the same time, framework dependencies listed in the `ui5.yaml` should not be listed in the `package.json` as they will be ignored by the UI5 Tooling.
 
 ## Configuration
 

--- a/docs/pages/SAPUI5.md
+++ b/docs/pages/SAPUI5.md
@@ -1,17 +1,16 @@
 # Consuming SAPUI5 libraries
 
 !!! info
-    **Make sure you have installed the latest UI5 CLI in version 2.0 or later:**
+    **Make sure you have installed the latest UI5 CLI in Version 2.0 or later:**
 
 ## Overview
 
 SAPUI5 libraries are hosted on the public npm registry at `registry.npmjs.org`. However, you should not install them using node package managers like npm or Yarn. Instead, please let the UI5 Tooling handle them by following this guide.
 
 ## Usage
-Since version 2.0 the UI5 CLI will automatically download all required framework dependencies of a project if they are defined in the corresponding `ui5.yaml` configuration. They will be cached in a `.ui5` directory located in your users home directory. This happens transparently whenever you are executing `ui5 serve` or `ui5 build` commands.
+Since Version 2.0 the UI5 CLI will automatically download all required framework dependencies of a project if they have been defined in the corresponding `ui5.yaml` configuration. They will be cached in a `.ui5` directory located in your users' home directory. This happens transparently whenever you execute the `ui5 serve` or `ui5 build` commands.
 
-All non-framework dependencies, like reuse libraries or UI5 Tooling extensions should still be maintained as npm dependencies in the projects `package.json`. At the same time, framework dependencies listed in the `ui5.yaml` should not be listed in the `package.json`.
-
+All non-framework dependencies, such as reuse libraries or UI5 Tooling extensions, still need to be maintained as npm dependencies in the projects `package.json`. At the same time, framework dependencies listed in the `ui5.yaml` should not be listed in the `package.json`.
 
 ## Configuration
 
@@ -63,6 +62,6 @@ The open source project [OpenUI5](https://openui5.org/) provides most of the fun
 
 OpenUI5 is provided under the Apache 2.0 license. The SAPUI5 packages that are consumed in the UI5 Tooling are provided under the terms of the [SAP Developer License Agreement](https://tools.hana.ondemand.com/developer-license-3.1.txt).
 
-Note that projects which use the OpenUI5 framework can not depend on projects that use the SAPUI5 framework.
+Note that projects which use the OpenUI5 framework cannot depend on projects that use the SAPUI5 framework.
 
 Please also see the [UI5 SDK documentation "SAPUI5 vs. OpenUI5"](https://ui5.sap.com/#/topic/5982a9734748474aa8d4af9c3d8f31c0).

--- a/docs/pages/SAPUI5.md
+++ b/docs/pages/SAPUI5.md
@@ -1,3 +1,68 @@
 # Consuming SAPUI5 libraries
 
-Coming soon
+!!! info
+    **Make sure you have installed the latest UI5 CLI in version 2.0 or later:**
+
+## Overview
+
+SAPUI5 libraries are hosted on the public npm registry at `registry.npmjs.org`. However, you should not install them using node package managers like npm or Yarn. Instead, please let the UI5 Tooling handle them by following this guide.
+
+## Usage
+Since version 2.0 the UI5 CLI will automatically download all required framework dependencies of a project if they are defined in the corresponding `ui5.yaml` configuration. They will be cached in a `.ui5` directory located in your users home directory. This happens transparently whenever you are executing `ui5 serve` or `ui5 build` commands.
+
+All non-framework dependencies, like reuse libraries or UI5 Tooling extensions should still be maintained as npm dependencies in the projects `package.json`. At the same time, framework dependencies listed in the `ui5.yaml` should not be listed in the `package.json`.
+
+
+## Configuration
+
+There is a new configuration section dedicated to framework dependency handling.
+
+**Example:**
+```yaml
+specVersion: "2.0"
+type: application
+metadata:
+  name: some.project.name
+framework:
+  name: SAPUI5
+  version: 1.76.0
+  libraries:
+    - name: sap.ui.core
+    - name: sap.m
+    - name: sap.ui.comp
+    - name: sap.ushell
+      development: true
+    - name: themelib_sap_fiori_3
+```
+
+**Example:**
+```yaml
+specVersion: "2.0"
+type: library
+metadata:
+  name: some.library
+framework:
+  name: SAPUI5
+  libraries:
+    - name: sap.ui.core
+    - name: themelib_sap_belize
+      optional: true
+    - name: themelib_sap_bluecrystal
+      optional: true
+    - name: themelib_sap_fiori_3
+      optional: true
+```
+
+Make sure that your project defines [Specification Version 2.0](./Configuration.md#specification-version-20) or higher.
+
+For details, please see the corresponding [framework configuration documentation](././Configuration.md#framework-configuratio).
+
+### Differences Between OpenUI5 and SAPUI5
+
+The open source project [OpenUI5](https://openui5.org/) provides most of the fundamental framework features. [SAPUI5](https://ui5.sap.com/) enhances on this by providing additional libraries under a different license.
+
+OpenUI5 is provided under the Apache 2.0 license. The SAPUI5 packages that are consumed in the UI5 Tooling are provided under the terms of the [SAP Developer License Agreement](https://tools.hana.ondemand.com/developer-license-3.1.txt).
+
+Note that projects which use the OpenUI5 framework can not depend on projects that use the SAPUI5 framework.
+
+Please also see the [UI5 SDK documentation "SAPUI5 vs. OpenUI5"](https://ui5.sap.com/#/topic/5982a9734748474aa8d4af9c3d8f31c0).

--- a/docs/pages/extensibility/CustomServerMiddleware.md
+++ b/docs/pages/extensibility/CustomServerMiddleware.md
@@ -9,7 +9,7 @@ A middleware may be executed before or after any other middleware.
 
 ### Example: Basic configuration
 ```yaml
-specVersion: "1.1"
+specVersion: "2.0"
 type: application
 metadata:
   name: my.application
@@ -39,7 +39,7 @@ A custom middleware extension consists of a `ui5.yaml` and a [custom middleware 
 ### Example: ui5.yaml
 
 ````yaml
-specVersion: "1.1"
+specVersion: "2.0"
 kind: extension
 type: server-middleware
 metadata:
@@ -59,7 +59,7 @@ The UI5 Server will detect the custom middleware configuration of the project an
 
 ````yaml
 # Project configuration for the above example
-specVersion: "1.1"
+specVersion: "2.0"
 kind: project
 type: application
 metadata:
@@ -70,7 +70,7 @@ server:
       beforeMiddleware: serveResources
 ---
 # Custom middleware extension as part of your project
-specVersion: "1.1"
+specVersion: "2.0"
 kind: extension
 type: server-middleware
 metadata:

--- a/docs/pages/extensibility/CustomTasks.md
+++ b/docs/pages/extensibility/CustomTasks.md
@@ -12,7 +12,7 @@ In the below example, when building the library `my.library` the `babel` task wi
 
 ````yaml
 # In this example configuration two custom tasks are defined: 'babel' and 'generateMarkdownFiles'.
-specVersion: "1.1"
+specVersion: "2.0"
 type: library
 metadata:
   name: my.library
@@ -32,7 +32,7 @@ You can also connect multiple custom task with each other. Please be aware that 
 
 ````yaml
 # In this example 'myCustomTask2' gets executed after 'myCustomTask1'.
-specVersion: "1.1"
+specVersion: "2.0"
 type: library
 metadata:
   name: my.library
@@ -51,7 +51,7 @@ A custom task extension consists of a `ui5.yaml` and a [task implementation](#ta
 ### Example: ui5.yaml
 
 ````yaml
-specVersion: "1.1"
+specVersion: "2.0"
 kind: extension
 type: task
 metadata:
@@ -71,7 +71,7 @@ The task extension will then be automatically collected and processed during the
 
 ````yaml
 # Project configuration for the above example
-specVersion: "1.1"
+specVersion: "2.0"
 kind: project
 type: library
 metadata:
@@ -84,7 +84,7 @@ builder:
         color: blue
 ---
 # Task extension as part of your project
-specVersion: "1.1"
+specVersion: "2.0"
 kind: extension
 type: task
 metadata:

--- a/docs/pages/extensibility/ProjectShims.md
+++ b/docs/pages/extensibility/ProjectShims.md
@@ -5,7 +5,7 @@ Also see [RFC 0002 Project Shims](https://github.com/SAP/ui5-tooling/blob/master
 
 #### Structure
 ```yaml
-specVersion: "1.1"
+specVersion: "2.0"
 kind: extension
 type: project-shim
 metadata:
@@ -13,12 +13,12 @@ metadata:
 shims:
   configurations:
     <module name (id)>:
-      specVersion: "1.1"
+      specVersion: "2.0",
       type: <project type>
       metadata:
         name: <project name>
     <module name (id)>:
-      specVersion: "1.1"
+      specVersion: "2.0",
       type: <project type>
       metadata:
         name: <project name>
@@ -61,12 +61,12 @@ An application "my-application" defines a npm dependency to [lodash](https://lod
 
 **ui5.yaml**
 ```yaml
-specVersion: "1.1"
+specVersion: "2.0"
 type: application
 metadata:
   name: my.application
 --- # Everything below this line could also be put into the ui5.yaml of a standalone extension module
-specVersion: "1.1"
+specVersion: "2.0"
 kind: extension
 type: project-shim
 metadata:
@@ -74,7 +74,7 @@ metadata:
 shims:
   configurations:
     lodash: # name as defined in package.json
-      specVersion: "1.1"
+      specVersion: "2.0"
       type: module # Use module type
       metadata:
         name: lodash
@@ -142,12 +142,12 @@ application-a/
 The shim defined in the application configures the legacy libraries and defines their dependencies. This shim might as well be a standalone module that is added to the applications dependencies. That would be the typical reuse scenario for shims.
 
 ```yaml
-specVersion: "1.1"
+specVersion: "2.0"
 type: application
 metadata:
   name: application.a
 ----
-specVersion: "1.1"
+specVersion: "2.0"
 kind: extension
 type: project-shim
 metadata:
@@ -155,17 +155,17 @@ metadata:
 shims:
   configurations:
     legacy-library-a:
-      specVersion: "1.1"
+      specVersion: "2.0"
       type: library
       metadata:
         name: legacy.library.a
     legacy-library-b:
-      specVersion: "1.1"
+      specVersion: "2.0"
       type: library
       metadata:
         name: legacy.library.b
     legacy-library-x:
-      specVersion: "1.1"
+      specVersion: "2.0"
       type: library
       metadata:
         name: legacy.library.x

--- a/docs/updates/migrate-v1.md
+++ b/docs/updates/migrate-v1.md
@@ -1,6 +1,6 @@
 # Migrate to v1
 
-v1 is the first stable release of the UI5 Tooling. There are only a few notable changes to the 0.x alpha version.
+v1.0.0 is the first stable release of the UI5 Tooling. There are only a few notable changes to the 0.x alpha version.
 
 ## Breaking changes
 

--- a/docs/updates/migrate-v1.md
+++ b/docs/updates/migrate-v1.md
@@ -1,6 +1,6 @@
-# Migrate to v1.0.0
+# Migrate to v1
 
-v1.0.0 is the first stable release of the UI5 Tooling. There are only a few notable changes to the 0.x alpha version.
+v1 is the first stable release of the UI5 Tooling. There are only a few notable changes to the 0.x alpha version.
 
 ## Breaking changes
 
@@ -52,7 +52,7 @@ npm install @ui5/cli@^1
 
 #### `specVersion: '1.0'`
 
-We have introduced the [specification version `1.0`](https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-version-10).
+We have introduced the [specification version `1.0`](../pages/Configuration.md#specification-version-10).
 New features will only be available for projects with specVersion `1.0` or newer.  
 The specVersion `0.1` will be compatible with the UI5 CLI v1.0.0, but we still recommend to adopt your projects.
 

--- a/docs/updates/migrate-v2.md
+++ b/docs/updates/migrate-v2.md
@@ -1,7 +1,36 @@
 # Migrate to v2
 
-## Breaking changes
+v2.0.0 of the UI5 Tooling was released on April 1, 2020. As a major feature, it introduces the easy consumption of SAPUI5 libraries in UI5 projects.
 
+## Breaking changes
+**All UI5 Tooling Modules: Require Node.js >= 10**
+
+Support for older Node.js releases has been dropped.
+
+**UI5 Builder: Make namespace mandatory for application and library projects ([SAP/ui5-builder#430](https://github.com/SAP/ui5-builder/pull/430))**
+
+The UI5 Tooling must be able to determine an application- or library project's namespace. Otherwise an error is thrown.
+
+Ideally the namespace should be defined in the `sap.app/id` field of the [`manifest.json`](https://ui5.sap.com/#/topic/74038a52dcd7404e82b38be6d5fb1458)
+
+In case of libraries, additional fallbacks are in place:
+
+1. The `name` attribute defined in the `.library` file
+2. The path of the `library.js` file
+
+**UI5 Builder: LibraryFormatter: Ignore manifest.json of nested apps ([SAP/ui5-builder#392](https://github.com/SAP/ui5-builder/pull/392))**
+
+If a library contains both, a manifest.json and .library file, they must either be located in the same directory or the manifest.json is ignored. In cases where the manifest.json is located on a higher level or different directory on the same level than a .library file, an exception is thrown.
+
+**UI5 Server: serveResources middleware: Expect *.properties files in UTF-8 by default ([SAP/ui5-server#303](https://github.com/SAP/ui5-server/pull/303))**
+
+When integrating the serveResources middleware directly into a custom server, it now handles `*.properties` files as being UTF-8 encoded.
+
+_**Note:** This change does not affect you when you are using the UI5 Server as part of the UI5 CLI or use the top level [`server.serve`](https://sap.github.io/ui5-tooling/api/module-@ui5_server.server.html#.serve) API. In those cases the project specific [configuration](../pages/Configuration.md#encoding-of-properties-files) defines the encoding of `*.properties` files._
+
+**UI5 FS: Remove deprecated parameter useNamespaces ([SAP/ui5-fs#223](https://github.com/SAP/ui5-fs/pull/223))**
+
+Remove deprecated parameter `useNamespaces` from method [`resourceFactory.createCollectionsForTree`](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.resourceFactory.html#.createCollectionsForTree). Use parameter `getVirtualBasePathPrefix` instead.
 
 ## How to upgrade
 

--- a/docs/updates/migrate-v2.md
+++ b/docs/updates/migrate-v2.md
@@ -1,0 +1,39 @@
+# Migrate to v2.0.0
+
+## Breaking changes
+
+
+## How to upgrade
+
+### Global installation
+
+To upgrade your global installation, just run the installation command again, which will upgrade to the latest version.
+
+```
+npm install --global @ui5/cli
+```
+
+**Note:** Your local CLI installation will still be preferred, so you need to make sure to upgrade it as well (see [Local vs. Global installation](https://github.com/SAP/ui5-cli#local-vs-global-installation)).
+
+### Local installation
+
+To upgrade the CLI installation within a project you need to run the following command.
+
+```
+npm install @ui5/cli@^2
+```
+
+### ui5.yaml
+
+#### `specVersion: '2.0'`
+
+We have introduced the [specification version `2.0`](https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-version-10).
+New features will only be available for projects with specVersion `2.0` or newer.  
+Most projects defining specVersion `0.1` or `1.0` can still be used.
+
+```yaml
+specVersion: '2.0'
+metadata:
+  name: <project-name>
+type: <project-type>
+```

--- a/docs/updates/migrate-v2.md
+++ b/docs/updates/migrate-v2.md
@@ -20,17 +20,17 @@ In case of libraries, additional fallbacks are in place:
 
 **UI5 Builder: LibraryFormatter: Ignore manifest.json of nested apps ([SAP/ui5-builder#392](https://github.com/SAP/ui5-builder/pull/392))**
 
-If a library contains both, a manifest.json and .library file, they must either be located in the same directory or the manifest.json is ignored. In cases where the manifest.json is located on a higher level or different directory on the same level than a .library file, an exception is thrown.
+If a library contains both a manifest.json and a .library file, they must be located in the same directory. Otherwise the manifest.json is ignored. In cases where the manifest.json is located at a higher level or in a different directory at the same level as the .library file, an exception is thrown.
 
 **UI5 Server: serveResources middleware: Expect *.properties files in UTF-8 by default ([SAP/ui5-server#303](https://github.com/SAP/ui5-server/pull/303))**
 
 When integrating the serveResources middleware directly into a custom server, it now handles `*.properties` files as being UTF-8 encoded.
 
-_**Note:** This change does not affect you when you are using the UI5 Server as part of the UI5 CLI or use the top level [`server.serve`](https://sap.github.io/ui5-tooling/api/module-@ui5_server.server.html#.serve) API. In those cases the project specific [configuration](../pages/Configuration.md#encoding-of-properties-files) defines the encoding of `*.properties` files._
+_**Note:** This change does not affect you when you use the UI5 Server as part of the UI5 CLI or use the top level [`server.serve`](https://sap.github.io/ui5-tooling/api/module-@ui5_server.server.html#.serve) API. In those cases the project specific [configuration](../pages/Configuration.md#encoding-of-properties-files) defines the encoding of `*.properties` files._
 
 **UI5 FS: Remove deprecated parameter useNamespaces ([SAP/ui5-fs#223](https://github.com/SAP/ui5-fs/pull/223))**
 
-Remove deprecated parameter `useNamespaces` from method [`resourceFactory.createCollectionsForTree`](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.resourceFactory.html#.createCollectionsForTree). Use parameter `getVirtualBasePathPrefix` instead.
+Remove the deprecated parameter `useNamespaces` from method [`resourceFactory.createCollectionsForTree`](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.resourceFactory.html#.createCollectionsForTree). Use the parameter `getVirtualBasePathPrefix` instead.
 
 ## How to upgrade
 
@@ -46,7 +46,7 @@ npm install --global @ui5/cli
 
 ### Local installation
 
-To upgrade the CLI installation within a project you need to run the following command.
+To upgrade the CLI installation within a project, you need to run the following command:
 
 ```
 npm install @ui5/cli@^2

--- a/docs/updates/migrate-v2.md
+++ b/docs/updates/migrate-v2.md
@@ -22,11 +22,11 @@ In case of libraries, additional fallbacks are in place:
 
 If a library contains both a manifest.json and a .library file, they must be located in the same directory. Otherwise the manifest.json is ignored. In cases where the manifest.json is located at a higher level or in a different directory at the same level as the .library file, an exception is thrown.
 
-**UI5 Server: serveResources middleware: Expect *.properties files in UTF-8 by default ([SAP/ui5-server#303](https://github.com/SAP/ui5-server/pull/303))**
+**UI5 Server: serveResources middleware: Expect `*.properties` files in UTF-8 by default ([SAP/ui5-server#303](https://github.com/SAP/ui5-server/pull/303))**
 
-When integrating the serveResources middleware directly into a custom server, it now handles `*.properties` files as being UTF-8 encoded.
+For projects of types **other** than `application` or `library`, the UI5 Server now expects `*.properties` files to be UTF-8 encoded as opposed to `ISO-8859-1` before.
 
-_**Note:** This change does not affect you when you use the UI5 Server as part of the UI5 CLI or use the top level [`server.serve`](https://sap.github.io/ui5-tooling/api/module-@ui5_server.server.html#.serve) API. In those cases the project specific [configuration](../pages/Configuration.md#encoding-of-properties-files) defines the encoding of `*.properties` files._
+_**Note:** This change does not affect most projects as `*.properties` files are typically only located in applications or libraries, for which their project specific [configuration](../pages/Configuration.md#encoding-of-properties-files) is used._
 
 **UI5 FS: Remove deprecated parameter useNamespaces ([SAP/ui5-fs#223](https://github.com/SAP/ui5-fs/pull/223))**
 
@@ -49,7 +49,7 @@ npm install --global @ui5/cli
 To upgrade the CLI installation within a project, you need to run the following command:
 
 ```
-npm install @ui5/cli@^2
+npm install --save-dev @ui5/cli@^2
 ```
 
 ### ui5.yaml

--- a/docs/updates/migrate-v2.md
+++ b/docs/updates/migrate-v2.md
@@ -1,4 +1,4 @@
-# Migrate to v2.0.0
+# Migrate to v2
 
 ## Breaking changes
 
@@ -27,7 +27,7 @@ npm install @ui5/cli@^2
 
 #### `specVersion: '2.0'`
 
-We have introduced the [specification version `2.0`](https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-version-10).
+We have introduced the [specification version `2.0`](../pages/Configuration.md#specification-version-10).
 New features will only be available for projects with specVersion `2.0` or newer.  
 Most projects defining specVersion `0.1` or `1.0` can still be used.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - Workflows: pages/Workflows.md
     - Configuration: pages/Configuration.md
     - CLI: pages/CLI.md
+    - SAPUI5: pages/SAPUI5.md
     - Modules:
       - Server: pages/Server.md
       - Builder: pages/Builder.md
@@ -20,6 +21,7 @@ nav:
       - Project Shims: pages/extensibility/ProjectShims.md
     - Upgrade Guides:
       - Migrate to v1: updates/migrate-v1.md
+      - Migrate to v2: updates/migrate-v2.md
     - FAQ: pages/FAQ.md
     - Troubleshooting: pages/Troubleshooting.md
     - API Reference: 'api/index.html' # only available in final build, not serve

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,8 +20,8 @@ nav:
       - Custom Server Middleware: pages/extensibility/CustomServerMiddleware.md
       - Project Shims: pages/extensibility/ProjectShims.md
     - Upgrade Guides:
-      - Migrate to v1: updates/migrate-v1.md
       - Migrate to v2: updates/migrate-v2.md
+      - Migrate to v1: updates/migrate-v1.md
     - FAQ: pages/FAQ.md
     - Troubleshooting: pages/Troubleshooting.md
     - API Reference: 'api/index.html' # only available in final build, not serve

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"tool"
 	],
 	"engines": {
-		"node": ">= 8.5",
+		"node": ">= 10",
 		"npm": ">= 5"
 	},
 	"scripts": {


### PR DESCRIPTION
This PR or at least the branch should be used to collect all UI5 Tooling 2.0 documentation changes and enhancements.

We should also think about whether we copy all current documentation into a "1.x Documentation" sub-section for archival.