### PR TITLE
build(deps-dev): Bump minimatch from 10.0.3 to 10.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1933,9 +1933,9 @@
 			}
 		},
 		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+			"integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@isaacs/balanced-match": "^4.0.1"
@@ -14478,12 +14478,12 @@
 			"license": "ISC"
 		},
 		"node_modules/minimatch": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-			"integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+			"integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.0"
+				"@isaacs/brace-expansion": "^5.0.1"
 			},
 			"engines": {
 				"node": "20 || >=22"
@@ -21386,7 +21386,7 @@
 				"globby": "^15.0.0",
 				"graceful-fs": "^4.2.11",
 				"micromatch": "^4.0.8",
-				"minimatch": "^10.0.3",
+				"minimatch": "^10.1.2",
 				"pretty-hrtime": "^1.0.3",
 				"random-int": "^3.1.0"
 			},

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -62,7 +62,7 @@
 		"globby": "^15.0.0",
 		"graceful-fs": "^4.2.11",
 		"micromatch": "^4.0.8",
-		"minimatch": "^10.0.3",
+		"minimatch": "^10.1.2",
 		"pretty-hrtime": "^1.0.3",
 		"random-int": "^3.1.0"
 	},


### PR DESCRIPTION
Resolves alert for security advisory:
https://github.com/advisories/GHSA-7h2j-956f-4vf2
