### PR TITLE
refactor: Release all packages as grouped version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,6 +34,18 @@
 	"plugins": [
 		{
 			"type": "node-workspace"
+		},
+		{
+			"type": "linked-versions",
+			"groupName": "ui5-cli-packages",
+			"components": [
+				"logger",
+				"fs",
+				"builder",
+				"server",
+				"project",
+				"cli"
+			]
 		}
 	],
 	"changelog-sections": [


### PR DESCRIPTION
Packages now always have the exact same version. The bump is based on the package with the highest value: https://github.com/googleapis/release-please/blob/009c2a61a038843957e7002aa1c32e317b654aa1/docs/manifest-releaser.md#linked-versions

JIRA: CPOUI5FOUNDATION-1166