### PR TITLE
[INTERNAL] README.md: Adjust migration note to highlight Version 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 >
 > [UI5 Tooling v2](https://sap.github.io/ui5-tooling/v2) has been deprecated 🚫  
 >
-> Please migrate your projects to [UI5 Tooling v3](https://sap.github.io/ui5-tooling/v3/updates/migrate-v3/)!
+> Please migrate your projects to [UI5 Tooling v4](https://sap.github.io/ui5-tooling/v4/updates/migrate-v4/)!
 
 ## Resources
 


### PR DESCRIPTION
UI5 Tooling Version 4 is released for some weeks, so consumers should migrate to Version 4 instead of Version 3