### PR TITLE
refactor(project): Add internal flag to skip writing resources to dist

### DIFF
--- a/packages/project/lib/build/ProjectBuilder.js
+++ b/packages/project/lib/build/ProjectBuilder.js
@@ -251,8 +251,8 @@ class ProjectBuilder {
 					await projectBuildContext.getTaskRunner().runTasks();
 					this.#log.endProjectBuild(projectName, projectType);
 				}
-				if (!requestedProjects.includes(projectName)) {
-					// Project has not been requested
+				if (!requestedProjects.includes(projectName) || !!process.env.UI5_BUILD_NO_WRITE_DEST) {
+					// Project has not been requested or writing is disabled
 					//	=> Its resources shall not be part of the build result
 					continue;
 				}


### PR DESCRIPTION
By setting `UI5_BUILD_NO_WRITE_DEST` to any truthy value, build results will not be written to the dist directory.

This is useful for testing the build performance, focusing on the build itself rather then the heavy I/O operation of writing the result to disk.