### PR TITLE
[FIX] V2 security audit add exception

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -3,5 +3,7 @@
 	"$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
 	"low": true,
 	"allowlist": [
+		// Taffdb is only used during jsdoc build and contains only data for jsdoc generation. After jsdoc build finished, db is destroyed
+		"GHSA-mxhp-79qh-mcx6"
 	]
   }


### PR DESCRIPTION
The exception for the `taffdb` needs to be defined within the scanned branch config