### PR TITLE
ci(release-please): Refactor release config to bump automatically prerelase versions

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
 	"pull-request-header": ":tractor: New release prepared",
 	"prerelease": true,
 	"prerelease-type": "alpha",
-	"release-as": "5.0.0-alpha.1",
+	"versioning": "prerelease",
 	"packages": {
 		"packages/logger": {
 			"component": "logger"


### PR DESCRIPTION
Replacing the `release-as` hardcoded bumping with `prerelase` versioning strategy that will automatically bump the alpha releases