### PR TITLE
[INTERNAL] Reorder documentation

### DIFF
--- a/docs/pages/Builder.md
+++ b/docs/pages/Builder.md
@@ -8,37 +8,6 @@ For every type there is a set of default tasks. You can disable single tasks usi
 
 [**API Reference**](https://sap.github.io/ui5-tooling/v3/api/index.html){: .md-button .sap-icon-initiative }
 
-## Types
-Types define how a project can be configured and how it is built. A type orchestrates a set of tasks and defines the order in which they get applied during build phase. Furthermore, it takes care of formatting and validating the project-specific configuration.
-
-Also see [UI5 Project: Configuration](./Configuration.md#general-configuration)
-
-### application
-Projects of type `application` are typically the main or root project. In a projects dependency tree, there should only be one project of type `application`. If multiple are found, those further away from the root are ignored.
-
-The source directory of an application (typically named `webapp`) is mapped to the virtual root path `/`.
-
-An applications source directory may or may not contain a `Component.js` file. If it does, it must also contain a `manifest.json` file. If there is a `Component.js` file, an optimized `Component-preload.js` file will be generated during the build.
-
-### library
-UI5 libraries are often referred to as reuse-, custom- or [control libraries](https://github.com/SAP/openui5/blob/main/docs/controllibraries.md). They are a key component in sharing code across multiple projects in UI5.
-
-A project of type `library` must have a source directory (typically named `src`). It may also feature a "test" directory. These directories are mapped to the virtual directories `/resources` for the sources and `/test-resources` for the test resources.
-
-These directories should contain a directory structure representing the namespace of the library (e.g. `src/my/first/library`) to prevent name clashes between the resources of different libraries.
-
-### theme-library
-*Available since [Specification Version](./Configuration.md#specification-versions) 1.1*
-
-UI5 theme libraries provide theming resources for the controls of one or multiple libraries.
-
-A project of type `theme-library` must have a source directory (typically named `src`). It may also feature a "test" directory. These directories are mapped to the virtual directories `/resources` for the sources and `/test-resources` for the test resources.
-
-The source directory must contain a directory structure representing the namespaces of the libraries it provides theme resources for. For example, a theme library named `my_custom_theme`, providing resources for a library named `my.library` should have these resources in a directory path `my/library/themes/my_custom_theme/`.
-
-### module
-The `module` type is meant for usage with non-UI5 resources like third-party libraries. Their path mapping can be configured freely. During a build, their resources are copied without modifications.
-
 ## Tasks
 Tasks are specific build steps to be executed during build phase.
 

--- a/docs/pages/Project.md
+++ b/docs/pages/Project.md
@@ -2,4 +2,36 @@
 
 The [UI5 Project](https://github.com/SAP/ui5-project) module provides functionality to build a UI5 project. Also see [Development Overview: Project Dependencies](./Overview.md#project-dependencies).
 
+## Types
+Types define how a project can be configured and how it is built. A type orchestrates a set of tasks and defines the order in which they get applied during build phase. Furthermore, it takes care of formatting and validating the project-specific configuration.
+
+Also see [UI5 Project: Configuration](./Configuration.md#general-configuration)
+
+### application
+Projects of type `application` are typically the main or root project. In a projects dependency tree, there should only be one project of type `application`. If multiple are found, those further away from the root are ignored.
+
+The source directory of an application (typically named `webapp`) is mapped to the virtual root path `/`.
+
+An applications source directory may or may not contain a `Component.js` file. If it does, it must also contain a `manifest.json` file. If there is a `Component.js` file, an optimized `Component-preload.js` file will be generated during the build.
+
+### library
+UI5 libraries are often referred to as reuse-, custom- or [control libraries](https://github.com/SAP/openui5/blob/main/docs/controllibraries.md). They are a key component in sharing code across multiple projects in UI5.
+
+A project of type `library` must have a source directory (typically named `src`). It may also feature a "test" directory. These directories are mapped to the virtual directories `/resources` for the sources and `/test-resources` for the test resources.
+
+These directories should contain a directory structure representing the namespace of the library (e.g. `src/my/first/library`) to prevent name clashes between the resources of different libraries.
+
+### theme-library
+*Available since [Specification Version](./Configuration.md#specification-versions) 1.1*
+
+UI5 theme libraries provide theming resources for the controls of one or multiple libraries.
+
+A project of type `theme-library` must have a source directory (typically named `src`). It may also feature a "test" directory. These directories are mapped to the virtual directories `/resources` for the sources and `/test-resources` for the test resources.
+
+The source directory must contain a directory structure representing the namespaces of the libraries it provides theme resources for. For example, a theme library named `my_custom_theme`, providing resources for a library named `my.library` should have these resources in a directory path `my/library/themes/my_custom_theme/`.
+
+### module
+The `module` type is meant for usage with non-UI5 resources like third-party libraries. Their path mapping can be configured freely. During a build, their resources are copied without modifications.
+
+
 [**API Reference**](https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_ProjectBuilder.html){: .md-button .sap-icon-initiative }


### PR DESCRIPTION
This change does not introduce any changes, but just moves the (project) Types section from [`/Builder`](https://sap.github.io/ui5-tooling/stable/pages/Builder/#types) page to the [`/Project`](https://sap.github.io/ui5-tooling/stable/pages/Project/) page where it actually belongs.