### PR TITLE
[INTERNAL] v2: Put UI5 Tooling V2 in maintenance

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,10 +6,9 @@ on:
 jobs:
   build-and-deploy:
     name: Build and Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MIKE_VERSION: v2
-      MIKE_ALIAS: stable
       DOCKER_IMAGE: ui5-tooling/mkdocs-material
       GIT_COMMITTER_NAME: "OpenUI5 Bot"
       GIT_COMMITTER_EMAIL: "openui5@sap.com"

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,12 @@
+{#-
+  This file was initialy copied from https://squidfunk.github.io/mkdocs-material/customization/#overriding-blocks
+  It displays a message for the non-default branch
+-#}
+{% extends "base.html" %}
+
+{% block announce %}
+  You're currently viewing the 'In Maintenance' version of UI5 Tooling (v2).
+  <a href="{{ '../v3/' ~ base_url }}">
+  <strong>Click here to go to the latest version (v3).</strong>
+  </a>
+{% endblock %}


### PR DESCRIPTION
- Add a note informing user about UI5 Tooling is in maintenance
- Remove stable alias from mkdocs run