### PR TITLE
[FIX] Replace Slack invite link, direct link to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 Please check our [Contribution Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md).
 
 ## Support
-Please follow our [Contribution Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#report-an-issue) on how to report an issue. Or chat with us in the `#tooling` channel of the [OpenUI5 Community Slack](https://join-ui5-slack.herokuapp.com)
+Please follow our [Contribution Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#report-an-issue) on how to report an issue. Or chat with us in the [`#tooling`](https://openui5.slack.com/archives/C0A7QFN6B) channel of the [OpenUI5 Community Slack](https://ui5-slack-invite.cfapps.eu10.hana.ondemand.com/)
 
 ## License
 This project is licensed under the Apache Software License, Version 2.0 except as noted otherwise in the [LICENSE](https://github.com/SAP/ui5-tooling/blob/master/LICENSE.txt) file.


### PR DESCRIPTION
Use the same invite app as on https://openui5.org/community/ that is hosted on the SAP Mentors Account for SAP Cloud Platform Cloud Foundry. Also a direct link to the #tooling channel in Slack.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
