### PR TITLE
[INTERNAL] v2 docs versioning

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,28 +7,48 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: ubuntu-20.04
+    env:
+      MIKE_VERSION: v2
+      MIKE_ALIAS: stable
+      DOCKER_IMAGE: ui5-tooling/mkdocs-material
+      GIT_COMMITTER_NAME: "OpenUI5 Bot"
+      GIT_COMMITTER_EMAIL: "openui5@sap.com"
+
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Install npm dependencies
       run: npm ci
-    - name: Update CLI Doc
-      run: npm run generate-cli-doc
-    - name: Build mkdocs
-      uses: docker://squidfunk/mkdocs-material:8.5.6
-      with:
-        args: build
+
+    - name: Fetch gh-pages branch
+      run: git fetch origin gh-pages --depth=1
+
+    - name: Build docs with Mike
+      run: ./scripts/buildDocs.sh
+
+    - name: Publish docs
+      run: docker run --rm -v $(pwd):/docs --entrypoint mike --env GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME}" --env GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL}" $DOCKER_IMAGE set-default stable --push
+
     - name: Set /site ownership to current user
       run: sudo chown -R $(id -u):$(id -g) ./site
-    
     - name: Build JSDoc
       run: npm run jsdoc-generate
-    - name: Build Schema
-      run: npm run schema-generate
-    - name: Deploy docs to gh-pages
-      uses: JamesIves/github-pages-deploy-action@v4.4.1
+
+    - name: Checkout gh-pages
+      uses: actions/checkout@v3
       with:
-        branch: gh-pages
-        folder: site
-        token: ${{ secrets.GH_PAT }}
-        git-config-name: OpenUI5 Bot
-        git-config-email: openui5@sap.com
+        ref: gh-pages
+        path: gh-pages
+    - name: Copy the additional resources to gh-pages
+      run: |
+        rm -rf ./gh-pages/$MIKE_VERSION/api
+        cp -R ./site/api ./gh-pages/$MIKE_VERSION/
+    - name: Publish Docs
+      run: |
+        cd ./gh-pages
+        git config --local user.email $GIT_COMMITTER_EMAIL
+        git config --local user.name $GIT_COMMITTER_NAME
+        git add .
+        git commit --amend --no-edit
+        git push --force

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,9 @@
+FROM squidfunk/mkdocs-material:8.5.9
+
+# mike version 2 is required in order to enable ENV vars for the container. By the time mike 2 is released we'll
+# use a specific dev version: https://github.com/jimporter/mike/issues/125
+RUN python -m pip install 'mike @ git+https://github.com/jimporter/mike.git@e77357960886f9d9bf2e6ecbc39c7ca6991a2179'
+
+# Define env variables for mike
+ENV GIT_COMMITTER_NAME="OpenUI5 Bot"
+ENV GIT_COMMITTER_EMAIL="openui5@sap.com"

--- a/scripts/buildDocs.sh
+++ b/scripts/buildDocs.sh
@@ -2,11 +2,29 @@
 set -e
 
 cd "$(dirname -- "$0")/.."
-
 echo "Changed directory to $(pwd)"
+
+# Store docker image name
+DOCKER_IMAGE=ui5-tooling/mkdocs-material
+
+# Build image if not existing
+./scripts/buildImage.sh
 
 npm run generate-cli-doc
 
-docker run --rm -it -v $(pwd):/docs squidfunk/mkdocs-material:8.5.6 build
+
+if [[ $MIKE_VERSION ]]; then # Build with Mike (versioning)
+	echo "Starting building & versioning Docs with Mike version: ${MIKE_VERSION}; alias: ${MIKE_ALIAS}..."
+	docker run --rm -v $(pwd):/docs --entrypoint mike \
+		--env GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME}" --env GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL}"  \
+		$DOCKER_IMAGE deploy $MIKE_VERSION $MIKE_ALIAS --rebase --update-aliases
+
+else # Build with MkDocs
+	echo "Starting building Docs with MkDocs..."
+	docker run --rm -v $(pwd):/docs $DOCKER_IMAGE build
+
+fi
 
 npm run jsdoc-generate
+
+echo "Documentation has been built"

--- a/scripts/buildImage.sh
+++ b/scripts/buildImage.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname -- "$0")"
+echo "Changed directory to $(pwd)"
+
+# Store docker image name
+DOCKER_IMAGE=ui5-tooling/mkdocs-material
+# If Dockerfile has been modified, we need to rebuild the image
+DOCKER_TAG=$(node ./hash.js ./Dockerfile)
+
+if [[ "$(docker images -q $DOCKER_IMAGE:$DOCKER_TAG 2> /dev/null)" != "" ]]; then
+	echo "Image ${DOCKER_IMAGE}:${DOCKER_TAG} already exists"
+	exit 0
+fi
+
+echo "Building image '${DOCKER_IMAGE}:${DOCKER_TAG}'..."
+docker build -t $DOCKER_IMAGE -f Dockerfile .
+docker tag $DOCKER_IMAGE $DOCKER_IMAGE:$DOCKER_TAG # Tag the image with Dockerfile's hash
+echo "Done building image."
+
+exit 0

--- a/scripts/hash.js
+++ b/scripts/hash.js
@@ -5,9 +5,9 @@
  * Usage:
  * node hash.js /path/to/file
  */
-import crypto from "crypto";
-import fs from "fs";
-import path from "path";
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
 
 const filename = path.resolve(process.argv[2]);
 

--- a/scripts/hash.js
+++ b/scripts/hash.js
@@ -1,0 +1,18 @@
+/**
+ * Utility to resolve the hash of a file
+ * Used to check whether Dockerfile has been changed and if we need to rebuild it
+ *
+ * Usage:
+ * node hash.js /path/to/file
+ */
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+
+const filename = path.resolve(process.argv[2]);
+
+const fileBuffer = fs.readFileSync(filename);
+const hashSum = crypto.createHash("md5");
+hashSum.update(fileBuffer);
+
+console.log(hashSum.digest("hex"));

--- a/scripts/serveDocs.sh
+++ b/scripts/serveDocs.sh
@@ -2,9 +2,14 @@
 set -e
 
 cd "$(dirname -- "$0")/.."
-
 echo "Changed directory to $(pwd)"
+
+# Store docker image name
+DOCKER_IMAGE=ui5-tooling/mkdocs-material
+
+# Build image if not existing
+./scripts/buildImage.sh
 
 npm run generate-cli-doc
 
-docker run --rm -it -p 8000:8000 -v $(pwd):/docs squidfunk/mkdocs-material:8.5.6
+docker run --rm -it -p 8000:8000 -v $(pwd):/docs $DOCKER_IMAGE


### PR DESCRIPTION
JIRA: CPOUI5FOUNDATION-565

Relates to: https://github.com/SAP/ui5-tooling/pull/697

This change creates a new documentation release workflow that enables versioning.

It extends the MkDocs squidfunk/mkdocs-material image by adding [mike](https://github.com/jimporter/mike) to it.
The GitHub Actions workflow is also being extended to support the new feature.

URLs of the documentation would be changed with a version number prepending the path. In order to "keep" old links available for the end users, there's a custom redirect for GH Pages.