### PR TITLE
[INTERNAL] Removes connectUi5Proxy documentation

### DIFF
--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -691,6 +691,7 @@ Unless otherwise noted in the table below, UI5 Tooling modules are backward comp
 
 Version | UI5 CLI Release
 --- | ---
+[**3.0 [beta]**](https://sap.github.io/ui5-tooling/v3/updates/migrate-v3/) | v3.0.0+
 **2.6** | v2.14.0+
 **2.5** | v2.12.0+
 **2.4** | v2.11.0+
@@ -701,6 +702,19 @@ Version | UI5 CLI Release
 **1.1** | v1.13.0+
 **1.0** | v1.0.0+
 **0.1** | v0.0.1+
+
+### Specification Version 3.0 [beta]
+
+!!! info
+    **Note:** UI5 Tooling version 3.0 is currently in development. If you wish to migrate to the latest UI5 Tooling, please check the [Upgrade Guide for v3](https://sap.github.io/ui5-tooling/v3/updates/migrate-v3/)
+
+**Breaking changes:**
+
+- Removes the `/proxy` endpoint and the corresponding
+[**connectUi5Proxy**](https://sap.github.io/ui5-tooling/v2/pages/Server/#connectui5proxy) middleware from the standard [ui5-server](https://github.com/SAP/ui5-server).  More sophisticated proxy solutions for [ui5-server](https://github.com/SAP/ui5-server) are already available in the form of custom middleware extensions from the UI5-community.  For more information on how to transition your project to UI5 Tooling v3, please check the [v3 Migration Guide](https://sap.github.io/ui5-tooling/v3/updates/migrate-v3/)
+
+
+Specification Version 3.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v3.0.0 and above.
 
 ### Specification Version 2.6
 **Features:**

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -711,7 +711,7 @@ Version | UI5 CLI Release
 **Breaking changes:**
 
 - Removes the `/proxy` endpoint and the corresponding
-[**connectUi5Proxy**](https://sap.github.io/ui5-tooling/v2/pages/Server/#connectui5proxy) middleware from the standard [ui5-server](https://github.com/SAP/ui5-server).  More sophisticated proxy solutions for [ui5-server](https://github.com/SAP/ui5-server) are already available in the form of custom middleware extensions from the UI5-community.  For more information on how to transition your project to UI5 Tooling v3, please check the [v3 Migration Guide](https://sap.github.io/ui5-tooling/v3/updates/migrate-v3/)
+[**connectUi5Proxy**](https://sap.github.io/ui5-tooling/v2/pages/Server/#connectui5proxy) middleware from the standard [ui5-server](https://github.com/SAP/ui5-server). More sophisticated proxy solutions for [ui5-server](https://github.com/SAP/ui5-server) are already available in the form of custom middleware extensions from the UI5-community. For more information on how to transition your project to UI5 Tooling v3, please check the [v3 Migration Guide](https://sap.github.io/ui5-tooling/v3/updates/migrate-v3/)
 
 
 Specification Version 3.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v3.0.0 and above.

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -691,7 +691,6 @@ Unless otherwise noted in the table below, UI5 Tooling modules are backward comp
 
 Version | UI5 CLI Release
 --- | ---
-[**3.0 [beta]**](https://sap.github.io/ui5-tooling/v3/updates/migrate-v3/) | v3.0.0+
 **2.6** | v2.14.0+
 **2.5** | v2.12.0+
 **2.4** | v2.11.0+
@@ -702,19 +701,6 @@ Version | UI5 CLI Release
 **1.1** | v1.13.0+
 **1.0** | v1.0.0+
 **0.1** | v0.0.1+
-
-### Specification Version 3.0 [beta]
-
-!!! info
-    **Note:** UI5 Tooling version 3.0 is currently in development. If you wish to migrate to the latest UI5 Tooling, please check the [Upgrade Guide for v3](https://sap.github.io/ui5-tooling/v3/updates/migrate-v3/)
-
-**Breaking changes:**
-
-- Removes the `/proxy` endpoint and the corresponding
-[**connectUi5Proxy**](https://sap.github.io/ui5-tooling/v2/pages/Server/#connectui5proxy) middleware from the standard [ui5-server](https://github.com/SAP/ui5-server). More sophisticated proxy solutions for [ui5-server](https://github.com/SAP/ui5-server) are already available in the form of custom middleware extensions from the UI5-community. For more information on how to transition your project to UI5 Tooling v3, please check the [v3 Migration Guide](https://sap.github.io/ui5-tooling/v3/updates/migrate-v3/)
-
-
-Specification Version 3.0 projects are supported by [UI5 CLI](https://github.com/SAP/ui5-cli) v3.0.0 and above.
 
 ### Specification Version 2.6
 **Features:**

--- a/docs/pages/Server.md
+++ b/docs/pages/Server.md
@@ -20,7 +20,6 @@ A project can also add custom middleware to the server by using the [Custom Serv
 | `testRunner` | See chapter [testRunner](#testrunner) |
 | `serveThemes` | See chapter [serveThemes](#servethemes)  |
 | `versionInfo` | See chapter [versionInfo](#versioninfo)  |
-| `connectUi5Proxy` | See chapter [connectUi5Proxy](#connectui5proxy)  |
 | `nonReadRequests` | See chapter [nonReadRequests](#nonreadrequests)  |
 | `serveIndex` | See chapter [serveIndex](#serveindex)  |
 
@@ -63,9 +62,6 @@ Changes made to these `*.less` files while the server is running will automatica
 
 ### versionInfo
 Generates and serves the version info file `/resources/sap-ui-version.json`, which is required for several framework functionalities.
-
-### connectUi5Proxy
-Provides basic proxy functionality using the proxy offered by [`connect-openui5`](https://github.com/SAP/connect-openui5#proxy) under the endpoint `/proxy`.
 
 ### nonReadRequests
 Answers all non-read requests (POST, PUT, DELETE, etc.) that have not been answered by any other middleware with the 404 "Not Found" status code . This signals the client that these operations are not supported by the server.

--- a/docs/updates/migrate-v3.md
+++ b/docs/updates/migrate-v3.md
@@ -137,7 +137,7 @@ The following middlewares have been removed:
 
 | UI5 Tooling v2              | UI5 Tooling v3              | Note |
 | --------------------------- | --------------------------- | ------------------------- |
-| connectUi5Proxy | *None* | More sophisticated proxy solutions for [ui5-server](https://github.com/SAP/ui5-server) are already available in the form of custom middleware extensions from the UI5-community. Please refactor any custom middleware that attaches to `beforeMiddleware` or `afterMiddleware` of `connectUi5Proxy` to reference some other middleware. |
+| connectUi5Proxy | *None* | More sophisticated proxy solutions for ui5-server are already available in the form of [custom middleware extensions from the UI5-community](https://bestofui5.org/#/packages?tokens=proxy:tag). Please refactor any custom middleware that attaches to `beforeMiddleware` or `afterMiddleware` of `connectUi5Proxy` to reference some other middleware. |
 
 
 **Updated list of standard middlewares:**

--- a/docs/updates/migrate-v3.md
+++ b/docs/updates/migrate-v3.md
@@ -126,3 +126,30 @@ The following processors have been removed:
 ^2^ Enabled for projects defining a [component preload configuration](../pages/Configuration.md#component-preload-generation)  
 ^3^ Enabled in `self-contained` build, which disables `generateComponentPreload` and `generateLibraryPreload`  
 ^4^ Enabled for projects defining a [bundle configuration](../pages/Configuration.md#custom-bundling)  
+
+## Removal of Standard Middleware
+
+The following middlewares have been removed:
+
+- connectUi5Proxy
+
+**Middleware Migration**
+
+| UI5 Tooling v2              | UI5 Tooling v3              | Note |
+| --------------------------- | --------------------------- | ------------------------- |
+| connectUi5Proxy | *None* | More sophisticated proxy solutions for [ui5-server](https://github.com/SAP/ui5-server) are already available in the form of custom middleware extensions from the UI5-community.  Please refactor any custom middleware that attaches to `beforeMiddleware` or `afterMiddleware` of `connectUi5Proxy` to reference some other middleware. |
+
+
+**Updated list of standard middlewares:**
+
+- compression
+- cors
+- csp
+- serveResources
+- serveIndex
+- discovery
+- versionInfo
+- **REMOVED** ~~connectUi5Proxy~~
+- serveThemes
+- testRunner
+- nonReadRequests

--- a/docs/updates/migrate-v3.md
+++ b/docs/updates/migrate-v3.md
@@ -129,7 +129,7 @@ The following processors have been removed:
 
 ## Removal of Standard Middleware
 
-The following middlewares have been removed:
+The following middlewares have been removed from the [standard middlewares list](../../pages/Server/#standard-middleware):
 
 - connectUi5Proxy
 
@@ -138,18 +138,3 @@ The following middlewares have been removed:
 | UI5 Tooling v2              | UI5 Tooling v3              | Note |
 | --------------------------- | --------------------------- | ------------------------- |
 | connectUi5Proxy | *None* | More sophisticated proxy solutions for ui5-server are already available in the form of [custom middleware extensions from the UI5-community](https://bestofui5.org/#/packages?tokens=proxy:tag). Please refactor any custom middleware that attaches to `beforeMiddleware` or `afterMiddleware` of `connectUi5Proxy` to reference some other middleware. |
-
-
-**Updated list of standard middlewares:**
-
-- compression
-- cors
-- csp
-- serveResources
-- serveIndex
-- discovery
-- versionInfo
-- **REMOVED** ~~connectUi5Proxy~~
-- serveThemes
-- testRunner
-- nonReadRequests

--- a/docs/updates/migrate-v3.md
+++ b/docs/updates/migrate-v3.md
@@ -137,7 +137,7 @@ The following middlewares have been removed:
 
 | UI5 Tooling v2              | UI5 Tooling v3              | Note |
 | --------------------------- | --------------------------- | ------------------------- |
-| connectUi5Proxy | *None* | More sophisticated proxy solutions for [ui5-server](https://github.com/SAP/ui5-server) are already available in the form of custom middleware extensions from the UI5-community.  Please refactor any custom middleware that attaches to `beforeMiddleware` or `afterMiddleware` of `connectUi5Proxy` to reference some other middleware. |
+| connectUi5Proxy | *None* | More sophisticated proxy solutions for [ui5-server](https://github.com/SAP/ui5-server) are already available in the form of custom middleware extensions from the UI5-community. Please refactor any custom middleware that attaches to `beforeMiddleware` or `afterMiddleware` of `connectUi5Proxy` to reference some other middleware. |
 
 
 **Updated list of standard middlewares:**


### PR DESCRIPTION
> This removes the "/proxy" endpoint and the corresponding
"connectUi5Proxy" middleware from the standard ui5-server.
Internally, this middleware made use of the connect-openui5 proxy
implementation (https://github.com/SAP/connect-openui5#proxy).

> More sophisticated proxy solutions for ui5-server are already available
in the form of custom middleware extensions from the UI5-community.

> The UI5 Team might provide a dedicated custom middleware extension,
with similar functionality, in the future.

Relates to: https://github.com/SAP/ui5-server/pull/550

JIRA: CPOUI5FOUNDATION-598
