### PR TITLE
[INTERNAL] Audit CI: Enable check on main branch

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch: ["v3"] # List of branches to run the security audit uppon
+        branch: ["main", "v3"] # List of branches to run the security audit on
 
     steps:
       - name: Checkout '${{ matrix.branch }}' branch
@@ -18,8 +18,5 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - name: install dependencies
-        run: npm ci
-
       - name: Use audit-ci
-        run: npx audit-ci@^6 --config ./audit-ci.jsonc
+        run: npx audit-ci@^7 --config ./audit-ci.jsonc

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,6 @@
+{
+    // $schema provides code completion hints to IDEs.
+    "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+    "low": true,
+    "allowlist": []
+}


### PR DESCRIPTION
Also checking the main branch to be notified about vulnerabilities based
on the released packages.
Although the main branch is covered by GitHub security checks and
dependabot updates, it could be missed that some vulnerabilities have
been solved already but not released yet.

Also removing the unnecessary "npm install". Audit CI checks based on
the existing lockfile.