### PR TITLE
ci: Allow for more hyperfine options, env variables

### DIFF
--- a/internal/benchmark/lib/benchmark/BenchmarkSpec.js
+++ b/internal/benchmark/lib/benchmark/BenchmarkSpec.js
@@ -6,7 +6,9 @@ export default class BenchmarkSpec {
 	/**
 	 * @param {object} config - The benchmark configuration object
 	 * @param {string} config.command - The UI5 CLI command to benchmark (e.g., "build")
+	 * @param {string} [config.env] - Optional environment variables to prefix the command with
 	 * @param {string} [config.prepare] - Optional shell command to run before each benchmark
+	 * @param {string} [config.conclude] - Optional shell command to run after each benchmark
 	 * @param {object} config.groups - Map of group keys to group-specific config
 	 * @param {string} config.groups[].name - Display name for this benchmark in the group
 	 * @param {string[]} [config.revisions] - Optional list of revision keys this benchmark should run on
@@ -19,8 +21,14 @@ export default class BenchmarkSpec {
 		if (!config.command || typeof config.command !== "string") {
 			throw new Error("Benchmark must have a command string");
 		}
+		if (config.env !== undefined && typeof config.env !== "string") {
+			throw new Error("Benchmark env must be a string if provided");
+		}
 		if (config.prepare !== undefined && typeof config.prepare !== "string") {
 			throw new Error("Benchmark prepare must be a string if provided");
+		}
+		if (config.conclude !== undefined && typeof config.conclude !== "string") {
+			throw new Error("Benchmark conclude must be a string if provided");
 		}
 		if (!config.groups || typeof config.groups !== "object" || Object.keys(config.groups).length === 0) {
 			throw new Error("Benchmark must belong to at least one group");
@@ -53,14 +61,18 @@ export default class BenchmarkSpec {
 
 		this.#index = index;
 		this.#command = config.command;
+		this.#env = config.env || null;
 		this.#prepare = config.prepare || null;
+		this.#conclude = config.conclude || null;
 		this.#groupMemberships = new Map(Object.entries(config.groups));
 		this.#revisionKeys = config.revisions ? [...config.revisions] : null;
 	}
 
 	#index;
 	#command;
+	#env;
 	#prepare;
+	#conclude;
 	#groupMemberships; // Map<groupKey, {name: displayName}>
 	#revisionKeys; // null means all revisions, otherwise array of revision keys
 
@@ -72,8 +84,16 @@ export default class BenchmarkSpec {
 		return this.#command;
 	}
 
+	get env() {
+		return this.#env;
+	}
+
 	get prepare() {
 		return this.#prepare;
+	}
+
+	get conclude() {
+		return this.#conclude;
 	}
 
 	get groupMemberships() {

--- a/internal/benchmark/lib/services/ExecutionPlanner.js
+++ b/internal/benchmark/lib/services/ExecutionPlanner.js
@@ -24,7 +24,9 @@ export default class ExecutionPlanner {
 	 * BenchmarkExecution = {
 	 *   index: number,
 	 *   command: string,
+	 *   env: string|null,
 	 *   prepare: string|null,
+	 *   conclude: string|null,
 	 *   groupMemberships: Array<{groupKey: string, displayName: string}>
 	 * }
 	 */
@@ -58,7 +60,9 @@ export default class ExecutionPlanner {
 					revisionPlan.benchmarks.push({
 						index: benchmark.index,
 						command: benchmark.command,
+						env: benchmark.env,
 						prepare: benchmark.prepare,
+						conclude: benchmark.conclude,
 						groupMemberships
 					});
 				}
@@ -96,8 +100,14 @@ export default class ExecutionPlanner {
 					.map((gm) => `${gm.groupKey}: "${gm.displayName}"`)
 					.join(", ");
 				summary += `      [${benchmark.index}] ui5 ${benchmark.command}`;
+				if (benchmark.env) {
+					summary += ` [env: ${benchmark.env}]`;
+				}
 				if (benchmark.prepare) {
 					summary += ` (prepare: ${benchmark.prepare})`;
+				}
+				if (benchmark.conclude) {
+					summary += ` (conclude: ${benchmark.conclude})`;
 				}
 				summary += `\n        Groups: ${groupNames}\n`;
 			}

--- a/internal/benchmark/lib/services/HyperfineRunner.js
+++ b/internal/benchmark/lib/services/HyperfineRunner.js
@@ -66,10 +66,16 @@ export default class HyperfineRunner {
 			// Add each benchmark as a separate command to hyperfine
 			for (const benchmark of benchmarks) {
 				const commandName = this.#buildCommandName(name, revisionKey, benchmark);
-				const fullCommand = `node ${this.#ui5CliPath} ${benchmark.command}`;
+				let env = "";
+				if (benchmark.env) {
+					env += `${benchmark.env} `;
+				}
+				const fullCommand = `${env}node ${this.#ui5CliPath} ${benchmark.command}`;
 
 				// Add prepare command (empty string if none)
 				args.push("--prepare", benchmark.prepare || "");
+				// Add conclude command (empty string if none)
+				args.push("--conclude", benchmark.conclude || "");
 
 				// Add the benchmark command
 				args.push("--command-name", commandName, fullCommand);


### PR DESCRIPTION
Make the `conclude` hyperfine option available for configuration. This hook will be executed after each command.

Add an additional `env` configuration to specify environment variables that will prefix the respective command.