### PR TITLE
[INTERNAL] Use default branch identifier '-' instead of hardcoded branch name for external links

### DIFF
--- a/docs/pages/OpenUI5.md
+++ b/docs/pages/OpenUI5.md
@@ -66,4 +66,4 @@ When working on UI5 applications or libraries that use OpenUI5, you can link a l
 A detailed step-by-step guide on how to achieve such a setup with the OpenUI5 Sample App can be found [here](https://github.com/SAP/openui5-sample-app#working-with-local-dependencies).
 
 ## OpenUI5 Framework Development
-Please refer to the [OpenUI5 Framework Development Documentation](https://github.com/SAP/openui5/blob/master/docs/developing.md#developing-ui5).
+Please refer to the [OpenUI5 Framework Development Documentation](https://github.com/SAP/openui5/blob/-/docs/developing.md#developing-ui5).

--- a/lib/jsdoc/plugin/template/layout.tmpl
+++ b/lib/jsdoc/plugin/template/layout.tmpl
@@ -1,6 +1,6 @@
 <?js
 // ##### BEGIN: MODIFIED BY SAP
-// This file was initialy copied from https://github.com/clenemt/docdash/blob/master/tmpl/layout.tmpl
+// This file was initialy copied from https://github.com/clenemt/docdash/blob/-/tmpl/layout.tmpl
 // and adjusted to offer a customized footer according to the SAP Web Presence Policy.
 // See also the corresponding stylesheet content in lib/jsdoc/plugin/template/custom.css.
 // ##### END: MODIFIED BY SAP

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -1,5 +1,5 @@
 {#-
-  This file was initialy copied from https://github.com/squidfunk/mkdocs-material/blob/master/material/partials/footer.html
+  This file was initialy copied from https://github.com/squidfunk/mkdocs-material/blob/-/material/partials/footer.html
   and adjusted to offer a customized footer according to the SAP Web Presence Policy.
   See also the corresponding stylesheet content in /docs/stylesheets/extra.css.
 -#}

--- a/scripts/resources/CLI.template.md
+++ b/scripts/resources/CLI.template.md
@@ -19,7 +19,7 @@ ui5 --help
 {{common}}
 `
 
-The CLI automatically checks for updates using [update-notifier](https://github.com/yeoman/update-notifier). While this is skipped in CI environments, you might also opt-out manually by following the steps described [here](https://github.com/yeoman/update-notifier/blob/master/readme.md#user-settings).
+The CLI automatically checks for updates using [update-notifier](https://github.com/yeoman/update-notifier). While this is skipped in CI environments, you might also opt-out manually by following the steps described [here](https://github.com/yeoman/update-notifier/blob/-/readme.md#user-settings).
 
 ## Common options
 


### PR DESCRIPTION
This PR replaces the term "master" in links pointing to the default branch. 

**Advantages:**
- The link is stable also when default branch is switched without the branch renaming feature of github
- "master" is identified as non inclusive language