### PR TITLE
[INTERNAL] Fix edit button on documentation pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: UI5 Tooling
 site_url: 'https://sap.github.io/ui5-tooling/' # required for working 404 page
 repo_name: 'SAP/ui5-tooling'
 repo_url: 'https://github.com/SAP/ui5-tooling'
+edit_uri: ./edit/main/docs # default points to master branch
 docs_dir: 'docs' # default
 site_dir: 'site' # default
 copyright: '© Copyright 2023, SAP SE and UI5 Tooling Contributors'


### PR DESCRIPTION
URI needs to be manually defined in case the branch is not "master".
