### PR TITLE
fix: JSDoc build

### DIFF
--- a/internal/documentation/jsdoc/jsdoc.json
+++ b/internal/documentation/jsdoc/jsdoc.json
@@ -3,12 +3,16 @@
 		"allowUnknownTags": false
 	},
 	"source": {
-		"include": ["jsdoc/index.md", "../../node_modules/@ui5"],
+		"include": ["jsdoc/index.md", "../../node_modules/@ui5", "./node_modules/@ui5"],
 		"exclude": [
 			"../../node_modules/@ui5/builder-npm/lib/lbt/utils/JSTokenizer.js",
 			"../../node_modules/@ui5/builder-npm/lib/processors/jsdoc/lib/ui5/plugin.js",
 			"../../node_modules/@ui5/builder-npm/lib/processors/jsdoc/lib/ui5/template/publish.js",
-			"../../node_modules/@ui5/builder-npm/lib/processors/jsdoc/lib/ui5/template/utils/versionUtil.js"
+			"../../node_modules/@ui5/builder-npm/lib/processors/jsdoc/lib/ui5/template/utils/versionUtil.js",
+			"./node_modules/@ui5/builder-npm/lib/lbt/utils/JSTokenizer.js",
+			"./node_modules/@ui5/builder-npm/lib/processors/jsdoc/lib/ui5/plugin.js",
+			"./node_modules/@ui5/builder-npm/lib/processors/jsdoc/lib/ui5/template/publish.js",
+			"./node_modules/@ui5/builder-npm/lib/processors/jsdoc/lib/ui5/template/utils/versionUtil.js"
 		],
 		"includePattern": "@ui5/[^/]*-npm/(lib/.+|index)\\.js$",
 		"excludePattern": "@ui5/.*/node_modules/@ui5"


### PR DESCRIPTION
The JSDoc configuration was set to exclude specific files containing custom UI5 tags (like `@ui5-restricted`) that aren't recognized by JSDoc. However, **these exclusion patterns weren't working** in the monorepo setup.

With npm workspaces, dependencies can be installed in multiple locations:
- Root level: `../../node_modules/@ui5/` (relative to the documentation package)
- Package level: `./node_modules/@ui5/` (within the documentation package itself)

The original `jsdoc.json` only had exclusion patterns for the root-level path. When npm installed `@ui5/builder-npm` at the package level, the excluded files (like `JSTokenizer.js`) were still being processed. Since these files use the custom `@ui5-restricted` tag and `allowUnknownTags: false` was configured, JSDoc failed on encountering these unknown tags.