### PR TITLE
refactor(builder): Use only /resources of sap.ui.core for library preload generation

### DIFF
--- a/packages/builder/lib/tasks/bundlers/generateLibraryPreload.js
+++ b/packages/builder/lib/tasks/bundlers/generateLibraryPreload.js
@@ -271,7 +271,9 @@ export default async function({workspace, taskUtil, options: {skipBundles = [], 
 		return moduleBundler({options, resources});
 	};
 
-	return nonDbgWorkspace.byGlob("/**/*.{js,json,xml,html,properties,library,js.map}").then(async (resources) => {
+	return nonDbgWorkspace.byGlob(
+		"/resources/**/*.{js,json,xml,html,properties,library,js.map}"
+	).then(async (resources) => {
 		// Find all libraries and create a library-preload.js bundle
 
 		let p = Promise.resolve();
@@ -299,8 +301,8 @@ export default async function({workspace, taskUtil, options: {skipBundles = [], 
 							return !taskUtil.getTag(resource, taskUtil.STANDARD_TAGS.HasDebugVariant);
 						}
 					});
-					unoptimizedResources =
-						await unoptimizedWorkspace.byGlob("/**/*.{js,json,xml,html,properties,library,js.map}");
+					unoptimizedResources = await unoptimizedWorkspace.byGlob(
+						"/resources/**/*.{js,json,xml,html,properties,library,js.map}");
 
 					unoptimizedModuleNameMapping = createModuleNameMapping({
 						resources: unoptimizedResources,

--- a/packages/builder/test/lib/tasks/bundlers/generateLibraryPreload.js
+++ b/packages/builder/test/lib/tasks/bundlers/generateLibraryPreload.js
@@ -150,7 +150,7 @@ test.serial("generateLibraryPreload", async (t) => {
 
 	t.is(workspace.byGlob.callCount, 2,
 		"workspace.byGlob should have been called twice");
-	t.deepEqual(workspace.byGlob.getCall(0).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(0).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
 	t.deepEqual(workspace.byGlob.getCall(1).args, ["/resources/**/.library"],
 		"workspace.byGlob should have been called with expected pattern");
@@ -461,7 +461,7 @@ test.serial("generateLibraryPreload for sap.ui.core (w/o ui5loader.js)", async (
 
 	t.is(workspace.byGlob.callCount, 2,
 		"workspace.byGlob should have been called twice");
-	t.deepEqual(workspace.byGlob.getCall(0).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(0).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
 	t.deepEqual(workspace.byGlob.getCall(1).args, ["/resources/**/.library"],
 		"workspace.byGlob should have been called with expected pattern");
@@ -521,9 +521,9 @@ test.serial("generateLibraryPreload for sap.ui.core (/w ui5loader.js)", async (t
 
 	t.is(workspace.byGlob.callCount, 3,
 		"workspace.byGlob should have been called three times");
-	t.deepEqual(workspace.byGlob.getCall(0).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(0).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
-	t.deepEqual(workspace.byGlob.getCall(1).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(1).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
 	t.deepEqual(workspace.byGlob.getCall(2).args, ["/resources/**/.library"],
 		"workspace.byGlob should have been called with expected pattern");
@@ -947,9 +947,9 @@ test.serial("generateLibraryPreload for sap.ui.core with old specVersion defined
 
 	t.is(workspace.byGlob.callCount, 3,
 		"workspace.byGlob should have been called three times");
-	t.deepEqual(workspace.byGlob.getCall(0).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(0).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
-	t.deepEqual(workspace.byGlob.getCall(1).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(1).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
 	t.deepEqual(workspace.byGlob.getCall(2).args, ["/resources/**/.library"],
 		"workspace.byGlob should have been called with expected pattern");
@@ -1486,7 +1486,7 @@ test.serial("generateLibraryPreload for sap.ui.core with own bundle configuratio
 
 	t.is(workspace.byGlob.callCount, 2,
 		"workspace.byGlob should have been called twice");
-	t.deepEqual(workspace.byGlob.getCall(0).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(0).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
 	t.deepEqual(workspace.byGlob.getCall(1).args, ["/resources/**/.library"],
 		"workspace.byGlob should have been called with expected pattern");
@@ -1677,7 +1677,7 @@ test.serial("generateLibraryPreload for sap.ui.core with own bundle configuratio
 
 	t.is(workspace.byGlob.callCount, 2,
 		"workspace.byGlob should have been called twice");
-	t.deepEqual(workspace.byGlob.getCall(0).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(0).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
 	t.deepEqual(workspace.byGlob.getCall(1).args, ["/resources/**/.library"],
 		"workspace.byGlob should have been called with expected pattern");
@@ -1805,7 +1805,7 @@ test.serial("generateLibraryPreload with excludes", async (t) => {
 
 	t.is(workspace.byGlob.callCount, 2,
 		"workspace.byGlob should have been called twice");
-	t.deepEqual(workspace.byGlob.getCall(0).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(0).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
 	t.deepEqual(workspace.byGlob.getCall(1).args, ["/resources/**/.library"],
 		"workspace.byGlob should have been called with expected pattern");
@@ -1939,9 +1939,9 @@ test.serial("generateLibraryPreload for sap.ui.core (/w ui5loader.js), UI5 Versi
 
 	t.is(workspace.byGlob.callCount, 3,
 		"workspace.byGlob should have been called three times");
-	t.deepEqual(workspace.byGlob.getCall(0).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(0).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
-	t.deepEqual(workspace.byGlob.getCall(1).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
+	t.deepEqual(workspace.byGlob.getCall(1).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
 	t.deepEqual(workspace.byGlob.getCall(2).args, ["/resources/**/.library"],
 		"workspace.byGlob should have been called with expected pattern");


### PR DESCRIPTION
Adjust the glob pattern to exclude test-resources