### PR TITLE
[BUGFIX] Security audit for non-default branches

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout the default branch (security configuration)
         uses: actions/checkout@v3
+        with:
+          path: default
 
       - name: Checkout '${{ matrix.branch }}' branch
         uses: actions/checkout@v3
@@ -30,4 +32,4 @@ jobs:
       - name: Security check for '${{ matrix.branch }}' branch
         run: |
           cd ${{ matrix.branch }}
-          npx audit-ci@^6 --config ../audit-ci.jsonc
+          npx audit-ci@^6 --config ../default/audit-ci.jsonc

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,13 +13,21 @@ jobs:
         branch: ["v2"] # List of branches to run the security audit uppon
 
     steps:
+      - name: Checkout the default branch (security configuration)
+        uses: actions/checkout@v3
+
       - name: Checkout '${{ matrix.branch }}' branch
         uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
+          path: ${{ matrix.branch }}
 
-      - name: install dependencies
-        run: npm ci
+      - name: Install '${{ matrix.branch }}' dependencies
+        run: |
+          cd ${{ matrix.branch }}
+          npm ci
 
-      - name: Use audit-ci
-        run: npx audit-ci@^6 --config ./audit-ci.jsonc
+      - name: Security check for '${{ matrix.branch }}' branch
+        run: |
+          cd ${{ matrix.branch }}
+          npx audit-ci@^6 --config ../audit-ci.jsonc


### PR DESCRIPTION
The configuration of the security audit tool is contained within the main (default) branch, but the security scan should be made on some other branch.

We need to execute the scan on a "random" branch, but take the configuration from the default one. 
So, the workflow is:
- Checkout the default branch
- Checkout the branch (in a separate folder) to which the security scan would be run & install its npm dependencies
- Run the security audit with the configuration from the main branch.