### PR TITLE
[INTERNAL] GitHub Action: Flag and close stale issues

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,18 @@
+name: Issue/Pull Request Handling
+on:
+  schedule:
+    - cron: '00 20 * * *'
+
+jobs:
+  stale:
+    name: Flag and close stale issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: 'This issue has been automatically marked as stale because it has been open for 60 days with no activity. It will be closed in 10 days if no further activity occurs.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          days-before-stale: 60
+          days-before-close: 10
+          only-labels: 'information required'


### PR DESCRIPTION
Currently only applies to issues labeled "information required"