### PR TITLE
[INTERNAL] docu: Switch stable alias to v3 documentation

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -3,14 +3,13 @@
     "version": "v3",
     "title": "v3",
     "aliases": [
-      "next"
+      "next",
+      "stable"
     ]
   },
   {
     "version": "v2",
     "title": "v2",
-    "aliases": [
-      "stable"
-    ]
+    "aliases": []
   }
 ]


### PR DESCRIPTION
Redirect "stable" links to UI5 Tooling V3 documentation.

**Before this PR**:
https://sap.github.io/ui5-tooling/stable/ --> https://sap.github.io/ui5-tooling/v2/
https://sap.github.io/ui5-tooling/next/ --> https://sap.github.io/ui5-tooling/v3/

**After merging this PR**:
https://sap.github.io/ui5-tooling/stable/ --> https://sap.github.io/ui5-tooling/v3/
https://sap.github.io/ui5-tooling/next/ --> https://sap.github.io/ui5-tooling/v3/
