### PR TITLE
[INTERNAL] Update usages of CJS require/exports to ESM import/export

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,12 +86,12 @@ This allows you to rely on UI5 Tooling for UI5-specific build functionality and 
 
 All available APIs are documented in the [UI5 Tooling API Reference](https://sap.github.io/ui5-tooling/v3/api/index.html).
 
-=== "CommonJS"
+=== "ESM"
 
     ```js linenums="1"
+    import {graphFromPackageDependencies} from "@ui5/project/graph";
+
     async function buildApp(projectPath, destinationPath) {
-        const {graphFromPackageDependencies} = 
-            await import("@ui5/project/graph");
         const graph = await graphFromPackageDependencies({
             cwd: projectPath
         });
@@ -104,12 +104,12 @@ All available APIs are documented in the [UI5 Tooling API Reference](https://sap
     }
     ```
 
-=== "ESM"
+=== "CommonJS"
 
     ```js linenums="1"
-    import {graphFromPackageDependencies} from "@ui5/project/graph";
-
     async function buildApp(projectPath, destinationPath) {
+        const {graphFromPackageDependencies} = 
+            await import("@ui5/project/graph");
         const graph = await graphFromPackageDependencies({
             cwd: projectPath
         });

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,15 @@
 ![UI5 logo](images/UI5_logo_wide.png)
 
 # UI5 Tooling
+
 An open and modular toolchain to develop state-of-the-art applications based on the [UI5](https://ui5.sap.com) framework.
 
 [**Get Started**](./pages/GettingStarted.md){: .md-button .md-button--primary .sap-icon-initiative }
 
-
 ## Main Features
+
 ### 💻 UI5 CLI
+
 *Also see the [UI5 CLI Documentation](./pages/CLI.md)*
 
 ```sh
@@ -48,6 +50,7 @@ Added framework libraries sap.ui.core sap.m themelib_sap_fiori_3 as dependencies
 ```
 
 #### 🏄 Development Server
+
 Start a local development server to work on your project.  
 *Also see the [Server Documentation](./pages/Server.md)*
 
@@ -58,6 +61,7 @@ URL: http://localhost:8080
 ```
 
 #### 🛠 Build for Production
+
 Build an optimized version of your project.  
 *Also see the [Builder Documentation](./pages/Builder.md)*
 
@@ -76,25 +80,44 @@ Build succeeded in 363 ms
 ```
 
 ### 🧪 Node.js API
+
 Most UI5 Tooling modules provide JavaScript APIs for direct consumption in other Node.js projects.
 This allows you to rely on UI5 Tooling for UI5-specific build functionality and project handling, while creating your own tools to perfectly match the needs of your project.
 
 All available APIs are documented in the [UI5 Tooling API Reference](https://sap.github.io/ui5-tooling/v3/api/index.html).
 
-```js linenums="1"
-import {graphFromPackageDependencies} from "@ui5/project/graph";
+=== "CommonJS"
 
-async function buildApp(projectPath, destinationPath) {
-    const graph = await graphFromPackageDependencies({
-        cwd: projectPath
-    });
-    await graph.build({
-        destPath: destinationPath,
-        selfContained: true,
-        excludedTasks: ["transformBootstrapHtml"],
-        includedDependencies: ["*"]
-    });
-}
+    ```js linenums="1"
+    async function buildApp(projectPath, destinationPath) {
+        const {graphFromPackageDependencies} = 
+            await import("@ui5/project/graph");
+        const graph = await graphFromPackageDependencies({
+            cwd: projectPath
+        });
+        await graph.build({
+            destPath: destinationPath,
+            selfContained: true,
+            excludedTasks: ["transformBootstrapHtml"],
+            includedDependencies: ["*"]
+        });
+    }
+    ```
 
-[...]
-```
+=== "ESM"
+
+    ```js linenums="1"
+    import {graphFromPackageDependencies} from "@ui5/project/graph";
+
+    async function buildApp(projectPath, destinationPath) {
+        const graph = await graphFromPackageDependencies({
+            cwd: projectPath
+        });
+        await graph.build({
+            destPath: destinationPath,
+            selfContained: true,
+            excludedTasks: ["transformBootstrapHtml"],
+            includedDependencies: ["*"]
+        });
+    }
+    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,19 +82,17 @@ This allows you to rely on UI5 Tooling for UI5-specific build functionality and 
 All available APIs are documented in the [UI5 Tooling API Reference](https://sap.github.io/ui5-tooling/v3/api/index.html).
 
 ```js linenums="1"
-const {normalizer} = require("@ui5/project");
-const {builder} = require("@ui5/builder");
+import {graphFromPackageDependencies} from "@ui5/project/graph";
 
 async function buildApp(projectPath, destinationPath) {
-    const tree = await normalizer.generateProjectTree({
+    const graph = await graphFromPackageDependencies({
         cwd: projectPath
     });
-    await builder.build({
-        tree,
+    await graph.build({
         destPath: destinationPath,
         selfContained: true,
         excludedTasks: ["transformBootstrapHtml"],
-        buildDependencies: true
+        includedDependencies: ["*"]
     });
 }
 

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -15,12 +15,12 @@ See the list of [clients](https://github.com/redhat-developer/yaml-language-serv
 
 ## Example
 
-````yaml
+```yaml
 specVersion: "2.6"
 type: application|library|theme-library|module
 metadata:
   name: some.project.name
-````
+```
 
 ## General Configuration
 A project must define a specification version (`specVersion`), to which its configuration is compatible to. Also see [Specification Versions](#specification-versions).
@@ -31,43 +31,43 @@ In addition, a project must define a `type`. This can be either `application`, `
 
     === "application"
 
-        ````yaml
+        ```yaml
         specVersion: "2.6"
         type: application
-        ````
+        ```
 
     === "library"
 
-        ````yaml
+        ```yaml
         specVersion: "2.6"
         type: library
-        ````
+        ```
 
     === "theme-library"
 
-        ````yaml
+        ```yaml
         specVersion: "2.6"
         type: theme-library
-        ````
+        ```
 
     === "module"
 
-        ````yaml
+        ```yaml
         specVersion: "2.6"
         type: module
-        ````
+        ```
 
 ### Metadata
 
 !!! example
-    ````yaml
+    ```yaml
     metadata:
       name: my.company.project
       copyright: |-
        My Project
         * (c) Copyright 2009-${currentYear} My Company
         * Licensed under the XYZ License, Version n - see LICENSE.txt.
-    ````
+    ```
 
 #### name
 
@@ -98,25 +98,25 @@ Note that all configured paths must be written in POSIX (i.e. using only forward
     - `webapp`: Mapped to runtime path `/` (root)
 
     *Default configuration:*
-    ````yaml
+    ```yaml
     resources:
       configuration:
         paths:
           webapp: webapp
-    ````
+    ```
 
 === "Libraries"
     - `src`: Mapped to runtime path `/resources`
     - `test`: Mapped to runtime path `/test-resources`
 
     *Default configuration:*
-    ````yaml
+    ```yaml
     resources:
       configuration:
         paths:
           src: src
           test: test
-    ````
+    ```
 
 === "Modules"
     Any virtual paths can be mapped to any physical path.
@@ -124,33 +124,33 @@ Note that all configured paths must be written in POSIX (i.e. using only forward
     However, it is recommended that modules include their namespace in the virtual path and use the `/resources` prefix (e.g. `/resources/my/library/module-xy/`).
 
     *Example configuration:*
-    ````yaml
+    ```yaml
     resources:
       configuration:
         paths:
           /resources/my/library/module-xy/: lib
           /resources/my/library/module-xy-min/: dist
-    ````
+    ```
 
 !!! example
     For an application project with the following directory structure, you need the path mapping configuration given below:
 
     *Directory Structure*
-    ```` hl_lines="3 4 5"
+    ``` hl_lines="3 4 5"
     my-app/
     \_ ui5.yaml
     \_ lib/
       \_ js/
         \_ app/
-    ````
+    ```
 
     *Path Mapping Configuration*
-    ````yaml hl_lines="4"
+    ```yaml hl_lines="4"
     resources:
       configuration:
         paths:
           webapp: lib/js/app
-    ````
+    ```
 
 
 ### Encoding of `*.properties` files
@@ -161,19 +161,19 @@ Note that all configured paths must be written in POSIX (i.e. using only forward
 !!! example
     === "UTF-8"
 
-        ````yaml
+        ```yaml
         resources:
           configuration:
             propertiesFileSourceEncoding: UTF-8
-        ````
+        ```
 
     === "ISO-8859-1"
 
-        ````yaml
+        ```yaml
         resources:
           configuration:
             propertiesFileSourceEncoding: ISO-8859-1
-        ````
+        ```
 
 By default UI5 Tooling expects different encodings for `*.properties` i18n files, depending on the project's specification version:
 
@@ -340,14 +340,14 @@ You can choose which theme library to use by the application that is consuming t
 ### Exclude Resources
 
 !!! example
-    ````yaml
+    ```yaml
     builder:
       resources:
         excludes:
           - "/resources/some/project/name/test_results/**"
           - "/test-resources/**"
           - "!/test-resources/some/project/name/demo-app/**"
-    ````
+    ```
 
 You can exclude a projects resources from the build process using a list of glob patterns. Matching resources will be ignored by the builder and all build tasks.
 
@@ -357,17 +357,17 @@ Patterns are applied to the **virtual** path of resources (i.e. the UI5 runtime 
 
 !!! example
     === "time (default)"
-        ````yaml
+        ```yaml
         builder:
           cachebuster:
             signatureType: time
-        ````
+        ```
     === "hash"
-        ````yaml
+        ```yaml
         builder:
           cachebuster:
             signatureType: hash
-        ````
+        ```
 
 By default, the generated cachebuster info file signatures are based on timestamps (`time`). In setups like CI environments, a mechanism based on file hashes (`hash`) might be more reliable. Also see [PR #241](https://github.com/SAP/ui5-builder/pull/241) for more details.
 
@@ -468,7 +468,7 @@ Note that patterns are always applied relative to the project's virtual source d
 ### Custom Tasks
 
 !!! example
-    ````yaml
+    ```yaml
     builder:
       customTasks:
         - name: custom-task-1
@@ -479,7 +479,7 @@ Note that patterns are always applied relative to the project's virtual source d
           afterTask: custom-task-1
           configuration:
             color: blue
-    ````
+    ```
 
 You can define custom build tasks that will be executed for the project. Please refer to the [Custom Tasks Documentation](./extensibility/CustomTasks.md) for a detailed explanation and examples of the build extensibility.
 
@@ -492,12 +492,12 @@ Optionally, arbitrary `configuration` can be passed to the custom task.
 ### JSDoc
 
 !!! example
-    ````yaml
+    ```yaml
     builder:
       jsdoc:
         excludes:
           - "some/project/name/thirdparty/**"
-    ````
+    ```
 
 You can exclude the resources of a project from the JSDoc build process using a list of glob patterns. Matching resources will be ignored by the JSDoc build task.
 
@@ -513,7 +513,7 @@ These excludes are applied *before* any general builder excludes that have been 
     2.5 or higher.
 
 !!! example
-    ````yaml
+    ```yaml
     builder:
       settings:
         includeDependency:
@@ -522,7 +522,7 @@ These excludes are applied *before* any general builder excludes that have been 
           - ^com\.namespace
         includeDependencyTree:
           - sap.m
-    ````
+    ```
 
 You can include certain dependencies into the build process using the `includeDependency` builder setting. By using `includeDependencyRegExp`, a regular expression can be used, for example to specify a namespace to dynamically select a group of dependencies that have to be included into the build result. By using `includeDependencyTree`, a selected dependency including all of its sub-dependencies is used.
 
@@ -556,12 +556,12 @@ Note that patterns are always applied relative to the project's virtual source d
 ## Server Configuration
 
 !!! example
-    ````yaml
+    ```yaml
     server:
       settings:
         httpPort: 1337
         httpsPort: 1443
-    ````
+    ```
 
 By default, UI5 Tooling will serve applications using Port `8080`. When running in HTTP/2 or HTTPS mode, Port `8443` will be used.
 
@@ -574,7 +574,7 @@ The default and configured server ports can always be overwritten with the CLI p
 ## Extension Configuration
 
 !!! example
-    ````yaml
+    ```yaml
     specVersion: "2.6"
     type: application
     metadata:
@@ -596,7 +596,7 @@ The default and configured server ports can always be overwritten with the CLI p
             configuration:
               paths:
                 /resources/my/application/thirdparty/: ""
-    ````
+    ```
 
 Extensions configuration can be added to any projects `ui5.yaml`. For better readability, it should to be located *after* the projects configuration, separated by [three dashes](https://yaml.org/spec/1.2/spec.html#id2760395) "`---`".
 
@@ -612,7 +612,7 @@ Extensions can be identified by the `kind: extension` configuration. Note that i
 ## Custom Bundling
 
 !!! example
-    ````yaml
+    ```yaml
     builder:
       bundles:
         - bundleDefinition:
@@ -639,7 +639,7 @@ Extensions can be identified by the `kind: extension` configuration. Note that i
                 resolve: true
           bundleOptions:
             optimize: true
-    ````
+    ```
 
 Custom bundles can be defined in the `ui5.yaml`. Within the `builder/bundles` configuration a list of `bundleDefinitions` can be described.
 
@@ -674,10 +674,10 @@ A list of bundle definitions. A `bundleDefinition` contains of the following opt
 ## Specification Versions
 A project must define a Specification Version by setting the `specVersion` property. UI5 Tooling uses this information to detect whether the currently installed version is compatible to a projects configuration.
 
-````yaml
+```yaml
 specVersion: "2.6"
 [...]
-````
+```
 
 To use new features, a project might need to update the `specVersion` property.
 

--- a/docs/pages/TasksAndProcessors.md
+++ b/docs/pages/TasksAndProcessors.md
@@ -6,103 +6,210 @@ This sample demonstrates how standard processors and tasks can be written.
 
 ### Task
 
-```js
-import minifier from "../processors/minifier.js";; // Require to processor
+=== "CommonJS"
 
-export default async function({workspace, taskUtil, options: {pattern, omitSourceMapResources = false}}) {
-    // "workspace" is a DuplexCollection that represents the projects source directory (e.g. /webapp)
-    // When calling the standard APIs "byGlob" and "byPath" it will also return resources that have just been created by other tasks.
-    // The minify task intents to only process those resources present in the project source directory therefore it calls the API "byGlobSource".
+    ```js
+    module.exports = async function({workspace, taskUtil, options: {pattern, omitSourceMapResources = false}}) {
+        const {default: minifier} = await import("../processors/minifier.js"); // Require to processor
 
-    // Collect all resources that shall be uglified. The caller provides the necessary GLOB pattern.
-    const resources = await workspace.byGlob(pattern); 
+        // "workspace" is a DuplexCollection that represents the projects source directory (e.g. /webapp)
+        // When calling the standard APIs "byGlob" and "byPath" it will also return resources that have just been created by other tasks.
+        // The minify task intents to only process those resources present in the project source directory therefore it calls the API "byGlobSource".
 
-    // Receive list of changed and newly created resources
-    const processedResources = await minifier({  // Call to the processor
-        resources, // Pass all resources
-        options: {
-            addSourceMappingUrl: !omitSourceMapResources
-        }
-    }); 
+        // Collect all resources that shall be uglified. The caller provides the necessary GLOB pattern.
+        const resources = await workspace.byGlob(pattern); 
 
-    // Write them back into the workspace DuplexCollection
-    return Promise.all(processedResources.map(async ({resource, dbgResource, sourceMapResource}) => {
-        if (taskUtil) {
-            taskUtil.setTag(resource, taskUtil.STANDARD_TAGS.HasDebugVariant);
-            taskUtil.setTag(dbgResource, taskUtil.STANDARD_TAGS.IsDebugVariant);
-            taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.HasDebugVariant);
-            if (omitSourceMapResources) {
-                taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.OmitFromBuildResult);
+        // Receive list of changed and newly created resources
+        const processedResources = await minifier({  // Call to the processor
+            resources, // Pass all resources
+            options: {
+                addSourceMappingUrl: !omitSourceMapResources
             }
-        }
-        return Promise.all([
-            workspace.write(resource),
-            workspace.write(dbgResource),
-            workspace.write(sourceMapResource)
-        ]);
+        }); 
+
+        // Write them back into the workspace DuplexCollection
+        return Promise.all(processedResources.map(async ({resource, dbgResource, sourceMapResource}) => {
+            if (taskUtil) {
+                taskUtil.setTag(resource, taskUtil.STANDARD_TAGS.HasDebugVariant);
+                taskUtil.setTag(dbgResource, taskUtil.STANDARD_TAGS.IsDebugVariant);
+                taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.HasDebugVariant);
+                if (omitSourceMapResources) {
+                    taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.OmitFromBuildResult);
+                }
+            }
+            return Promise.all([
+                workspace.write(resource),
+                workspace.write(dbgResource),
+                workspace.write(sourceMapResource)
+            ]);
+        };
     };
-};
-```
+    ```
+
+=== "ESM"
+
+    ```js
+    import minifier from "../processors/minifier.js"; // Require to processor
+
+    export default async function({workspace, taskUtil, options: {pattern, omitSourceMapResources = false}}) {
+        // "workspace" is a DuplexCollection that represents the projects source directory (e.g. /webapp)
+        // When calling the standard APIs "byGlob" and "byPath" it will also return resources that have just been created by other tasks.
+        // The minify task intents to only process those resources present in the project source directory therefore it calls the API "byGlobSource".
+
+        // Collect all resources that shall be uglified. The caller provides the necessary GLOB pattern.
+        const resources = await workspace.byGlob(pattern); 
+
+        // Receive list of changed and newly created resources
+        const processedResources = await minifier({  // Call to the processor
+            resources, // Pass all resources
+            options: {
+                addSourceMappingUrl: !omitSourceMapResources
+            }
+        }); 
+
+        // Write them back into the workspace DuplexCollection
+        return Promise.all(processedResources.map(async ({resource, dbgResource, sourceMapResource}) => {
+            if (taskUtil) {
+                taskUtil.setTag(resource, taskUtil.STANDARD_TAGS.HasDebugVariant);
+                taskUtil.setTag(dbgResource, taskUtil.STANDARD_TAGS.IsDebugVariant);
+                taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.HasDebugVariant);
+                if (omitSourceMapResources) {
+                    taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.OmitFromBuildResult);
+                }
+            }
+            return Promise.all([
+                workspace.write(resource),
+                workspace.write(dbgResource),
+                workspace.write(sourceMapResource)
+            ]);
+        };
+    };
+    ```
 
 ### Processor
 
-```js
-import posixPath from "node:path/posix";
-import {minify} from "terser";
-import Resource from "@ui5/fs/Resource";
-const copyrightCommentsAndBundleCommentPattern = /copyright|\(c\)(?:[0-9]+|\s+[0-9A-Za-z])|released under|license|\u00a9|^@ui5-bundle-raw-include |^@ui5-bundle /i;
-const debugFileRegex = /((?:\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)$/;
+=== "CommonJS"
 
-export default async function({resources, options: {addSourceMappingUrl = true} = {}}) {              
-    // Receive list of resources to uglify
-    return Promise.all(resources.map(async (resource) => {
-        const dbgPath = resource.getPath().replace(debugFileRegex, "-dbg$1");
-        const dbgResource = await resource.clone();
-        dbgResource.setPath(dbgPath);
+    ```js
+    const posixPath = require("node:path/posix");
+    const {minify} = require("terser");
+    const copyrightCommentsAndBundleCommentPattern = /copyright|\(c\)(?:[0-9]+|\s+[0-9A-Za-z])|released under|license|\u00a9|^@ui5-bundle-raw-include |^@ui5-bundle /i;
+    const debugFileRegex = /((?:\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)$/;
 
-        const filename = posixPath.basename(resource.getPath());
-        // Get resource content as string
-        const code = await resource.getString();
-        try {
-            const sourceMapOptions = {
-                filename
-            };
-            if (addSourceMappingUrl) {
-                sourceMapOptions.url = filename + ".map";
+    module.exports = async function({resources, options: {addSourceMappingUrl = true} = {}}) {   
+        const {default: Resource} = await import("@ui5/fs/Resource");           
+        // Receive list of resources to uglify
+        return Promise.all(resources.map(async (resource) => {
+            const dbgPath = resource.getPath().replace(debugFileRegex, "-dbg$1");
+            const dbgResource = await resource.clone();
+            dbgResource.setPath(dbgPath);
+
+            const filename = posixPath.basename(resource.getPath());
+            // Get resource content as string
+            const code = await resource.getString();
+            try {
+                const sourceMapOptions = {
+                    filename
+                };
+                if (addSourceMappingUrl) {
+                    sourceMapOptions.url = filename + ".map";
+                }
+                const dbgFilename = posixPath.basename(dbgPath);
+                // Call to the minify module
+                const result = await minify({
+                    // Use debug-name since this will be referenced in the source map "sources"
+                    [dbgFilename]: code
+                }, {
+                    output: {
+                        comments: copyrightCommentsAndBundleCommentPattern,
+                        wrap_func_args: false
+                    },
+                    compress: false,
+                    mangle: {
+                        reserved: [
+                            "jQuery",
+                            "jquery",
+                            "sap",
+                        ]
+                    },
+                    sourceMap: sourceMapOptions
+                });
+                resource.setString(result.code);
+                const sourceMapResource = new Resource({
+                    path: resource.getPath() + ".map",
+                    string: result.map
+                });
+                return {resource, dbgResource, sourceMapResource};
+            } catch (err) {
+                // Note: err.filename contains the debug-name
+                throw new Error(
+                    `Minification failed with error: ${err.message} in file ${filename} ` +
+                    `(line ${err.line}, col ${err.col}, pos ${err.pos})`);
             }
-            const dbgFilename = posixPath.basename(dbgPath);
-              // Call to the minify module
-            const result = await minify({
-                // Use debug-name since this will be referenced in the source map "sources"
-                [dbgFilename]: code
-            }, {
-                output: {
-                    comments: copyrightCommentsAndBundleCommentPattern,
-                    wrap_func_args: false
-                },
-                compress: false,
-                mangle: {
-                    reserved: [
-                        "jQuery",
-                        "jquery",
-                        "sap",
-                    ]
-                },
-                sourceMap: sourceMapOptions
-            });
-            resource.setString(result.code);
-            const sourceMapResource = new Resource({
-                path: resource.getPath() + ".map",
-                string: result.map
-            });
-            return {resource, dbgResource, sourceMapResource};
-        } catch (err) {
-            // Note: err.filename contains the debug-name
-            throw new Error(
-                `Minification failed with error: ${err.message} in file ${filename} ` +
-                `(line ${err.line}, col ${err.col}, pos ${err.pos})`);
-        }
-    }));
-}
+        }));
+    };
 
-```
+    ```
+
+=== "ESM"
+
+    ```js
+    import posixPath from "node:path/posix";
+    import {minify} from "terser";
+    import Resource from "@ui5/fs/Resource";
+    const copyrightCommentsAndBundleCommentPattern = /copyright|\(c\)(?:[0-9]+|\s+[0-9A-Za-z])|released under|license|\u00a9|^@ui5-bundle-raw-include |^@ui5-bundle /i;
+    const debugFileRegex = /((?:\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)$/;
+
+    export default async function({resources, options: {addSourceMappingUrl = true} = {}}) {              
+        // Receive list of resources to uglify
+        return Promise.all(resources.map(async (resource) => {
+            const dbgPath = resource.getPath().replace(debugFileRegex, "-dbg$1");
+            const dbgResource = await resource.clone();
+            dbgResource.setPath(dbgPath);
+
+            const filename = posixPath.basename(resource.getPath());
+            // Get resource content as string
+            const code = await resource.getString();
+            try {
+                const sourceMapOptions = {
+                    filename
+                };
+                if (addSourceMappingUrl) {
+                    sourceMapOptions.url = filename + ".map";
+                }
+                const dbgFilename = posixPath.basename(dbgPath);
+                // Call to the minify module
+                const result = await minify({
+                    // Use debug-name since this will be referenced in the source map "sources"
+                    [dbgFilename]: code
+                }, {
+                    output: {
+                        comments: copyrightCommentsAndBundleCommentPattern,
+                        wrap_func_args: false
+                    },
+                    compress: false,
+                    mangle: {
+                        reserved: [
+                            "jQuery",
+                            "jquery",
+                            "sap",
+                        ]
+                    },
+                    sourceMap: sourceMapOptions
+                });
+                resource.setString(result.code);
+                const sourceMapResource = new Resource({
+                    path: resource.getPath() + ".map",
+                    string: result.map
+                });
+                return {resource, dbgResource, sourceMapResource};
+            } catch (err) {
+                // Note: err.filename contains the debug-name
+                throw new Error(
+                    `Minification failed with error: ${err.message} in file ${filename} ` +
+                    `(line ${err.line}, col ${err.col}, pos ${err.pos})`);
+            }
+        }));
+    }
+
+    ```

--- a/docs/pages/TasksAndProcessors.md
+++ b/docs/pages/TasksAndProcessors.md
@@ -6,46 +6,6 @@ This sample demonstrates how standard processors and tasks can be written.
 
 ### Task
 
-=== "CommonJS"
-
-    ```js
-    module.exports = async function({workspace, taskUtil, options: {pattern, omitSourceMapResources = false}}) {
-        const {default: minifier} = await import("../processors/minifier.js"); // Require to processor
-
-        // "workspace" is a DuplexCollection that represents the projects source directory (e.g. /webapp)
-        // When calling the standard APIs "byGlob" and "byPath" it will also return resources that have just been created by other tasks.
-        // The minify task intents to only process those resources present in the project source directory therefore it calls the API "byGlobSource".
-
-        // Collect all resources that shall be uglified. The caller provides the necessary GLOB pattern.
-        const resources = await workspace.byGlob(pattern); 
-
-        // Receive list of changed and newly created resources
-        const processedResources = await minifier({  // Call to the processor
-            resources, // Pass all resources
-            options: {
-                addSourceMappingUrl: !omitSourceMapResources
-            }
-        }); 
-
-        // Write them back into the workspace DuplexCollection
-        return Promise.all(processedResources.map(async ({resource, dbgResource, sourceMapResource}) => {
-            if (taskUtil) {
-                taskUtil.setTag(resource, taskUtil.STANDARD_TAGS.HasDebugVariant);
-                taskUtil.setTag(dbgResource, taskUtil.STANDARD_TAGS.IsDebugVariant);
-                taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.HasDebugVariant);
-                if (omitSourceMapResources) {
-                    taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.OmitFromBuildResult);
-                }
-            }
-            return Promise.all([
-                workspace.write(resource),
-                workspace.write(dbgResource),
-                workspace.write(sourceMapResource)
-            ]);
-        };
-    };
-    ```
-
 === "ESM"
 
     ```js
@@ -86,70 +46,47 @@ This sample demonstrates how standard processors and tasks can be written.
     };
     ```
 
-### Processor
-
 === "CommonJS"
 
     ```js
-    const posixPath = require("node:path/posix");
-    const {minify} = require("terser");
-    const copyrightCommentsAndBundleCommentPattern = /copyright|\(c\)(?:[0-9]+|\s+[0-9A-Za-z])|released under|license|\u00a9|^@ui5-bundle-raw-include |^@ui5-bundle /i;
-    const debugFileRegex = /((?:\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)$/;
+    module.exports = async function({workspace, taskUtil, options: {pattern, omitSourceMapResources = false}}) {
+        const {default: minifier} = await import("../processors/minifier.js"); // Require to processor
 
-    module.exports = async function({resources, options: {addSourceMappingUrl = true} = {}}) {   
-        const {default: Resource} = await import("@ui5/fs/Resource");           
-        // Receive list of resources to uglify
-        return Promise.all(resources.map(async (resource) => {
-            const dbgPath = resource.getPath().replace(debugFileRegex, "-dbg$1");
-            const dbgResource = await resource.clone();
-            dbgResource.setPath(dbgPath);
+        // "workspace" is a DuplexCollection that represents the projects source directory (e.g. /webapp)
+        // When calling the standard APIs "byGlob" and "byPath" it will also return resources that have just been created by other tasks.
+        // The minify task intents to only process those resources present in the project source directory therefore it calls the API "byGlobSource".
 
-            const filename = posixPath.basename(resource.getPath());
-            // Get resource content as string
-            const code = await resource.getString();
-            try {
-                const sourceMapOptions = {
-                    filename
-                };
-                if (addSourceMappingUrl) {
-                    sourceMapOptions.url = filename + ".map";
-                }
-                const dbgFilename = posixPath.basename(dbgPath);
-                // Call to the minify module
-                const result = await minify({
-                    // Use debug-name since this will be referenced in the source map "sources"
-                    [dbgFilename]: code
-                }, {
-                    output: {
-                        comments: copyrightCommentsAndBundleCommentPattern,
-                        wrap_func_args: false
-                    },
-                    compress: false,
-                    mangle: {
-                        reserved: [
-                            "jQuery",
-                            "jquery",
-                            "sap",
-                        ]
-                    },
-                    sourceMap: sourceMapOptions
-                });
-                resource.setString(result.code);
-                const sourceMapResource = new Resource({
-                    path: resource.getPath() + ".map",
-                    string: result.map
-                });
-                return {resource, dbgResource, sourceMapResource};
-            } catch (err) {
-                // Note: err.filename contains the debug-name
-                throw new Error(
-                    `Minification failed with error: ${err.message} in file ${filename} ` +
-                    `(line ${err.line}, col ${err.col}, pos ${err.pos})`);
+        // Collect all resources that shall be uglified. The caller provides the necessary GLOB pattern.
+        const resources = await workspace.byGlob(pattern); 
+
+        // Receive list of changed and newly created resources
+        const processedResources = await minifier({  // Call to the processor
+            resources, // Pass all resources
+            options: {
+                addSourceMappingUrl: !omitSourceMapResources
             }
-        }));
-    };
+        }); 
 
+        // Write them back into the workspace DuplexCollection
+        return Promise.all(processedResources.map(async ({resource, dbgResource, sourceMapResource}) => {
+            if (taskUtil) {
+                taskUtil.setTag(resource, taskUtil.STANDARD_TAGS.HasDebugVariant);
+                taskUtil.setTag(dbgResource, taskUtil.STANDARD_TAGS.IsDebugVariant);
+                taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.HasDebugVariant);
+                if (omitSourceMapResources) {
+                    taskUtil.setTag(sourceMapResource, taskUtil.STANDARD_TAGS.OmitFromBuildResult);
+                }
+            }
+            return Promise.all([
+                workspace.write(resource),
+                workspace.write(dbgResource),
+                workspace.write(sourceMapResource)
+            ]);
+        };
+    };
     ```
+
+### Processor
 
 === "ESM"
 
@@ -211,5 +148,66 @@ This sample demonstrates how standard processors and tasks can be written.
             }
         }));
     }
+    ```
 
+=== "CommonJS"
+
+    ```js
+    const posixPath = require("node:path/posix");
+    const {minify} = require("terser");
+    const copyrightCommentsAndBundleCommentPattern = /copyright|\(c\)(?:[0-9]+|\s+[0-9A-Za-z])|released under|license|\u00a9|^@ui5-bundle-raw-include |^@ui5-bundle /i;
+    const debugFileRegex = /((?:\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)$/;
+
+    module.exports = async function({resources, options: {addSourceMappingUrl = true} = {}}) {   
+        const {default: Resource} = await import("@ui5/fs/Resource");           
+        // Receive list of resources to uglify
+        return Promise.all(resources.map(async (resource) => {
+            const dbgPath = resource.getPath().replace(debugFileRegex, "-dbg$1");
+            const dbgResource = await resource.clone();
+            dbgResource.setPath(dbgPath);
+
+            const filename = posixPath.basename(resource.getPath());
+            // Get resource content as string
+            const code = await resource.getString();
+            try {
+                const sourceMapOptions = {
+                    filename
+                };
+                if (addSourceMappingUrl) {
+                    sourceMapOptions.url = filename + ".map";
+                }
+                const dbgFilename = posixPath.basename(dbgPath);
+                // Call to the minify module
+                const result = await minify({
+                    // Use debug-name since this will be referenced in the source map "sources"
+                    [dbgFilename]: code
+                }, {
+                    output: {
+                        comments: copyrightCommentsAndBundleCommentPattern,
+                        wrap_func_args: false
+                    },
+                    compress: false,
+                    mangle: {
+                        reserved: [
+                            "jQuery",
+                            "jquery",
+                            "sap",
+                        ]
+                    },
+                    sourceMap: sourceMapOptions
+                });
+                resource.setString(result.code);
+                const sourceMapResource = new Resource({
+                    path: resource.getPath() + ".map",
+                    string: result.map
+                });
+                return {resource, dbgResource, sourceMapResource};
+            } catch (err) {
+                // Note: err.filename contains the debug-name
+                throw new Error(
+                    `Minification failed with error: ${err.message} in file ${filename} ` +
+                    `(line ${err.line}, col ${err.col}, pos ${err.pos})`);
+            }
+        }));
+    };
     ```

--- a/docs/pages/extensibility/CustomServerMiddleware.md
+++ b/docs/pages/extensibility/CustomServerMiddleware.md
@@ -89,44 +89,6 @@ middleware:
 
 A custom middleware implementation needs to return a function with the following signature:
 
-=== "CommonJS"
-
-    ```js linenums="1"
-    /**
-     * Custom UI5 Server middleware API
-     * 
-     * @param {object} parameters Parameters
-     * @param {@ui5/logger/StandardLogger} parameters.log
-     *      Logger instance for use in the custom middleware.
-     *      This parameter is only provided to custom middleware
-     *      extensions defining Specification Version 3.0 and later.
-     * @param {@ui5/server.middleware.MiddlewareUtil} parameters.middlewareUtil
-     *      Specification version-dependent interface to a
-     *      MiddlewareUtil instance. See the corresponding API reference for details:
-     *      https://sap.github.io/ui5-tooling/v3/api/@ui5_server_middleware_MiddlewareUtil.html
-     * @param {object} parameters.options Options
-     * @param {string} parameters.options.configuration
-     *      Custom middleware configuration, as defined in the project's ui5.yaml
-     * @param {string} parameters.options.middlewareName
-     *      Name of the custom middleware.
-     *      This parameter is only provided to custom middleware extensions
-     *      defining Specification Version 3.0 and later
-     * @param {object} parameters.resources Readers for accessing resources
-     * @param {module:@ui5/fs.AbstractReader} parameters.resources.all
-     *      Reader to access resources of the root project and its dependencies
-     * @param {module:@ui5/fs.AbstractReader} parameters.resources.rootProject
-     *      Reader to access resources of the root project
-     * @param {module:@ui5/fs.AbstractReader} parameters.resources.dependencies
-     *      Reader to access resources of the project's dependencies.
-     * @returns {function} Middleware function to use
-     */
-    module.exports = function({log, middlewareUtil, options, resources}) {
-        return async function (req, res, next) {
-            // [...]
-        }
-    };
-    ```
-
 === "ESM"
 
     ```js linenums="1"
@@ -165,40 +127,45 @@ A custom middleware implementation needs to return a function with the following
     };
     ```
 
-### Example: lib/middleware/markdownHandler.(m)js
-
 === "CommonJS"
 
     ```js linenums="1"
-    module.exports = async function({log, middlewareUtil, options, resources}) {
-        const MarkdownIt = require("markdown-it");
-        const md = new MarkdownIt();
-        return function (req, res, next) {
-            if (!req.path || !req.path.endsWith(".html")) {
-                // Do not handle non-HTML requests
-                next();
-                return;
-            }
-            // Try to read a corresponding markdown file
-            resources.rootProject.byPath(req.path.replace(".html", ".md")).then(async (resource) => {
-                if (!resource) {
-                    // No file found, hand over to next middleware
-                    next();
-                    return;
-                }
-                log.info(`Rendering markdown for ${resource.getPath()}`);
-                const markdown = await resource.getBuffer();
-                // Generate HTML from markdown string
-                const html = md.render(markdown.toString());
-                res.type('.html');
-                res.end(html);
-            }).catch((err) => {
-                next(err);
-            });
+    /**
+     * Custom UI5 Server middleware API
+     * 
+     * @param {object} parameters Parameters
+     * @param {@ui5/logger/StandardLogger} parameters.log
+     *      Logger instance for use in the custom middleware.
+     *      This parameter is only provided to custom middleware
+     *      extensions defining Specification Version 3.0 and later.
+     * @param {@ui5/server.middleware.MiddlewareUtil} parameters.middlewareUtil
+     *      Specification version-dependent interface to a
+     *      MiddlewareUtil instance. See the corresponding API reference for details:
+     *      https://sap.github.io/ui5-tooling/v3/api/@ui5_server_middleware_MiddlewareUtil.html
+     * @param {object} parameters.options Options
+     * @param {string} parameters.options.configuration
+     *      Custom middleware configuration, as defined in the project's ui5.yaml
+     * @param {string} parameters.options.middlewareName
+     *      Name of the custom middleware.
+     *      This parameter is only provided to custom middleware extensions
+     *      defining Specification Version 3.0 and later
+     * @param {object} parameters.resources Readers for accessing resources
+     * @param {module:@ui5/fs.AbstractReader} parameters.resources.all
+     *      Reader to access resources of the root project and its dependencies
+     * @param {module:@ui5/fs.AbstractReader} parameters.resources.rootProject
+     *      Reader to access resources of the root project
+     * @param {module:@ui5/fs.AbstractReader} parameters.resources.dependencies
+     *      Reader to access resources of the project's dependencies.
+     * @returns {function} Middleware function to use
+     */
+    module.exports = function({log, middlewareUtil, options, resources}) {
+        return async function (req, res, next) {
+            // [...]
         }
     };
     ```
-    Live demo of the above example: [openui5-sample-app with custom middleware](https://github.com/SAP/openui5-sample-app/tree/demo-server-middleware-extensibility-v3)
+
+### Example: lib/middleware/markdownHandler.(m)js
 
 === "ESM"
 
@@ -233,6 +200,39 @@ A custom middleware implementation needs to return a function with the following
     };
     ```
     Live demo of the above example: [openui5-sample-app with custom middleware](https://github.com/SAP/openui5-sample-app/tree/demo-server-middleware-extensibility-v3-esm)
+
+=== "CommonJS"
+
+    ```js linenums="1"
+    module.exports = async function({log, middlewareUtil, options, resources}) {
+        const MarkdownIt = require("markdown-it");
+        const md = new MarkdownIt();
+        return function (req, res, next) {
+            if (!req.path || !req.path.endsWith(".html")) {
+                // Do not handle non-HTML requests
+                next();
+                return;
+            }
+            // Try to read a corresponding markdown file
+            resources.rootProject.byPath(req.path.replace(".html", ".md")).then(async (resource) => {
+                if (!resource) {
+                    // No file found, hand over to next middleware
+                    next();
+                    return;
+                }
+                log.info(`Rendering markdown for ${resource.getPath()}`);
+                const markdown = await resource.getBuffer();
+                // Generate HTML from markdown string
+                const html = md.render(markdown.toString());
+                res.type('.html');
+                res.end(html);
+            }).catch((err) => {
+                next(err);
+            });
+        }
+    };
+    ```
+    Live demo of the above example: [openui5-sample-app with custom middleware](https://github.com/SAP/openui5-sample-app/tree/demo-server-middleware-extensibility-v3)
 
 ## Helper Class `MiddlewareUtil`
 

--- a/docs/pages/extensibility/CustomServerMiddleware.md
+++ b/docs/pages/extensibility/CustomServerMiddleware.md
@@ -7,11 +7,13 @@ The UI5 community already created many custom middleware packages which you can 
 Please note that custom middleware packages from third parties can not only modify how your project is served but also execute arbitrary code on your system. In fact, this is the case for all npm packages you install. Always act with the according care and follow best practices.
 
 ## Configuration
+
 In a projects `ui5.yaml` file, you can define additional server middleware modules that will be executed when the request is received by the server. This configuration exclusively affects the server started in this project. Custom middleware configurations defined in any dependencies are ignored.
 
 A middleware may be executed before or after any other middleware. This can either be a [standard middleware](../Server.md#standard-middleware) or another custom middleware.
 
 ### Example: Basic configuration
+
 ```yaml
 specVersion: "3.0"
 type: application
@@ -33,9 +35,11 @@ There can be optional configuration parameters which are passed directly to the 
 An optional mountPath for which the middleware function is invoked can be provided. It will be passed to the `app.use` call (see [express API reference](https://expressjs.com/en/4x/api.html#app.use)).
 
 ### Execution order
+
 Note that middleware configurations are applied in the order they are defined. When referencing another custom middleware, it has to be defined *before* that reference.
 
 ## Custom Middleware Extension
+
 A custom middleware extension consists of a `ui5.yaml` and a [custom middleware implementation](#custom-middleware-implementation). It can be a standalone module or part of an existing UI5 project.
 
 ### Example: ui5.yaml
@@ -82,7 +86,9 @@ middleware:
 ````
 
 ## Custom Middleware Implementation
+
 A custom middleware implementation needs to return a function with the following signature:
+
 ````javascript
 /**
  * Custom UI5 Server middleware API
@@ -112,19 +118,20 @@ A custom middleware implementation needs to return a function with the following
  *      defining Specification Version 3.0 and later.
  * @returns {function} Middleware function to use
  */
-module.exports = function({resources, middlewareUtil, log, options}) {
-    return function (req, res, next) {
+export default function({resources, middlewareUtil, log, options}) {
+    return async function (req, res, next) {
         // [...]
     }
 };
 ````
 
 ### Example: lib/middleware/markdownHandler.js
+
 ````javascript
 // Custom middleware implementation
 
-module.exports = function({resources, middlewareUtil, log, options}) {
-    const MarkdownIt = require('markdown-it');
+export default async function({resources, middlewareUtil, log, options}) {
+    const MarkdownIt = await import('markdown-it');
     const md = new MarkdownIt();
     return function (req, res, next) {
         if (!req.path.endsWith(".html")) {

--- a/docs/pages/extensibility/CustomServerMiddleware.md
+++ b/docs/pages/extensibility/CustomServerMiddleware.md
@@ -174,7 +174,7 @@ A custom middleware implementation needs to return a function with the following
         const MarkdownIt = require("markdown-it");
         const md = new MarkdownIt();
         return function (req, res, next) {
-            if (!req.path.endsWith(".html")) {
+            if (!req.path || !req.path.endsWith(".html")) {
                 // Do not handle non-HTML requests
                 next();
                 return;
@@ -198,7 +198,7 @@ A custom middleware implementation needs to return a function with the following
         }
     };
     ```
-    Live demo of the above example: https://github.com/SAP/openui5-sample-app/tree/demo-server-middleware-extensibility-v3
+    Live demo of the above example: [openui5-sample-app with custom middleware](https://github.com/SAP/openui5-sample-app/tree/demo-server-middleware-extensibility-v3)
 
 === "ESM"
 
@@ -208,7 +208,7 @@ A custom middleware implementation needs to return a function with the following
     export default async function({log, middlewareUtil, options, resources}) {
         const md = new MarkdownIt();
         return function (req, res, next) {
-            if (!req.path.endsWith(".html")) {
+            if (!req.path || !req.path.endsWith(".html")) {
                 // Do not handle non-HTML requests
                 next();
                 return;
@@ -232,7 +232,7 @@ A custom middleware implementation needs to return a function with the following
         }
     };
     ```
-    Live demo of the above example: https://github.com/SAP/openui5-sample-app/tree/demo-server-middleware-extensibility-v3-esm
+    Live demo of the above example: [openui5-sample-app with custom middleware](https://github.com/SAP/openui5-sample-app/tree/demo-server-middleware-extensibility-v3-esm)
 
 ## Helper Class `MiddlewareUtil`
 

--- a/docs/pages/extensibility/CustomTasks.md
+++ b/docs/pages/extensibility/CustomTasks.md
@@ -106,46 +106,6 @@ task:
 
 A custom task implementation needs to return a function with the following signature:
 
-=== "CommonJS"
-
-    ```js linenums="1"
-    /**
-     * Custom task API
-     *
-     * @param {object} parameters
-     * 
-     * @param {module:@ui5/fs.AbstractReader} parameters.dependencies
-     *      Reader to access resources of the project's dependencies
-     * @param {@ui5/logger/StandardLogger} parameters.log
-     *      Logger instance for use in the custom task.
-     *      This parameter is only available to custom task extensions
-     *      defining Specification Version 3.0 and later.
-     * @param {object} parameters.options Options
-     * @param {string} parameters.options.projectName
-     *      Name of the project currently being built
-     * @param {string} parameters.options.projectNamespace
-     *      Namespace of the project currently being built
-     * @param {string} parameters.options.configuration
-     *      Custom task configuration, as defined in the project's ui5.yaml
-     * @param {string} parameters.options.taskName
-     *      Name of the custom task.
-     *      This parameter is only provided to custom task extensions
-     *      defining Specification Version 3.0 and later.
-     * @param {@ui5/builder.tasks.TaskUtil} parameters.taskUtil
-     *      Specification Version-dependent interface to a TaskUtil instance.
-     *      See the corresponding API reference for details:
-     *      https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html
-     * @param {module:@ui5/fs.DuplexCollection} parameters.workspace
-     *      Reader/Writer to access and modify resources of the
-     *      project currently being built
-     * @returns {Promise<undefined>}
-     *      Promise resolving once the task has finished
-     */
-    module.exports = async function({dependencies, log, options, taskUtil, workspace}) {
-        // [...]
-    };
-    ```
-
 === "ESM"
 
     ```js linenums="1"
@@ -186,6 +146,46 @@ A custom task implementation needs to return a function with the following signa
     };
     ```
 
+=== "CommonJS"
+
+    ```js linenums="1"
+    /**
+     * Custom task API
+     *
+     * @param {object} parameters
+     * 
+     * @param {module:@ui5/fs.AbstractReader} parameters.dependencies
+     *      Reader to access resources of the project's dependencies
+     * @param {@ui5/logger/StandardLogger} parameters.log
+     *      Logger instance for use in the custom task.
+     *      This parameter is only available to custom task extensions
+     *      defining Specification Version 3.0 and later.
+     * @param {object} parameters.options Options
+     * @param {string} parameters.options.projectName
+     *      Name of the project currently being built
+     * @param {string} parameters.options.projectNamespace
+     *      Namespace of the project currently being built
+     * @param {string} parameters.options.configuration
+     *      Custom task configuration, as defined in the project's ui5.yaml
+     * @param {string} parameters.options.taskName
+     *      Name of the custom task.
+     *      This parameter is only provided to custom task extensions
+     *      defining Specification Version 3.0 and later.
+     * @param {@ui5/builder.tasks.TaskUtil} parameters.taskUtil
+     *      Specification Version-dependent interface to a TaskUtil instance.
+     *      See the corresponding API reference for details:
+     *      https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html
+     * @param {module:@ui5/fs.DuplexCollection} parameters.workspace
+     *      Reader/Writer to access and modify resources of the
+     *      project currently being built
+     * @returns {Promise<undefined>}
+     *      Promise resolving once the task has finished
+     */
+    module.exports = async function({dependencies, log, options, taskUtil, workspace}) {
+        // [...]
+    };
+    ```
+
 ### Required Dependencies
 
 !!! info
@@ -202,47 +202,6 @@ If this callback is not provided, UI5 Tooling will make an assumption as to whet
 
 
 *For more details, see also [RFC 0012 UI5 Tooling Extension API v3](https://github.com/SAP/ui5-tooling/blob/rfc-ui5-tooling-extension-api-v3/rfcs/0012-UI5-Tooling-Extension-API-3.md#3-tasks-requiring-dependencies)*
-
-=== "CommonJS"
-
-    ```js linenums="1"
-    /**
-     * Callback function to define the list of required dependencies
-     *
-     * @param {object} parameters
-     * @param {Set} parameters.availableDependencies
-     *      Set containing the names of all direct dependencies of
-     *      the project currently being built.
-     * @param {function} parameters.getDependencies
-     *      Identical to TaskUtil#getDependencies
-     *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
-     *      Creates a list of names of all direct dependencies
-     *      of a given project.
-     * @param {function} parameters.getProject
-     *      Identical to TaskUtil#getProject
-     *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
-     *      Retrieves a Project-instance for a given project name.
-     * @params {object} parameters.options
-     *      Identical to the options given to the standard task function.
-     * @returns {Promise<Set>}
-     *      Promise resolving with a Set containing all dependencies
-     *      that should be made available to the task.
-     *      UI5 Tooling will ensure that those dependencies have been
-     *      built before executing the task.
-     */
-    module.exports = async function determineRequiredDependencies({availableDependencies, getDependencies, getProject, options}) {
-        // "availableDependencies" could look like this: Set(3) { "sap.ui.core", "sap.m", "my.lib" }
-
-        // Reduce list of required dependencies: Do not require any UI5 framework projects
-        availableDependencies.forEach((depName) => {
-            if (getProject(depName).isFrameworkProject()) {
-                availableDependencies.delete(depName)
-            }
-        });
-        // => Only resources of project "my.lib" will be available to the task
-        return availableDependencies;
-    }
-    ```
 
 === "ESM"
 
@@ -285,42 +244,52 @@ If this callback is not provided, UI5 Tooling will make an assumption as to whet
     }
     ```
 
+=== "CommonJS"
+
+    ```js linenums="1"
+    /**
+     * Callback function to define the list of required dependencies
+     *
+     * @param {object} parameters
+     * @param {Set} parameters.availableDependencies
+     *      Set containing the names of all direct dependencies of
+     *      the project currently being built.
+     * @param {function} parameters.getDependencies
+     *      Identical to TaskUtil#getDependencies
+     *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
+     *      Creates a list of names of all direct dependencies
+     *      of a given project.
+     * @param {function} parameters.getProject
+     *      Identical to TaskUtil#getProject
+     *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
+     *      Retrieves a Project-instance for a given project name.
+     * @params {object} parameters.options
+     *      Identical to the options given to the standard task function.
+     * @returns {Promise<Set>}
+     *      Promise resolving with a Set containing all dependencies
+     *      that should be made available to the task.
+     *      UI5 Tooling will ensure that those dependencies have been
+     *      built before executing the task.
+     */
+    module.exports = async function determineRequiredDependencies({availableDependencies, getDependencies, getProject, options}) {
+        // "availableDependencies" could look like this: Set(3) { "sap.ui.core", "sap.m", "my.lib" }
+
+        // Reduce list of required dependencies: Do not require any UI5 framework projects
+        availableDependencies.forEach((depName) => {
+            if (getProject(depName).isFrameworkProject()) {
+                availableDependencies.delete(depName)
+            }
+        });
+        // => Only resources of project "my.lib" will be available to the task
+        return availableDependencies;
+    }
+    ```
+
 ### Examples
 
 The following code snippets show examples for custom task implementations.
 
 ### Example: lib/tasks/renderMarkdownFiles.js
-
-=== "CommonJS"
-
-    ```js linenums="1"
-    const path = require("node:path");
-    const renderMarkdown = require("./renderMarkdown.js");
-
-    /*
-    * Render all .md (Markdown) files in the project to HTML
-    */
-    module.exports = async function({dependencies, log, options, taskUtil, workspace}) {
-        const {createResource} = taskUtil.resourceFactory;
-        const textResources = await workspace.byGlob("**/*.md");
-        await Promise.all(textResources.map(async (resource) => {
-            const markdownResourcePath = resource.getPath();
-
-            log.info(`Rendering markdown file ${markdownResourcePath}...`);
-            const htmlString = await renderMarkdown(await resource.getString(), options.configuration);
-
-            // Note: @ui5/fs virtual paths are always (on *all* platforms) POSIX. Therefore using path.posix here
-            const newResourceName = path.posix.basename(markdownResourcePath, ".md") + ".html";
-            const newResourcePath = path.posix.join(path.posix.dirname(markdownResourcePath), newResourceName);
-
-            const markdownResource = createResource({
-                path: newResourcePath,
-                string: htmlString
-            });
-            await workspace.write(markdownResource);
-        }));
-    };
-    ```
 
 === "ESM"
 
@@ -353,6 +322,37 @@ The following code snippets show examples for custom task implementations.
     };
     ```
 
+=== "CommonJS"
+
+    ```js linenums="1"
+    const path = require("node:path");
+    const renderMarkdown = require("./renderMarkdown.js");
+
+    /*
+    * Render all .md (Markdown) files in the project to HTML
+    */
+    module.exports = async function({dependencies, log, options, taskUtil, workspace}) {
+        const {createResource} = taskUtil.resourceFactory;
+        const textResources = await workspace.byGlob("**/*.md");
+        await Promise.all(textResources.map(async (resource) => {
+            const markdownResourcePath = resource.getPath();
+
+            log.info(`Rendering markdown file ${markdownResourcePath}...`);
+            const htmlString = await renderMarkdown(await resource.getString(), options.configuration);
+
+            // Note: @ui5/fs virtual paths are always (on *all* platforms) POSIX. Therefore using path.posix here
+            const newResourceName = path.posix.basename(markdownResourcePath, ".md") + ".html";
+            const newResourcePath = path.posix.join(path.posix.dirname(markdownResourcePath), newResourceName);
+
+            const markdownResource = createResource({
+                path: newResourcePath,
+                string: htmlString
+            });
+            await workspace.write(markdownResource);
+        }));
+    };
+    ```
+
 !!! warning
     Depending on your project setup, UI5 Tooling tends to open many files simultaneously during a build. To prevent errors like `EMFILE: too many open files`, we urge custom task implementations to use the [graceful-fs](https://github.com/isaacs/node-graceful-fs#readme) module as a drop-in replacement for the native `fs` module in case it is used.
 
@@ -360,16 +360,16 @@ The following code snippets show examples for custom task implementations.
 
 ### Example: lib/tasks/compileLicenseSummary.js
 
-=== "CommonJS"
+=== "ESM"
 
     ```js linenums="1"
-    const path = require("node:path");
+    import path from "node:path";
 
     /*
     * Compile a list of all licenses of the project's dependencies
     * and write it to "dependency-license-summary.json"
     */
-    module.exports = async function({dependencies, log, options, taskUtil, workspace}) {
+    export default async function({dependencies, log, options, taskUtil, workspace}) {
         const {createResource} = taskUtil.resourceFactory;
         const licenses = new Map();
         const projectsVisited = new Set();
@@ -410,16 +410,16 @@ The following code snippets show examples for custom task implementations.
     };
     ```
 
-=== "ESM"
+=== "CommonJS"
 
     ```js linenums="1"
-    import path from "node:path";
+    const path = require("node:path");
 
     /*
     * Compile a list of all licenses of the project's dependencies
     * and write it to "dependency-license-summary.json"
     */
-    export default async function({dependencies, log, options, taskUtil, workspace}) {
+    module.exports = async function({dependencies, log, options, taskUtil, workspace}) {
         const {createResource} = taskUtil.resourceFactory;
         const licenses = new Map();
         const projectsVisited = new Set();

--- a/docs/pages/extensibility/CustomTasks.md
+++ b/docs/pages/extensibility/CustomTasks.md
@@ -17,7 +17,7 @@ Another custom task called `renderMarkdownFiles` is then executed immediately af
 
 ### Example: Basic configuration
 
-````yaml
+```yaml
 # In this example configuration two custom tasks are defined: 'babel' and 'renderMarkdownFiles'.
 specVersion: "3.0"
 type: library
@@ -32,13 +32,13 @@ builder:
       configuration:
         markdownStyle:
             firstH1IsTitle: true
-````
+```
 
 ### Example: Connect multiple custom tasks
 
 You can also connect multiple custom tasks with each other. The order in the configuration is important in this case. You have to make sure that a task is defined *before* you reference it via `beforeTask` or `afterTask`.
 
-````yaml
+```yaml
 # In this example 'myCustomTask2' gets executed after 'myCustomTask1'.
 specVersion: "3.0"
 type: library
@@ -50,7 +50,7 @@ builder:
       beforeTask: generateComponentPreload
     - name: myCustomTask2
       afterTask: myCustomTask1
-````
+```
 
 ## Custom Task Extension
 
@@ -58,7 +58,7 @@ A custom task extension consists of a `ui5.yaml` and a [task implementation](#ta
 
 ### Example: ui5.yaml
 
-````yaml
+```yaml
 specVersion: "3.0"
 kind: extension
 type: task
@@ -66,7 +66,7 @@ metadata:
   name: renderMarkdownFiles
 task:
   path: lib/tasks/renderMarkdownFiles.js
-````
+```
 
 Task extensions can be **standalone modules** which are handled as dependencies.
 
@@ -77,7 +77,7 @@ The task extension will then be automatically collected and processed during the
 
 ### Example: Custom Task Extension defined in UI5 project
 
-````yaml
+```yaml
 # Project configuration for the above example
 specVersion: "3.0"
 kind: project
@@ -100,49 +100,91 @@ metadata:
   name: renderMarkdownFiles
 task:
   path: lib/tasks/renderMarkdownFiles.js
-````
+```
 
 ## Task Implementation
 
 A custom task implementation needs to return a function with the following signature:
 
-````javascript
-/**
- * Custom task API
- *
- * @param {object} parameters
- * @param {module:@ui5/fs.DuplexCollection} parameters.workspace
- *      Reader/Writer to access and modify resources of the
- *      project currently being built
- * @param {module:@ui5/fs.AbstractReader} parameters.dependencies
- *      Reader to access resources of the project's dependencies
- * @param {@ui5/builder.tasks.TaskUtil} parameters.taskUtil
- *      Specification Version-dependent interface to a TaskUtil instance.
- *      See the corresponding API reference for details:
- *      https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html
- * @param {@ui5/logger/GroupLogger} parameters.log
- *      Logger instance for use in the custom task.
- *      This parameter is only available to custom task extensions
- *      defining Specification Version 3.0 and later.
- * @param {object} parameters.options Options
- * @param {string} parameters.options.projectName
- *      Name of the project currently being built
- * @param {string} parameters.options.projectNamespace
- *      Namespace of the project currently being built
- * @param {string} parameters.options.configuration
- *      Custom task configuration, as defined in the project's ui5.yaml
- * @param {string} parameters.options.taskName
- *      Name of the custom task.
- *      This parameter is only provided to custom task extensions
- *      defining Specification Version 3.0 and later.
- * @returns {Promise<undefined>}
- *      Promise resolving once the task has finished
- */
-export default async function({workspace, dependencies, taskUtil, options}) {
-    // [...]
-};
+=== "CommonJS"
 
-````
+    ```js linenums="1"
+    /**
+     * Custom task API
+     *
+     * @param {object} parameters
+     * 
+     * @param {module:@ui5/fs.AbstractReader} parameters.dependencies
+     *      Reader to access resources of the project's dependencies
+     * @param {@ui5/logger/StandardLogger} parameters.log
+     *      Logger instance for use in the custom task.
+     *      This parameter is only available to custom task extensions
+     *      defining Specification Version 3.0 and later.
+     * @param {object} parameters.options Options
+     * @param {string} parameters.options.projectName
+     *      Name of the project currently being built
+     * @param {string} parameters.options.projectNamespace
+     *      Namespace of the project currently being built
+     * @param {string} parameters.options.configuration
+     *      Custom task configuration, as defined in the project's ui5.yaml
+     * @param {string} parameters.options.taskName
+     *      Name of the custom task.
+     *      This parameter is only provided to custom task extensions
+     *      defining Specification Version 3.0 and later.
+     * @param {@ui5/builder.tasks.TaskUtil} parameters.taskUtil
+     *      Specification Version-dependent interface to a TaskUtil instance.
+     *      See the corresponding API reference for details:
+     *      https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html
+     * @param {module:@ui5/fs.DuplexCollection} parameters.workspace
+     *      Reader/Writer to access and modify resources of the
+     *      project currently being built
+     * @returns {Promise<undefined>}
+     *      Promise resolving once the task has finished
+     */
+    module.exports = async function({dependencies, log, options, taskUtil, workspace}) {
+        // [...]
+    };
+    ```
+
+=== "ESM"
+
+    ```js linenums="1"
+    /**
+     * Custom task API
+     *
+     * @param {object} parameters
+     * 
+     * @param {module:@ui5/fs.AbstractReader} parameters.dependencies
+     *      Reader to access resources of the project's dependencies
+     * @param {@ui5/logger/StandardLogger} parameters.log
+     *      Logger instance for use in the custom task.
+     *      This parameter is only available to custom task extensions
+     *      defining Specification Version 3.0 and later.
+     * @param {object} parameters.options Options
+     * @param {string} parameters.options.projectName
+     *      Name of the project currently being built
+     * @param {string} parameters.options.projectNamespace
+     *      Namespace of the project currently being built
+     * @param {string} parameters.options.configuration
+     *      Custom task configuration, as defined in the project's ui5.yaml
+     * @param {string} parameters.options.taskName
+     *      Name of the custom task.
+     *      This parameter is only provided to custom task extensions
+     *      defining Specification Version 3.0 and later.
+     * @param {@ui5/builder.tasks.TaskUtil} parameters.taskUtil
+     *      Specification Version-dependent interface to a TaskUtil instance.
+     *      See the corresponding API reference for details:
+     *      https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html
+     * @param {module:@ui5/fs.DuplexCollection} parameters.workspace
+     *      Reader/Writer to access and modify resources of the
+     *      project currently being built
+     * @returns {Promise<undefined>}
+     *      Promise resolving once the task has finished
+     */
+    export default async function({dependencies, log, options, taskUtil, workspace}) {
+        // [...]
+    };
+    ```
 
 ### Required Dependencies
 
@@ -161,44 +203,87 @@ If this callback is not provided, UI5 Tooling will make an assumption as to whet
 
 *For more details, see also [RFC 0012 UI5 Tooling Extension API v3](https://github.com/SAP/ui5-tooling/blob/rfc-ui5-tooling-extension-api-v3/rfcs/0012-UI5-Tooling-Extension-API-3.md#3-tasks-requiring-dependencies)*
 
-````javascript
-/**
- * Callback function to define the list of required dependencies
- *
- * @param {object} parameters
- * @param {Set} parameters.availableDependencies
- *      Set containing the names of all direct dependencies of
- *      the project currently being built.
- * @param {function} parameters.getProject
- *      Identical to TaskUtil#getProject
- *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
- *      Retrieves a Project-instance for a given project name.
- * @param {function} parameters.getDependencies
- *      Identical to TaskUtil#getDependencies
- *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
- *      Creates a list of names of all direct dependencies
- *      of a given project.
- * @params {object} parameters.options
- *      Identical to the options given to the standard task function.
- * @returns {Promise<Set>}
- *      Promise resolving with a Set containing all dependencies
- *      that should be made available to the task.
- *      UI5 Tooling will ensure that those dependencies have been
- *      built before executing the task.
- */
-export async function determineRequiredDependencies({availableDependencies, getProject, getDependencies, options}) {
-    // "availableDependencies" could look like this: Set(3) { "sap.ui.core", "sap.m", "my.lib" }
+=== "CommonJS"
 
-    // Reduce list of required dependencies: Do not require any UI5 framework projects
-    availableDependencies.forEach((depName) => {
-        if (getProject(depName).isFrameworkProject()) {
-            availableDependencies.delete(depName)
-        }
-    });
-    // => Only resources of project "my.lib" will be available to the task
-    return availableDependencies;
-}
-````
+    ```js linenums="1"
+    /**
+     * Callback function to define the list of required dependencies
+     *
+     * @param {object} parameters
+     * @param {Set} parameters.availableDependencies
+     *      Set containing the names of all direct dependencies of
+     *      the project currently being built.
+     * @param {function} parameters.getDependencies
+     *      Identical to TaskUtil#getDependencies
+     *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
+     *      Creates a list of names of all direct dependencies
+     *      of a given project.
+     * @param {function} parameters.getProject
+     *      Identical to TaskUtil#getProject
+     *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
+     *      Retrieves a Project-instance for a given project name.
+     * @params {object} parameters.options
+     *      Identical to the options given to the standard task function.
+     * @returns {Promise<Set>}
+     *      Promise resolving with a Set containing all dependencies
+     *      that should be made available to the task.
+     *      UI5 Tooling will ensure that those dependencies have been
+     *      built before executing the task.
+     */
+    module.exports = async function determineRequiredDependencies({availableDependencies, getDependencies, getProject, options}) {
+        // "availableDependencies" could look like this: Set(3) { "sap.ui.core", "sap.m", "my.lib" }
+
+        // Reduce list of required dependencies: Do not require any UI5 framework projects
+        availableDependencies.forEach((depName) => {
+            if (getProject(depName).isFrameworkProject()) {
+                availableDependencies.delete(depName)
+            }
+        });
+        // => Only resources of project "my.lib" will be available to the task
+        return availableDependencies;
+    }
+    ```
+
+=== "ESM"
+
+    ```js linenums="1"
+    /**
+     * Callback function to define the list of required dependencies
+     *
+     * @param {object} parameters
+     * @param {Set} parameters.availableDependencies
+     *      Set containing the names of all direct dependencies of
+     *      the project currently being built.
+     * @param {function} parameters.getProject
+     *      Identical to TaskUtil#getProject
+     *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
+     *      Retrieves a Project-instance for a given project name.
+     * @param {function} parameters.getDependencies
+     *      Identical to TaskUtil#getDependencies
+     *         (see https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html).
+     *      Creates a list of names of all direct dependencies
+     *      of a given project.
+     * @params {object} parameters.options
+     *      Identical to the options given to the standard task function.
+     * @returns {Promise<Set>}
+     *      Promise resolving with a Set containing all dependencies
+     *      that should be made available to the task.
+     *      UI5 Tooling will ensure that those dependencies have been
+     *      built before executing the task.
+     */
+    export async function determineRequiredDependencies({availableDependencies, getDependencies, getProject, options}) {
+        // "availableDependencies" could look like this: Set(3) { "sap.ui.core", "sap.m", "my.lib" }
+
+        // Reduce list of required dependencies: Do not require any UI5 framework projects
+        availableDependencies.forEach((depName) => {
+            if (getProject(depName).isFrameworkProject()) {
+                availableDependencies.delete(depName)
+            }
+        });
+        // => Only resources of project "my.lib" will be available to the task
+        return availableDependencies;
+    }
+    ```
 
 ### Examples
 
@@ -206,34 +291,67 @@ The following code snippets show examples for custom task implementations.
 
 ### Example: lib/tasks/renderMarkdownFiles.js
 
-````javascript
-import path from "node:path";
-import renderMarkdown from "./renderMarkdown.js";
+=== "CommonJS"
 
-/*
- * Render all .md (Markdown) files in the project to HTML
- */
-export default async function({workspace, dependencies, log, taskUtil, options}) {
-    const {createResource} = taskUtil.resourceFactory;
-    const textResources = await workspace.byGlob("**/*.md");
-    await Promise.all(textResources.map(async (resource) => {
-        const markdownResourcePath = resource.getPath();
+    ```js linenums="1"
+    const path = require("node:path");
+    const renderMarkdown = require("./renderMarkdown.js");
 
-        log.info(`Rendering markdown file ${markdownResourcePath}...`);
-        const htmlString = await renderMarkdown(await resource.getString(), options.configuration);
+    /*
+    * Render all .md (Markdown) files in the project to HTML
+    */
+    module.exports = async function({dependencies, log, options, taskUtil, workspace}) {
+        const {createResource} = taskUtil.resourceFactory;
+        const textResources = await workspace.byGlob("**/*.md");
+        await Promise.all(textResources.map(async (resource) => {
+            const markdownResourcePath = resource.getPath();
 
-        // Note: @ui5/fs virtual paths are always (on *all* platforms) POSIX. Therefore using path.posix here
-        const newResourceName = path.posix.basename(markdownResourcePath, ".md") + ".html";
-        const newResourcePath = path.posix.join(path.posix.dirname(markdownResourcePath), newResourceName);
+            log.info(`Rendering markdown file ${markdownResourcePath}...`);
+            const htmlString = await renderMarkdown(await resource.getString(), options.configuration);
 
-        const markdownResource = createResource({
-            path: newResourcePath,
-            string: htmlString
-        });
-        await workspace.write(markdownResource);
-    }));
-};
-````
+            // Note: @ui5/fs virtual paths are always (on *all* platforms) POSIX. Therefore using path.posix here
+            const newResourceName = path.posix.basename(markdownResourcePath, ".md") + ".html";
+            const newResourcePath = path.posix.join(path.posix.dirname(markdownResourcePath), newResourceName);
+
+            const markdownResource = createResource({
+                path: newResourcePath,
+                string: htmlString
+            });
+            await workspace.write(markdownResource);
+        }));
+    };
+    ```
+
+=== "ESM"
+
+    ```js linenums="1"
+    import path from "node:path";
+    import renderMarkdown from "./renderMarkdown.js";
+
+    /*
+    * Render all .md (Markdown) files in the project to HTML
+    */
+    export default async function({dependencies, log, options, taskUtil, workspace}) {
+        const {createResource} = taskUtil.resourceFactory;
+        const textResources = await workspace.byGlob("**/*.md");
+        await Promise.all(textResources.map(async (resource) => {
+            const markdownResourcePath = resource.getPath();
+
+            log.info(`Rendering markdown file ${markdownResourcePath}...`);
+            const htmlString = await renderMarkdown(await resource.getString(), options.configuration);
+
+            // Note: @ui5/fs virtual paths are always (on *all* platforms) POSIX. Therefore using path.posix here
+            const newResourceName = path.posix.basename(markdownResourcePath, ".md") + ".html";
+            const newResourcePath = path.posix.join(path.posix.dirname(markdownResourcePath), newResourceName);
+
+            const markdownResource = createResource({
+                path: newResourcePath,
+                string: htmlString
+            });
+            await workspace.write(markdownResource);
+        }));
+    };
+    ```
 
 !!! warning
     Depending on your project setup, UI5 Tooling tends to open many files simultaneously during a build. To prevent errors like `EMFILE: too many open files`, we urge custom task implementations to use the [graceful-fs](https://github.com/isaacs/node-graceful-fs#readme) module as a drop-in replacement for the native `fs` module in case it is used.
@@ -242,53 +360,105 @@ export default async function({workspace, dependencies, log, taskUtil, options})
 
 ### Example: lib/tasks/compileLicenseSummary.js
 
-````javascript
-import path from "node:path";
+=== "CommonJS"
 
-/*
- * Compile a list of all licenses of the project's dependencies
- * and write it to "dependency-license-summary.json"
- */
-export default async function({workspace, dependencies, log, taskUtil, options}) {
-    const {createResource} = taskUtil.resourceFactory;
-    const licenses = new Map();
-    const projectsVisited = new Set();
+    ```js linenums="1"
+    const path = require("node:path");
 
-    async function processProject(project) {
-        return Promise.all(taskUtil.getDependencies().map(async (projectName) => {
-            if (projectsVisited.has(projectName)) {
-                return;
-            }
-            projectsVisited.add(projectName);
-            const project = taskUtil.getProject(projectName);
-            const pkgResource = await project.getRootReader().byPath("/package.json");
-            if (pkgResource) {
-                const pkg = JSON.parse(await pkgResource.getString())
+    /*
+    * Compile a list of all licenses of the project's dependencies
+    * and write it to "dependency-license-summary.json"
+    */
+    module.exports = async function({dependencies, log, options, taskUtil, workspace}) {
+        const {createResource} = taskUtil.resourceFactory;
+        const licenses = new Map();
+        const projectsVisited = new Set();
 
-                // Add project to list of licenses
-                if (licenses.has(pkg.license)) {
-                    licenses.get(pkg.license).push(project.getName());
-                } else {
-                    // License not yet in map. Define it
-                    licenses.set(pkg.license, [project.getName()]);
+        async function processProject(project) {
+            return Promise.all(taskUtil.getDependencies().map(async (projectName) => {
+                if (projectsVisited.has(projectName)) {
+                    return;
                 }
+                projectsVisited.add(projectName);
+                const project = taskUtil.getProject(projectName);
+                const pkgResource = await project.getRootReader().byPath("/package.json");
+                if (pkgResource) {
+                    const pkg = JSON.parse(await pkgResource.getString())
 
-            } else {
-                log.info(`Could not find package.json file in project ${project.getName()}`);
-            }
-            return processProject(project);
-        }));
-    }
-    // Start processing dependencies of the root project
-    await processProject(taskUtil.getProject());
+                    // Add project to list of licenses
+                    if (licenses.has(pkg.license)) {
+                        licenses.get(pkg.license).push(project.getName());
+                    } else {
+                        // License not yet in map. Define it
+                        licenses.set(pkg.license, [project.getName()]);
+                    }
 
-    const summaryResource = createResource({
-        path: "/dependency-license-summary.json",
-        string: JSON.stringify(Object.fromEntries(licenses), null, "\t")
-    });
-    await workspace.write(summaryResource);
-};
-````
+                } else {
+                    log.info(`Could not find package.json file in project ${project.getName()}`);
+                }
+                return processProject(project);
+            }));
+        }
+        // Start processing dependencies of the root project
+        await processProject(taskUtil.getProject());
+
+        const summaryResource = createResource({
+            path: "/dependency-license-summary.json",
+            string: JSON.stringify(Object.fromEntries(licenses), null, "\t")
+        });
+        await workspace.write(summaryResource);
+    };
+    ```
+
+=== "ESM"
+
+    ```js linenums="1"
+    import path from "node:path";
+
+    /*
+    * Compile a list of all licenses of the project's dependencies
+    * and write it to "dependency-license-summary.json"
+    */
+    export default async function({dependencies, log, options, taskUtil, workspace}) {
+        const {createResource} = taskUtil.resourceFactory;
+        const licenses = new Map();
+        const projectsVisited = new Set();
+
+        async function processProject(project) {
+            return Promise.all(taskUtil.getDependencies().map(async (projectName) => {
+                if (projectsVisited.has(projectName)) {
+                    return;
+                }
+                projectsVisited.add(projectName);
+                const project = taskUtil.getProject(projectName);
+                const pkgResource = await project.getRootReader().byPath("/package.json");
+                if (pkgResource) {
+                    const pkg = JSON.parse(await pkgResource.getString())
+
+                    // Add project to list of licenses
+                    if (licenses.has(pkg.license)) {
+                        licenses.get(pkg.license).push(project.getName());
+                    } else {
+                        // License not yet in map. Define it
+                        licenses.set(pkg.license, [project.getName()]);
+                    }
+
+                } else {
+                    log.info(`Could not find package.json file in project ${project.getName()}`);
+                }
+                return processProject(project);
+            }));
+        }
+        // Start processing dependencies of the root project
+        await processProject(taskUtil.getProject());
+
+        const summaryResource = createResource({
+            path: "/dependency-license-summary.json",
+            string: JSON.stringify(Object.fromEntries(licenses), null, "\t")
+        });
+        await workspace.write(summaryResource);
+    };
+    ```
 
 ## Helper Class `TaskUtil`
 

--- a/docs/updates/migrate-v3.md
+++ b/docs/updates/migrate-v3.md
@@ -77,9 +77,9 @@ await builder.build({
 **New: @ui5/project v3**
 
 ````javascript
-const {generateProjectGraph} = require("@ui5/project");
+import {graphFromPackageDependencies} from "@ui5/project/graph";
 
-let graph = await generateProjectGraph.usingNodePackageDependencies({cwd: "."});
+let graph = await graphFromPackageDependencies({cwd: "."});
 
 await graph.build({
     destPath: "./dist",

--- a/docs/updates/migrate-v3.md
+++ b/docs/updates/migrate-v3.md
@@ -24,10 +24,10 @@ This means your old projects might still work. Unless they have non-standard con
 For extensions defining the latest **Specification Versions 3.0 and higher**, some changes and improvements apply:
 
 * **Breaking Change:** Custom Tasks need to request access to dependency resources
-    * By default, resources of dependencies can't be accessed. A custom task requiring such access needs to implement a callback function `determineRequiredDependencies`, in which it can also define the scope of dependency-access. Please refer to the [Custom Task: Required Dependencies documentation](../pages/extensibility/CustomTasks.md#required-dependencies)
+  * By default, resources of dependencies can't be accessed. A custom task requiring such access needs to implement a callback function `determineRequiredDependencies`, in which it can also define the scope of dependency-access. Please refer to the [Custom Task: Required Dependencies documentation](../pages/extensibility/CustomTasks.md#required-dependencies)
 * **Features:** Enhanced TaskUtil and MiddlewareUtil API
-    * For example providing access to a [project's root directory](https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html#~ProjectInterface), or [dependencies](https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html#getDependencies)
-    * See also [Custom Tasks](../pages/extensibility/CustomTasks.md) and [Custom Server Middleware](../pages/extensibility/CustomServerMiddleware.md)
+  * For example providing access to a [project's root directory](https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html#~ProjectInterface), or [dependencies](https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html#getDependencies)
+  * See also [Custom Tasks](../pages/extensibility/CustomTasks.md) and [Custom Server Middleware](../pages/extensibility/CustomServerMiddleware.md)
 
 ## Changes to @ui5/project and @ui5/builder API
 
@@ -42,13 +42,13 @@ The JSON based, internal representation of a project dependency tree has been re
 
     ```diff title="package.json"
     {
-    	[...]
-    - 	  "ui5": {
-	-	    "dependencies": [
-	-	      "my-package"
-	-	    ]
-	-	  }
-		[...]
+        [...]
+    -     "ui5": {
+    -       "dependencies": [
+    -         "my-package"
+    -       ]
+    -     }
+        [...]
     }
     ```
 
@@ -61,7 +61,7 @@ The JSON based, internal representation of a project dependency tree has been re
 
 **Old: @ui5/project v2**
 
-````javascript
+```js
 const {normalizer} = require("@ui5/project");
 const {builder} = require("@ui5/builder");
 
@@ -72,20 +72,35 @@ await builder.build({
     destPath: "./dist",
     buildDependencies: true,
 });
-````
+```
 
 **New: @ui5/project v3**
 
-````javascript
-import {graphFromPackageDependencies} from "@ui5/project/graph";
+=== "CommonJS"
 
-let graph = await graphFromPackageDependencies({cwd: "."});
+    ```js
+    const {graphFromPackageDependencies} = await import("@ui5/project/graph");
 
-await graph.build({
-    destPath: "./dist",
-    includedDependencies: ["*"], // Parameter "buildDependencies" has been removed
-});
-````
+    let graph = await graphFromPackageDependencies({cwd: "."});
+
+    await graph.build({
+        destPath: "./dist",
+        includedDependencies: ["*"], // Parameter "buildDependencies" has been removed
+    });
+    ```
+
+=== "ESM"
+
+    ```js
+    import {graphFromPackageDependencies} from "@ui5/project/graph";
+
+    let graph = await graphFromPackageDependencies({cwd: "."});
+
+    await graph.build({
+        destPath: "./dist",
+        includedDependencies: ["*"], // Parameter "buildDependencies" has been removed
+    });
+    ```
 
 Also the @ui5/server API has been changed. Instead of a `tree`, it now only accepts a `graph` instance as the first parameter.
 
@@ -104,24 +119,24 @@ Especially for projects of type `library`, where standard tasks like [`buildThem
 In the future, a caching mechanism should help and improve build times with this new behavior.
 
 !!! info
-	The CLI flags `-a` and `--all` are still present and now an alias for `--include-all-dependencies`. This flag (along with `--include-dependency*` and `--exclude-dependency*`) mainly controls the **build output**. Use it to define whether dependency resources should be part of the build result.
+    The CLI flags `-a` and `--all` are still present and now an alias for `--include-all-dependencies`. This flag (along with `--include-dependency*` and `--exclude-dependency*`) mainly controls the **build output**. Use it to define whether dependency resources should be part of the build result.
 
-	Please also refer to the [`ui5 build` documentation](../pages/CLI.md#ui5-build).
+    Please also refer to the [`ui5 build` documentation](../pages/CLI.md#ui5-build).
 
 ## Removal of Standard Tasks and Processors
 
 The following tasks have been removed:
 
-- createDebugFiles
-- generateManifestBundle
-- uglify
+* createDebugFiles
+* generateManifestBundle
+* uglify
 
 The following processors have been removed:
 
-- debugFileCreator
-- manifestBundler
-- resourceCopier
-- uglifier
+* debugFileCreator
+* manifestBundler
+* resourceCopier
+* uglifier
 
 **Task Migration**
 
@@ -130,7 +145,6 @@ The following processors have been removed:
 | createDebugFiles<br/>uglify | minify                      | The minify task is executed earlier, before the bundling process takes place. Any existing 'beforeTask' or 'afterTask' configuration of custom tasks might need to be adapted to cater for this change. |
 | generateVersionInfo         | generateVersionInfo         | The task is no longer executed by default for application projects. It can be re-enabled by using the `--include-task` parameter. |
 | generateManifestBundle      | *None*                      | This task was only needed for the HTML5 repository in Cloud Foundry. Meanwhile, the HTML5 repository implemented its own mechanism, so the task is no longer needed |
-
 
 **Updated list of standard tasks:**
 
@@ -173,7 +187,7 @@ The following processors have been removed:
 
 The following middleware has been removed from the [standard middlewares list](../../pages/Server/#standard-middleware):
 
-- connectUi5Proxy
+* connectUi5Proxy
 
 **Middleware Migration**
 

--- a/docs/updates/migrate-v3.md
+++ b/docs/updates/migrate-v3.md
@@ -76,10 +76,10 @@ await builder.build({
 
 **New: @ui5/project v3**
 
-=== "CommonJS"
+=== "ESM"
 
     ```js
-    const {graphFromPackageDependencies} = await import("@ui5/project/graph");
+    import {graphFromPackageDependencies} from "@ui5/project/graph";
 
     let graph = await graphFromPackageDependencies({cwd: "."});
 
@@ -89,10 +89,10 @@ await builder.build({
     });
     ```
 
-=== "ESM"
+=== "CommonJS"
 
     ```js
-    import {graphFromPackageDependencies} from "@ui5/project/graph";
+    const {graphFromPackageDependencies} = await import("@ui5/project/graph");
 
     let graph = await graphFromPackageDependencies({cwd: "."});
 

--- a/examples/browsersync/README.md
+++ b/examples/browsersync/README.md
@@ -7,7 +7,7 @@ This example shows how to use `ui5 serve` in combination with [Browsersync](http
 1. Install all dependencies
    ```sh
    npm install
-   ````
+   ```
 2. Run the server
    ```
    npm start


### PR DESCRIPTION
Update the code samples to use additionally ESM import and export statements. The respective code blocks are displayed in tabs "CommonJS" and "ESM".

![Screenshot 2023-01-02 at 12 34 28](https://user-images.githubusercontent.com/34711402/210226021-0b63fd1d-9ac1-4964-b8ec-4c44520e42d3.png)
![Screenshot 2023-01-02 at 12 34 35](https://user-images.githubusercontent.com/34711402/210226017-b4a649f1-9667-485a-ad15-a46cbcfea52e.png)



