### PR TITLE
build(deps-dev): bump koa from 2.16.2 to 2.16.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9656,7 +9656,9 @@
 			}
 		},
 		"node_modules/koa": {
-			"version": "2.16.2",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/koa/-/koa-2.16.3.tgz",
+			"integrity": "sha512-zPPuIt+ku1iCpFBRwseMcPYQ1cJL8l60rSmKeOuGfOXyE6YnTBmf2aEFNL2HQGrD0cPcLO/t+v9RTgC+fwEh/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
Resolves https://github.com/advisories/GHSA-g8mr-fgfg-5qpc
