### PR TITLE
[INTERNAL] audit-ci(v2): Add security alert for taffdb 'GHSA-mxhp-79qh-mcx6' to allow list

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -3,5 +3,7 @@
 	"$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
 	"low": true,
 	"allowlist": [
+		// Taffdb is only used during jsdoc build and contains only data for jsdoc generation. After jsdoc build finished, db is destroyed
+		"GHSA-mxhp-79qh-mcx6"
 	]
   }


### PR DESCRIPTION
Taffdb is only used during jsdoc build and contains only data for jsdoc generation. After jsdoc build db is destroyed.