### PR TITLE
[INTERNAL] Revert mkdocs-material to v6.0.2

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Update CLI Doc
       run: npm run generate-cli-doc
     - name: Build mkdocs
-      uses: docker://squidfunk/mkdocs-material:7.2.6
+      uses: docker://squidfunk/mkdocs-material:6.0.2
       with:
         args: build
     - name: Set /site ownership to current user

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -95,10 +95,15 @@ html, body, h1, h2, h3, h4, h5, h6, p {
   margin-right: 0.5em;
 }
 
+.sap-icon-circle-task-2 {
+  font-family: SAP-icons;
+}
+
 .sap-icon-circle-task-2::before {
   font-family: SAP-icons;
   content: "\e255";
 }
+
 .sap-icon-circle-task-2-before::before {
   font-family: SAP-icons;
   content: "\e255";

--- a/scripts/buildDocs.sh
+++ b/scripts/buildDocs.sh
@@ -7,6 +7,6 @@ echo "Changed directory to $(pwd)"
 
 npm run generate-cli-doc
 
-docker run --rm -it -v $(pwd):/docs squidfunk/mkdocs-material:7.2.6 build
+docker run --rm -it -v $(pwd):/docs squidfunk/mkdocs-material:6.0.2 build
 
 npm run jsdoc-generate

--- a/scripts/serveDocs.sh
+++ b/scripts/serveDocs.sh
@@ -7,4 +7,4 @@ echo "Changed directory to $(pwd)"
 
 npm run generate-cli-doc
 
-docker run --rm -it -p 8000:8000 -v $(pwd):/docs squidfunk/mkdocs-material:7.2.6
+docker run --rm -it -p 8000:8000 -v $(pwd):/docs squidfunk/mkdocs-material:6.0.2


### PR DESCRIPTION
Starting with v6.1.0 and still with the latest v7.3.0, our custom CSS
classes are not applied in tables. Instead, they are rendered as strings.

Examples from CLI and Builder pages:
![Screenshot 2021-09-24 at 11 07 22](https://user-images.githubusercontent.com/1589939/134649315-4286e692-a3cd-45e9-b094-2aab100bbae1.png)
![Screenshot 2021-09-24 at 11 07 00](https://user-images.githubusercontent.com/1589939/134649325-2d70824b-5daa-426a-9e7f-d67f0e628655.png)


This partially reverts https://github.com/SAP/ui5-tooling/pull/556