### PR TITLE
build(deps-dev): Bump preact from 10.27.2 to 10.28.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16425,9 +16425,9 @@
 			"license": "MIT"
 		},
 		"node_modules/preact": {
-			"version": "10.27.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
-			"integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+			"version": "10.28.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
+			"integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",


### PR DESCRIPTION
It's a transitive dependency.

Fixes: https://github.com/UI5/cli/actions/runs/20982805757/job/60311139695