### PR TITLE
[INTERNAL] Use native fs.mkdir instead of mkdirp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
 				"handlebars": "^4.7.7",
 				"jsdoc": "^3.6.11",
 				"local-web-server": "^5.2.1",
-				"mkdirp": "^1.0.4",
 				"open-cli": "^7.1.0",
 				"traverse": "^0.6.7"
 			},
@@ -1635,17 +1634,6 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
 		},
-		"node_modules/@ui5/cli/node_modules/atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"bin": {
-				"atob": "bin/atob.js"
-			},
-			"engines": {
-				"node": ">= 4.5.0"
-			}
-		},
 		"node_modules/@ui5/cli/node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2386,16 +2374,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@ui5/cli/node_modules/css": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-			"integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"source-map": "^0.6.1",
-				"source-map-resolve": "^0.6.0"
-			}
-		},
 		"node_modules/@ui5/cli/node_modules/css-select": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -2450,14 +2428,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"node_modules/@ui5/cli/node_modules/decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
-			"engines": {
-				"node": ">=0.10"
-			}
 		},
 		"node_modules/@ui5/cli/node_modules/decompress-response": {
 			"version": "6.0.0",
@@ -5933,16 +5903,6 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@ui5/cli/node_modules/source-map-resolve": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-			"integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-			"deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-			"dependencies": {
-				"atob": "^2.1.2",
-				"decode-uri-component": "^0.2.0"
 			}
 		},
 		"node_modules/@ui5/cli/node_modules/source-map-support": {
@@ -15284,11 +15244,6 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
 				},
-				"atob": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-					"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-				},
 				"balanced-match": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -15830,15 +15785,6 @@
 						}
 					}
 				},
-				"css": {
-					"version": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-					"integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-					"requires": {
-						"inherits": "^2.0.4",
-						"source-map": "^0.6.1",
-						"source-map-resolve": "^0.6.0"
-					}
-				},
 				"css-select": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -15878,11 +15824,6 @@
 							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 						}
 					}
-				},
-				"decode-uri-component": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-					"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
 				},
 				"decompress-response": {
 					"version": "6.0.0",
@@ -18430,15 +18371,6 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"source-map-resolve": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-					"integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-					"requires": {
-						"atob": "^2.1.2",
-						"decode-uri-component": "^0.2.0"
-					}
 				},
 				"source-map-support": {
 					"version": "0.5.21",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
 		"handlebars": "^4.7.7",
 		"jsdoc": "^3.6.11",
 		"local-web-server": "^5.2.1",
-		"mkdirp": "^1.0.4",
 		"open-cli": "^7.1.0",
 		"traverse": "^0.6.7"
 	}

--- a/scripts/buildSchema.js
+++ b/scripts/buildSchema.js
@@ -1,7 +1,6 @@
 import path from "node:path";
 import {fileURLToPath, pathToFileURL} from "node:url";
-import {writeFile} from "node:fs/promises";
-import mkdirp from "mkdirp";
+import {writeFile, mkdir} from "node:fs/promises";
 import $RefParser from "@apidevtools/json-schema-ref-parser";
 import traverse from "traverse";
 
@@ -43,7 +42,7 @@ try {
 		}
 	});
 
-	await mkdirp(path.dirname(TARGET_SCHEMA_PATH));
+	await mkdir(path.dirname(TARGET_SCHEMA_PATH), {recursive: true});
 	await writeFile(TARGET_SCHEMA_PATH, JSON.stringify(schema, null, 2));
 
 	console.log("Wrote bundled ui5.yaml schema file to " + TARGET_SCHEMA_PATH);


### PR DESCRIPTION
The recursive option is available since Node v10.12, which makes the
use of thirdparty packages obsolete for most use cases.
