### PR TITLE
refactor: Add vitepress scan to the audit-ci's allowlist

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -3,8 +3,12 @@
     "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
     "low": true,
     "allowlist": [
-        // Transitive dependency in vitepress (dev-only, documentation tool).
-        // Cannot be fixed until upstream vite updates esbuild. Excluded to avoid scan noise.
+        // GHSA-67mh-4wv8-2f99 allows malicious websites to read localhost files while dev server runs.
+        // We use VitePress for documentation build and all the information is already publicly available on GitHub Pages.
+        // Exposure during local development doesn't leak confidential information.
+        // This issue affects only the dev server. Production/CI builds are unaffected.
+        //
+        // Fix is available in VitePress 2.x with esbuild v0.25.x, but no stable release yet (only alpha).
         "GHSA-67mh-4wv8-2f99|vitepress>vite>esbuild"
     ]
 }


### PR DESCRIPTION
In order to receive valid reports and not to miss something, we shall silence this one for now