### PR TITLE
[INTERNAL] v2: stabilize deprecation anouncement link

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,7 +6,7 @@
 
 {% block announce %}
   ⚠️ UI5 Tooling v2 has been deprecated! We highly recommend migrating to
-  <a href="{{ '../v3/' ~ base_url }}">
+  <a href="{{ base_url ~ '/../v3/' }}">
   <strong>the latest version (v3).</strong>
   </a>
 {% endblock %}


### PR DESCRIPTION
The link described in the main mike/mkdocs-material docs is not quite correct and in some cases leads to bad landings: https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/?h=base+url#version-warning
For example, trying to follow the deprecation link on this page: https://sap.github.io/ui5-tooling/v2/pages/extensibility/CustomServerMiddleware/

The issue is because the `base_url` produces a backtrack, but not a real base URL. However, it takes into account the versioning!

Now, it's been adjusted to lead always to the root page of v3

**Note:** This is a docs adjustment for v2 branch!