### PR TITLE
[INTERNAL] Switch API links to explicitly point to /v2/api documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 ## Resources
-- [Documentation](https://sap.github.io/ui5-tooling/)
-- [API Reference](https://sap.github.io/ui5-tooling/api/)
-- [CLI Documentation](https://sap.github.io/ui5-tooling/pages/CLI/)
-- [Project Configuration](https://sap.github.io/ui5-tooling/pages/Configuration/)
+- [Documentation v2](https://sap.github.io/ui5-tooling/v2/)
+- [API Reference v2](https://sap.github.io/ui5-tooling/v2/api/)
+- [CLI Documentation v2](https://sap.github.io/ui5-tooling/v2/pages/CLI/)
+- [Project Configuration v2](https://sap.github.io/ui5-tooling/v2/pages/Configuration/)
 - 🎬 [UI5con@SAP 2018 Talk](https://www.youtube.com/watch?v=iQ07oe26y_k)
 - 🎬 [UI5con@SAP 2020 Talk](https://www.youtube.com/watch?v=8IHoVJLKN34)
 - [Contribution Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ Build succeeded in 363 ms
 Most UI5 Tooling modules provide JavaScript APIs for direct consumption in other Node.js projects.
 This allows you to rely on UI5 Tooling for UI5-specific build functionality and project handling, while creating your own tools to perfectly match the needs of your project.
 
-All available APIs are documented in the [UI5 Tooling API Reference](https://sap.github.io/ui5-tooling/api/index.html).
+All available APIs are documented in the [UI5 Tooling API Reference](https://sap.github.io/ui5-tooling/v2/api/index.html).
 
 ```js linenums="1"
 const {normalizer} = require("@ui5/project");

--- a/docs/pages/Builder.md
+++ b/docs/pages/Builder.md
@@ -6,7 +6,7 @@ Based on a project's type, the UI5 Builder defines a series of build steps to ex
 
 For every type there is a set of default tasks. You can disable single tasks using the `--exclude-task` [CLI parameter](./CLI.md#ui5-build), and you can include tasks using the `--include-task` parameter.
 
-[**API Reference**](https://sap.github.io/ui5-tooling/api/module-@ui5_builder.html){: .md-button .sap-icon-initiative }
+[**API Reference**](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_builder.html){: .md-button .sap-icon-initiative }
 
 ## Types
 Types define how a project can be configured and how it is built. A type orchestrates a set of tasks and defines the order in which they get applied during build phase. Furthermore, it takes care of formatting and validating the project-specific configuration.
@@ -48,7 +48,7 @@ A project can add custom tasks to the build by using the [Custom Tasks Extensibi
 
 ### Standard Tasks
 
-All available standard tasks are documented [in the API reference](https://sap.github.io/ui5-tooling/api/module-@ui5_builder.tasks.html) and are listed below in the order of their execution:
+All available standard tasks are documented [in the API reference](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_builder.tasks.html) and are listed below in the order of their execution:
 
 | Task | Type `application` | Type `library` | Type `theme-library` |
 | ---- | :----: | :----: | :----: |
@@ -90,7 +90,7 @@ Processors work with provided resources. They contain the actual build step logi
 Processors can be implemented generically. The string replacer is an example for that.
 Since string replacement is a common build step, it can be useful in different contexts, e.g. code, version, date, and copyright replacement. A concrete replacement operation could be achieved by passing a custom configuration to the processor. This way, multiple tasks can make use of the same processor to achieve their build step.
 
-Available processors are listed [in the API reference](https://sap.github.io/ui5-tooling/api/module-@ui5_builder.processors.html).
+Available processors are listed [in the API reference](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_builder.processors.html).
 
 ## Source Map support
 

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -651,7 +651,7 @@ A list of bundle definitions. A `bundleDefinition` contains of the following opt
 
 - `name`: The module bundle name
 - `defaultFileTypes`: List of default file types which should be included in the bundle. Defaults to: `.js`, `.control.xml`, `.fragment.html`, `.fragment.json`, `.fragment.xml`, `.view.html`, `.view.json` and `.view.xml`
-  - `sections`: A list of module bundle definition sections. Each section specifies an embedding technology (see [API-Reference](https://sap.github.io/ui5-tooling/api/module-@ui5_builder.tasks.html#.generateBundle)) and lists the resources that should be in- or excluded from the section.
+  - `sections`: A list of module bundle definition sections. Each section specifies an embedding technology (see [API-Reference](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_builder.tasks.html#.generateBundle)) and lists the resources that should be in- or excluded from the section.
     - `mode`:  The embedding technology (e.g. provided, raw, preload)
     - `filters`: List of modules declared as glob patterns (resource name patterns) that are in- or excluded. Similarly to the use of a single `*` or double `**` asterisk, a pattern ending with a slash `/` denotes an arbitrary number of characters or folder names. Excludes have to be marked with a leading exclamation mark `!`. The order of filters is relevant; a later inclusion overrides an earlier exclusion, and vice versa.
     - `resolve`: Setting resolve to `true` will also include all (transitive) dependencies of the files

--- a/docs/pages/Overview.md
+++ b/docs/pages/Overview.md
@@ -76,4 +76,4 @@ This requires an SSL certificate. You are guided through the automatic generatio
 ## Integration in Other Tools
 One of the key features of the UI5 Tooling is its modularization. Single parts of the tooling can easily be integrated in other `Node.js`-based tools and frameworks like [Grunt](https://gruntjs.com/) or [Gulp](https://gulpjs.com/).
 
-All JavaScript APIs available for direct consumption are listed [here](https://sap.github.io/ui5-tooling/api/index.html). However, for standard UI5 development, the [UI5 CLI](./CLI.md) should always be the first choice.
+All JavaScript APIs available for direct consumption are listed [here](https://sap.github.io/ui5-tooling/v2/api/index.html). However, for standard UI5 development, the [UI5 CLI](./CLI.md) should always be the first choice.

--- a/docs/pages/Project.md
+++ b/docs/pages/Project.md
@@ -2,14 +2,14 @@
 
 The [UI5 Project](https://github.com/SAP/ui5-project) module provides functionality to build a UI5 project's dependency tree, including the validated project configurations. It is also responsible for installing and managing framework dependencies. Also see [Development Overview: Project Dependencies](./Overview.md#project-dependencies).
 
-[**API Reference**](https://sap.github.io/ui5-tooling/api/module-@ui5_project.html){: .md-button .sap-icon-initiative }
+[**API Reference**](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_project.html){: .md-button .sap-icon-initiative }
 
 ## Normalizer
-The purpose of the normalizer is to collect dependency information and to enrich it with project configuration (both done in [generateProjectTree](https://sap.github.io/ui5-tooling/api/module-@ui5_project.normalizer.html#.generateProjectTree)).
+The purpose of the normalizer is to collect dependency information and to enrich it with project configuration (both done in [generateProjectTree](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_project.normalizer.html#.generateProjectTree)).
 
 [Translators](#translators) are used to collect dependency information. The [Project Preprocessor](#project-preprocessor) enriches this dependency information with project configuration, typically from a `ui5.yaml` file. A development server and build process can use this information to locate project and dependency resources.
 
-If you want to retrieve the project dependency graph without any configuration, you may use use the [generateDependencyTree](https://sap.github.io/ui5-tooling/api/module-@ui5_project.normalizer.html#.generateDependencyTree) API.
+If you want to retrieve the project dependency graph without any configuration, you may use use the [generateDependencyTree](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_project.normalizer.html#.generateDependencyTree) API.
 
 ## Translators
 Translators collect recursively all dependencies on a package manager specific layer and return information about them in a well-defined tree structure.

--- a/docs/pages/Server.md
+++ b/docs/pages/Server.md
@@ -2,7 +2,7 @@
 
 The [UI5 Server](https://github.com/SAP/ui5-server) module provides server capabilities for local development of UI5 projects.
 
-[**API Reference**](https://sap.github.io/ui5-tooling/api/module-@ui5_server.html){: .md-button .sap-icon-initiative }
+[**API Reference**](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_server.html){: .md-button .sap-icon-initiative }
 
 ## Standard Middleware
 

--- a/docs/pages/extensibility/CustomServerMiddleware.md
+++ b/docs/pages/extensibility/CustomServerMiddleware.md
@@ -144,6 +144,6 @@ Live demo of the above example: https://github.com/SAP/openui5-sample-app/tree/d
 
 ## Helper Class `MiddlewareUtil`
 
-Custom middleware defining [Specification Version](../Configuration.md#specification-versions) 2.0 or higher have access to an interface of a [MiddlewareUtil](https://sap.github.io/ui5-tooling/api/module-@ui5_server.middleware.MiddlewareUtil.html) instance.
+Custom middleware defining [Specification Version](../Configuration.md#specification-versions) 2.0 or higher have access to an interface of a [MiddlewareUtil](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_server.middleware.MiddlewareUtil.html) instance.
 
-In this case, a `middlewareUtil` object is provided as a part of the custom middleware's [parameters](#custom-middleware-implementation). Depending on the specification version of the custom middleware, a set of helper functions is available to the implementation. The lowest required specification version for every function is listed in the [MiddlewareUtil API reference](https://sap.github.io/ui5-tooling/api/module-@ui5_server.middleware.MiddlewareUtil.html).
+In this case, a `middlewareUtil` object is provided as a part of the custom middleware's [parameters](#custom-middleware-implementation). Depending on the specification version of the custom middleware, a set of helper functions is available to the implementation. The lowest required specification version for every function is listed in the [MiddlewareUtil API reference](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_server.middleware.MiddlewareUtil.html).

--- a/docs/pages/extensibility/CustomTasks.md
+++ b/docs/pages/extensibility/CustomTasks.md
@@ -126,8 +126,8 @@ module.exports = async function({workspace, dependencies, taskUtil, options}) {
 
 **Parameters:**
 
-- **`workspace`**: A [DuplexCollection](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.DuplexCollection.html) to read and write [Resources](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.Resource.html) for the project that is currently being built
-- **`dependencies`**: A [ReaderCollection](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.ReaderCollection.html) to read [Resources](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.Resource.html) of the project's dependencies
+- **`workspace`**: A [DuplexCollection](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.DuplexCollection.html) to read and write [Resources](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.Resource.html) for the project that is currently being built
+- **`dependencies`**: A [ReaderCollection](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.ReaderCollection.html) to read [Resources](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.Resource.html) of the project's dependencies
 - **`taskUtil`**: See [details below](https://sap.github.io/ui5-tooling/pages/extensibility/CustomTasks/#helper-class-taskutil)
 - **`options.projectName`**: The name of the project currently being built. *Example: `my.library`*
 - **`options.projectNamespace`**: The namespace of the project. *Example: `my/library`*
@@ -192,8 +192,8 @@ module.exports = async function({workspace, dependencies, taskUtil, options}) {
 
 ## Helper Class `TaskUtil`
 
-Custom tasks defining [Specification Version](../Configuration.md#specification-versions) 2.2 or higher have access to an interface of a [TaskUtil](https://sap.github.io/ui5-tooling/api/module-@ui5_builder.tasks.TaskUtil.html) instance.
+Custom tasks defining [Specification Version](../Configuration.md#specification-versions) 2.2 or higher have access to an interface of a [TaskUtil](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_builder.tasks.TaskUtil.html) instance.
 
-In this case, a `taskUtil` object is provided as a part of the custom task's [parameters](#task-implementation). Depending on the specification version of the custom task, a set of helper functions is available to the implementation. The lowest required specification version for every function is listed in the [TaskUtil API reference](https://sap.github.io/ui5-tooling/api/module-@ui5_builder.tasks.TaskUtil.html).
+In this case, a `taskUtil` object is provided as a part of the custom task's [parameters](#task-implementation). Depending on the specification version of the custom task, a set of helper functions is available to the implementation. The lowest required specification version for every function is listed in the [TaskUtil API reference](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_builder.tasks.TaskUtil.html).
 
 Also see UI5 Tooling [RFC 0008 Resource Tagging During Build](https://github.com/SAP/ui5-tooling/blob/master/rfcs/0008-resource-tagging-during-build.md) for details on resource tagging.

--- a/docs/pages/fsInterface.md
+++ b/docs/pages/fsInterface.md
@@ -1,4 +1,4 @@
-The [fsInterface](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.html#.fsInterface) module is a custom fs implementation which is used to replace node [fs](https://nodejs.org/api/fs.html).
+The [fsInterface](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.html#.fsInterface) module is a custom fs implementation which is used to replace node [fs](https://nodejs.org/api/fs.html).
 A custom or modified fs can be necessary due to several reasons, maybe for caching functionality or to fallback to multiple locations automatically.
 
 To ensure a module or library can be used with custom fs implementations, it is best practice

--- a/docs/updates/migrate-v2.md
+++ b/docs/updates/migrate-v2.md
@@ -30,7 +30,7 @@ _**Note:** This change does not affect most projects as `*.properties` files are
 
 **UI5 FS: Remove deprecated parameter useNamespaces ([SAP/ui5-fs#223](https://github.com/SAP/ui5-fs/pull/223))**
 
-Remove the deprecated parameter `useNamespaces` from method [`resourceFactory.createCollectionsForTree`](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.resourceFactory.html#.createCollectionsForTree). Use the parameter `getVirtualBasePathPrefix` instead.
+Remove the deprecated parameter `useNamespaces` from method [`resourceFactory.createCollectionsForTree`](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.resourceFactory.html#.createCollectionsForTree). Use the parameter `getVirtualBasePathPrefix` instead.
 
 ## How to upgrade
 

--- a/rfcs/0008-resource-tagging-during-build.md
+++ b/rfcs/0008-resource-tagging-during-build.md
@@ -18,7 +18,7 @@ Provide a functionality to store simple information for a resource during the bu
 ## Motivation
 This concept was initially created as a solution for the requirement stated in [SAP/ui5-fs#155](https://github.com/SAP/ui5-fs/issues/155) for an "API to remove resources". Which in turn was created based on a use case of the UI5 Flexibility Area, which would like to remove resources *from the build result*.
 
-Since *removing* resources is not trivial due to the layered structure of the "workspace" [DuplexCollection](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.DuplexCollection.html), a resource might have multiple sources and should not be removed from all of them. A tagging mechanism that rather focuses on the handling of a resource, e.g. that it should not be included into the build result, seems better suited to solve the above use case.
+Since *removing* resources is not trivial due to the layered structure of the "workspace" [DuplexCollection](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.DuplexCollection.html), a resource might have multiple sources and should not be removed from all of them. A tagging mechanism that rather focuses on the handling of a resource, e.g. that it should not be included into the build result, seems better suited to solve the above use case.
 
 There are also other use cases for such a tagging mechanism. For example it would be useful for some tasks to know whether a resource should not be minified (e.g. some bundles).
 
@@ -54,7 +54,7 @@ In the future, custom tasks shall be enabled to use self-defined tags for the pu
 
 ### New APIs in Detail
 
-The task facing API shall be wrapped in a new class "TaskUtil". Similarly to the [MiddlewareUtil](https://sap.github.io/ui5-tooling/api/module-@ui5_server.middleware.MiddlewareUtil.html) of the UI5 Server, it should provide a [specVersion-dependent interface](https://github.com/SAP/ui5-server/blob/master/lib/middleware/MiddlewareUtil.js#L21) to convenience functions as well as the new tagging APIs.
+The task facing API shall be wrapped in a new class "TaskUtil". Similarly to the [MiddlewareUtil](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_server.middleware.MiddlewareUtil.html) of the UI5 Server, it should provide a [specVersion-dependent interface](https://github.com/SAP/ui5-server/blob/master/lib/middleware/MiddlewareUtil.js#L21) to convenience functions as well as the new tagging APIs.
 
 An instance of TaskUtil will be passed to every standard task that requires it. To stay compatible for current consumers of those tasks, the new parameter must be treated as optional.
 
@@ -70,7 +70,7 @@ taskUtil.getTag(resource, OmitFromBuildResult);
 
 #### TaskUtil#setTag(resource, tagName, value)
 
-* The resource must be of type [@ui5/fs.Resource](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.Resource.html)
+* The resource must be of type [@ui5/fs.Resource](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.Resource.html)
 * Throws an error if the tag name does not follow the naming conventions and restrictions outlined [above](#tags)
 * Value must be primitive. If no value is supplied, it defaults to true (hence can't be undefined)
 * Returns undefined
@@ -132,7 +132,7 @@ Dependencies can be tagged, but might have already been processed. Therefore, de
 What other designs have been considered? What is the impact of not doing this?
 -->
 
-As outlined in the [Motivation](#motivation), an actual `remove` function could be added to the [ReaderCollection](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.ReaderCollection.html) or [DuplexCollection](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.DuplexCollection.html) classes. However, due to the layered structure of ui5-fs, it needs to be decided whether `remove` should actually remove a resource from its source or just ignore it at a higher level. Removing from source might not be intended. Ignoring a resource on a higher level could cause confusion since it might not be ignored when asking a different ReaderCollection for it.
+As outlined in the [Motivation](#motivation), an actual `remove` function could be added to the [ReaderCollection](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.ReaderCollection.html) or [DuplexCollection](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.DuplexCollection.html) classes. However, due to the layered structure of ui5-fs, it needs to be decided whether `remove` should actually remove a resource from its source or just ignore it at a higher level. Removing from source might not be intended. Ignoring a resource on a higher level could cause confusion since it might not be ignored when asking a different ReaderCollection for it.
 
 ## Unresolved Questions and Bikeshedding
 

--- a/rfcs/0010-ui5-builder-bundling-refactoring.md
+++ b/rfcs/0010-ui5-builder-bundling-refactoring.md
@@ -34,7 +34,7 @@ These tags are shared in a "global" build context, so that they can also be acce
 
 #### `@ui5/fs.readers.Filter`
 
-Filtering resources based on a tag can be achieved by enhancing on the [ReaderCollection](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.ReaderCollection.html) concept of the UI5 FS. A new `filter()` API of the [AbstractReader](https://sap.github.io/ui5-tooling/api/module-@ui5_fs.AbstractReader.html) will provide a "reader.Filter" instance *(which also implements `AbstractReader`)*, wrapping the given reader instance. For every resource retrieved through this reader.Filter, a filter callback function is called, allowing filtering on tags or other parameters. 
+Filtering resources based on a tag can be achieved by enhancing on the [ReaderCollection](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.ReaderCollection.html) concept of the UI5 FS. A new `filter()` API of the [AbstractReader](https://sap.github.io/ui5-tooling/v2/api/module-@ui5_fs.AbstractReader.html) will provide a "reader.Filter" instance *(which also implements `AbstractReader`)*, wrapping the given reader instance. For every resource retrieved through this reader.Filter, a filter callback function is called, allowing filtering on tags or other parameters. 
 
 This approach of filtering-out resources that should never be included in a specific bundle can also be used when exchanging the legacy-bundle-tooling with other tools like [Rollup](https://github.com/rollup/rollup), which also only expect the resources relevant for the bundle to be available.
 


### PR DESCRIPTION
Now all the API links need to point explicitly to the /v2/api path. This way links from the documentation would always be correct