### PR TITLE
refactor(builder): generateFlexChangesBundle should not rely on existing manifest.json

### DIFF
--- a/packages/builder/lib/tasks/bundlers/generateFlexChangesBundle.js
+++ b/packages/builder/lib/tasks/bundlers/generateFlexChangesBundle.js
@@ -63,6 +63,10 @@ export default async function({workspace, taskUtil, options = {}}) {
 
 	async function updateManifestWithFlDependencyAndFlexBundleFlag(bBundleCreated) {
 		const manifestResource = await workspace.byPath(`${pathPrefix}/manifest.json`);
+		if (!manifestResource) {
+			log.verbose("No manifest.json found, skipping update of sap.ui.fl dependency and flexBundle flag");
+			return;
+		}
 		const manifestContent = JSON.parse(await manifestResource.getString());
 
 		updateJson(manifestContent, bBundleCreated);
@@ -73,6 +77,10 @@ export default async function({workspace, taskUtil, options = {}}) {
 
 	async function readManifestMinUI5Version() {
 		const manifestResource = await workspace.byPath(`${pathPrefix}/manifest.json`);
+		if (!manifestResource) {
+			log.verbose("No manifest.json found, cannot read minUI5Version");
+			return [];
+		}
 		const manifestContent = JSON.parse(await manifestResource.getString());
 
 		manifestContent["sap.ui5"] = manifestContent["sap.ui5"] || {};


### PR DESCRIPTION
When running the `generateFlexChangesBundle` task, `manifest.json` might not be present.

Follow-up of https://github.com/UI5/cli/pull/1165