### PR TITLE
ci: Do not fail ci if Coverage reporting fails

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,5 +56,6 @@ jobs:
     steps:
       - name: Close parallel build
         uses: coverallsapp/github-action@v2.3.7
+        continue-on-error: true # Do not fail the job if coverage reporting fails (e.g. service is down)
         with:
           parallel-finished: true


### PR DESCRIPTION
As seen in this [GH Actions run](https://github.com/UI5/cli/actions/runs/20137761530/job/57796474383?pr=1243), the Coveralls servers can be down very easily. 

This adds `continue-on-error` to the coverage upload step too (previously only on coverage calculation steps)

