### PR TITLE
[BREAKING] Replace console.log with process.stderr

### DIFF
--- a/scripts/buildSchema.js
+++ b/scripts/buildSchema.js
@@ -44,9 +44,10 @@ try {
 	await mkdir(path.dirname(TARGET_SCHEMA_PATH), {recursive: true});
 	await writeFile(TARGET_SCHEMA_PATH, JSON.stringify(schema, null, 2));
 
-	console.log(`Wrote bundled ${schemaName}.yaml schema file to ${TARGET_SCHEMA_PATH}`);
+	process.stderr.write(`Wrote bundled ${schemaName}.yaml schema file to ${TARGET_SCHEMA_PATH}\n`);
 } catch (error) {
-	console.log(error);
+	process.stderr.write(error);
+	process.stderr.write("\n");
 	process.exit(1);
 }
 

--- a/scripts/generateCliDoc.js
+++ b/scripts/generateCliDoc.js
@@ -184,10 +184,12 @@ function generateDoc() {
 	try {
 		writeFileSync("./docs/pages/CLI.md", content);
 	} catch (err) {
-		console.error(`Failed to generate docs/pages/CLI.md: ${err.message}.`);
+		process.stderr.write(`Failed to generate docs/pages/CLI.md: ${err.message}.`);
+		process.stderr.write("\n");
 		throw err;
 	}
-	console.log("Generated docs/pages/CLI.md");
+	process.stderr.write("Generated docs/pages/CLI.md");
+	process.stderr.write("\n");
 }
 
 function splitString(temp) {

--- a/scripts/hash.js
+++ b/scripts/hash.js
@@ -15,4 +15,5 @@ const fileBuffer = fs.readFileSync(filename);
 const hashSum = crypto.createHash("md5");
 hashSum.update(fileBuffer);
 
-console.log(hashSum.digest("hex"));
+process.stderr.write(hashSum.digest("hex"));
+process.stderr.write("\n");


### PR DESCRIPTION
BREAKING CHANGE:
Error messages will now be written to stderr instead of stdout.

JIRA: CPOUI5FOUNDATION-802
Related to: https://github.com/SAP/ui5-tooling/issues/701
Sibling of: https://github.com/SAP/ui5-server/pull/643, https://github.com/SAP/ui5-cli/pull/686