### PR TITLE
[FIX] Updated node version requirements in docs

### DIFF
--- a/scripts/resources/CLI.template.md
+++ b/scripts/resources/CLI.template.md
@@ -1,6 +1,6 @@
 # UI5 CLI
 ## Requirements
-- [Node.js](https://nodejs.org/) Version v16.18.0, v18.12.0 or higher
+- [Node.js](https://nodejs.org/) Version v20.11.0, v22.0.0 or higher
 - [npm](https://www.npmjs.com/) Version v8.0.0 or higher
 
 ## Installation


### PR DESCRIPTION
The docs had not been updated with the correct node version requirements after the v4 release.