### PR TITLE
[INTERNAL] CustomTask: Fix CommonJS example for 'determineRequiredDependencies' export

### DIFF
--- a/docs/pages/extensibility/CustomTasks.md
+++ b/docs/pages/extensibility/CustomTasks.md
@@ -271,7 +271,7 @@ If this callback is not provided, UI5 Tooling will make an assumption as to whet
      *      UI5 Tooling will ensure that those dependencies have been
      *      built before executing the task.
      */
-    module.exports = async function determineRequiredDependencies({availableDependencies, getDependencies, getProject, options}) {
+    module.exports.determineRequiredDependencies = async function({availableDependencies, getDependencies, getProject, options}) {
         // "availableDependencies" could look like this: Set(3) { "sap.ui.core", "sap.m", "my.lib" }
 
         // Reduce list of required dependencies: Do not require any UI5 framework projects


### PR DESCRIPTION
It needs to be a named export. Currently it would overwrite the default
export (=main task function).