### PR TITLE
[INTERNAL] Add missing version to ui5.yaml example

### DIFF
--- a/docs/pages/OpenUI5.md
+++ b/docs/pages/OpenUI5.md
@@ -45,6 +45,7 @@ metadata:
   name: some.library
 framework:
   name: OpenUI5
+  version: 1.76.0
   libraries:
     - name: sap.ui.core
     - name: themelib_sap_belize

--- a/docs/pages/SAPUI5.md
+++ b/docs/pages/SAPUI5.md
@@ -58,6 +58,7 @@ metadata:
   name: some.library
 framework:
   name: SAPUI5
+  version: 1.82.0
   libraries:
     - name: sap.ui.core
     - name: themelib_sap_belize


### PR DESCRIPTION
Although being added by their respective commands (like `ui5 use openui5@latest`, the examples were missing the version within their ui5.yaml files. Really small adjustment, hope the commit message is according to the guidelines.

## Pull Request Checklist
- [X] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [X] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [X] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
