### PR TITLE
[FEATURE] Bundling: Remove option 'usePredefineCalls'

### DIFF
--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -710,7 +710,6 @@ A list of bundle definitions. A `bundleDefinition` contains of the following opt
     - Projects defining [Specification Version](#specification-versions) lower than 3.0: Defaults to `false`
 - `decorateBootstrapModule`: By default set to `false`. If set to `true`, the module will be decorated with an optimization marker
 - `addTryCatchRestartWrapper`: By default set to `false`. If set to `true`, bootable module bundles gets wrapped with a try/catch to filter "Restart" errors
-- `usePredefineCalls`: If set to `true`, `sap.ui.predefine` is used for UI5 modules
 - `numberOfParts`: By default set to `1`. The number of parts into which a module bundle should be splitted
 - `sourceMap`: By default set to `true`. Adds source map support to the bundle. Available since UI5 Tooling `v4.0.0`
 


### PR DESCRIPTION
Up until UI5 Tooling v3, the bundle option "usePredefineCalls" defaults to "false" and has to be activated explicitly in a custom bundle configuration.
For default bundles, such as Component-preload or self-contained bundle (sap-ui-custom.js), there is no way to use the option apart from re-defining the whole bundle via custom bundle definition.

With UI5 Tooling v4 bundles are generated with the usage sap.ui.predefine calls instead of the former default function wrapper. This leads to smaller bundle sizes and less overhead at runtime.

As the option only affects the internal handling of bundling without affecting the actual users,
the option is removed completely, instead of just changing the default value of the option.

Implementation covered in https://github.com/SAP/ui5-builder/pull/1021.

JIRA: CPOUI5FOUNDATION-760