### PR TITLE
[BREAKING] Require Node.js 20.11.x/>=21.2.0 and npm >=10

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,10 +18,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Use Node.js LTS 18.x
+    - name: Use Node.js LTS 20.x
       uses: actions/setup-node@v4.0.2
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Install npm dependencies
       run: npm ci

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Use Node.js LTS 18.x
+    - name: Use Node.js LTS 20.x
       uses: actions/setup-node@v4.0.2
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Install dependencies
       run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,8 @@
 				"traverse": "^0.6.8"
 			},
 			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">= 8"
+				"node": "^20.11.0 || >=21.2.0",
+				"npm": ">= 10"
 			}
 		},
 		"node_modules/@75lb/deep-merge": {
@@ -8059,6 +8059,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
 			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
@@ -8069,6 +8070,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -8083,6 +8085,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -8093,12 +8096,14 @@
 		"node_modules/cliui/node_modules/color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/cliui/node_modules/wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -8582,6 +8587,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
 			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -8976,6 +8982,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
 			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -9797,6 +9804,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
@@ -10443,6 +10451,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
 			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"dev": true,
 			"bin": {
 				"is-docker": "cli.js"
 			},
@@ -10594,6 +10603,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
 			"dependencies": {
 				"is-docker": "^2.0.0"
 			},
@@ -12286,6 +12296,7 @@
 			"version": "8.4.2",
 			"resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
 			"integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+			"dev": true,
 			"dependencies": {
 				"define-lazy-prop": "^2.0.0",
 				"is-docker": "^2.1.1",
@@ -13087,6 +13098,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -14636,6 +14648,7 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -14658,6 +14671,7 @@
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
 			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
 			"dependencies": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -14675,6 +14689,7 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
 			"engines": {
 				"node": ">=10"
 			}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
 	],
 	"type": "module",
 	"engines": {
-		"node": ">=18.0.0",
-		"npm": ">= 8"
+		"node": "^20.11.0 || >=21.2.0",
+		"npm": ">= 10"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run jsdoc-generate && npm run schema-generate && npm run generate-cli-doc",

--- a/scripts/buildSchema.js
+++ b/scripts/buildSchema.js
@@ -1,18 +1,15 @@
 import path from "node:path";
-import {fileURLToPath, pathToFileURL} from "node:url";
+import {fileURLToPath} from "node:url";
 import {writeFile, mkdir} from "node:fs/promises";
 import {$RefParser} from "@apidevtools/json-schema-ref-parser";
 import traverse from "traverse";
 
-// Using CommonsJS require.resolve as long as import.meta.resolve is experimental
-import {createRequire} from "node:module";
-const require = createRequire(import.meta.url);
 // Provide schema name as CLI argument
 const schemaName = process.argv[2] || "ui5";
 
 // Using @ui5/project/package.json export to calculate the path to the root ui5-project folder
 const SOURCE_SCHEMA_PATH = fileURLToPath(
-	new URL(`./lib/validation/schema/${schemaName}.json`, pathToFileURL(require.resolve("@ui5/project/package.json")))
+	new URL(`./lib/validation/schema/${schemaName}.json`, import.meta.resolve("@ui5/project/package.json"))
 );
 const TARGET_SCHEMA_PATH = fileURLToPath(
 	new URL(`../site/schema/${schemaName}.yaml.json`, import.meta.url)

--- a/scripts/isWorkspace.js
+++ b/scripts/isWorkspace.js
@@ -1,7 +1,7 @@
 import path from "node:path";
 import {fileURLToPath} from "node:url";
 
-const cliPath = path.relative(__dirname, fileURLToPath(import.meta.resolve("@ui5/cli/package.json")));
+const cliPath = path.relative(import.meta.dirname, fileURLToPath(import.meta.resolve("@ui5/cli/package.json")));
 
 // no workspace detected
 if (!cliPath.startsWith(path.join("..", ".."))) {

--- a/scripts/isWorkspace.js
+++ b/scripts/isWorkspace.js
@@ -1,13 +1,7 @@
 import path from "node:path";
 import {fileURLToPath} from "node:url";
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Using CommonsJS require.resolve as long as import.meta.resolve is experimental
-import {createRequire} from "node:module";
-const require = createRequire(import.meta.url);
-
-const cPath = require.resolve("@ui5/cli/package.json");
-const cliPath = path.relative(__dirname, path.dirname(cPath));
+const cliPath = path.relative(__dirname, fileURLToPath(import.meta.resolve("@ui5/cli/package.json")));
 
 // no workspace detected
 if (!cliPath.startsWith(path.join("..", ".."))) {


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js and npm releases has been dropped.
Only Node.js 20.11.x and >=21.2.0 as well as npm v10 or higher are supported.

JIRA: CPOUI5FOUNDATION-800