### PR TITLE
docs: Add spacing between code block and caption

### DIFF
--- a/packages/builder/lib/processors/bundlers/moduleBundler.js
+++ b/packages/builder/lib/processors/bundlers/moduleBundler.js
@@ -57,7 +57,9 @@ const log = getLogger("builder:processors:bundlers:moduleBundler");
  *		denote an arbitrary number of characters or folder names.
  * 		Excludes should be marked with a leading exclamation mark '!'. The order of filters is relevant; a later
  *		exclusion overrides an earlier inclusion, and vice versa.
+ *
  * <caption>List of modules as glob patterns that should be in- or excluded</caption>
+ *
  * ```js
  * // Includes everything from "some/path/to/module/",
  * // but excludes the subfolder "some/path/to/module/to/be/excluded/"

--- a/packages/builder/lib/tasks/generateResourcesJson.js
+++ b/packages/builder/lib/tasks/generateResourcesJson.js
@@ -56,6 +56,7 @@ function getCreatorOptions(projectName) {
  * </p>
  *
  * <caption>sample resources.json</caption>
+ *
  * ```js
  * const resourcesJson = {
  * 	"_version": "1.1.0",


### PR DESCRIPTION
This fixes that some code blocks aren't rendered properly in Markdown

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/UI5/cli/blob/main/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/UI5/cli/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/UI5/cli/blob/main/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/UI5/cli/blob/main/docs/Guidelines.md#commit-message-style)
