### PR TITLE
docs: fix the links for custom builder task section

### DIFF
--- a/docs/pages/extensibility/CustomTasks.md
+++ b/docs/pages/extensibility/CustomTasks.md
@@ -1,10 +1,10 @@
 # Custom UI5 Builder Tasks
 
-The UI5 Build Extensibility enables you to enhance the build process of any UI5 project. In addition to the [standard task list](https://github.com/SAP/ui5-builder/blob/master/README.md#tasks), custom tasks can be created.
+The UI5 Build Extensibility enables you to enhance the build process of any UI5 project. In addition to the [standard task list](https://sap.github.io/ui5-tooling/api/module-@ui5_builder.tasks.html), custom tasks can be created.
 
 ## Configuration
 
-You can configure your build process with additional build task. The custom tasks can be defined in the project [configuration](https://github.com/SAP/ui5-project/blob/master/README.md#configuration) within the `ui5.yaml` file.
+You can configure your build process with additional build task. The custom tasks can be defined in the project [configuration](https://sap.github.io/ui5-tooling/pages/Configuration/) within the `ui5.yaml` file.
 
 In the below example, when building the library `my.library` the `babel` task will be executed before the standard task `generateComponentPreload`. Another custom task called `generateMarkdownFiles` is then executed immediatly after the standard task `uglify`.
 


### PR DESCRIPTION
This PR fixes the links of the custom builder task page pointing to the UI5 Tooling documentation.