### PR TITLE
[INTERNAL] Migrate v3: Align minimum Node version

### DIFF
--- a/docs/updates/migrate-v3.md
+++ b/docs/updates/migrate-v3.md
@@ -6,7 +6,7 @@
 
 ## Node.js and npm Version Support
 
-**Only Node.js v16.13.2 and npm v8 or higher are supported.**
+**Only Node.js v16.18.0 and npm v8 or higher are supported.**
 Support for older Node.js and npm releases has been dropped.
 
 ## Specification Versions Support


### PR DESCRIPTION
UI5 Tooling modules currently require at least Node v16.18.0