### PR TITLE
[INTERNAL] Bugfix: Keep gh-pages history for mike

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -56,5 +56,5 @@ jobs:
         git config --local user.email $GIT_COMMITTER_EMAIL
         git config --local user.name $GIT_COMMITTER_NAME
         git add .
-        git commit --amend --no-edit
+        git commit -m "Updating supplemental resources for ${MIKE_VERSION} documentation deployment"
         git push --force

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -57,4 +57,4 @@ jobs:
         git config --local user.name $GIT_COMMITTER_NAME
         git add .
         git commit -m "Updating supplemental resources for ${MIKE_VERSION} documentation deployment"
-        git push --force
+        git push


### PR DESCRIPTION
Adds additional, not `mike`/`mkdocs` related documents with a separate commit message instead of squashing the previous one. That way the git history is kept.