### PR TITLE
[INTERNAL] Fix for docs versioning workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,6 +23,11 @@ jobs:
 
     - name: Fetch gh-pages branch
       run: git fetch origin gh-pages --depth=1
+      
+    - name: Set /site ownership to current user
+      run: |
+        mkdir site
+        sudo chown -R $(id -u):$(id -g) ./site
 
     - name: Build docs with Mike
       run: ./scripts/buildDocs.sh
@@ -30,10 +35,6 @@ jobs:
     - name: Publish docs
       run: docker run --rm -v $(pwd):/docs --entrypoint mike --env GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME}" --env GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL}" $DOCKER_IMAGE set-default stable --push
 
-    - name: Set /site ownership to current user
-      run: sudo chown -R $(id -u):$(id -g) ./site
-    - name: Build JSDoc
-      run: npm run jsdoc-generate
     - name: Build Schema
       run: npm run schema-generate
 


### PR DESCRIPTION
Docs versioning workflow needs to be adjusted.
The buildDocs.sh file runs the npm run jsdoc-generate which creates a new folder (site) within the CI/CD environment.
This folder needs to have the correct access rights.

For `v2`: https://github.com/SAP/ui5-tooling/pull/714