### PR TITLE
ci(documentation): Improve integrity of documentation build

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -85,6 +85,12 @@ jobs:
       working-directory: internal/documentation
       run: npm run generate-cli-doc
 
+    - name: Vitepress build
+      working-directory: internal/documentation
+      run: |
+        npm run build:vitepress
+        npm run build:assets
+
     - name: Check shrinkwrap integrity
       working-directory: internal/shrinkwrap-extractor
       run: npm run test


### PR DESCRIPTION
Currently, if there's a package update of ceratin documentation dependencies, we cannot be sure whether this can break the vitepress build. 

This integrity test checks exactly this.

An example is https://github.com/UI5/cli/pull/1295