### PR TITLE
ci: Fix vitepress api docs deployment

### DIFF
--- a/.github/workflows/deploy-vitepress-docs.yaml
+++ b/.github/workflows/deploy-vitepress-docs.yaml
@@ -84,8 +84,6 @@ jobs:
                   # Alias route. E.g., next, latest, stable, etc.
                   # For vitepress must be a copy with different config, not a symlink
                   cp -R internal/documentation/dist-${DOC_ALIAS} ./gh-pages/${DOC_ALIAS}/
-                  # Symlink the api docs to avoid duplication
-                  ln -s ../${DOC_VERSION}/api ./gh-pages/${DOC_ALIAS}/api
 
                   # Custom 404 page
                   cp internal/documentation/scripts/resources/custom404.html ./gh-pages/404.html


### PR DESCRIPTION
As the "api" folder is now integrated into vitepress, we can't use a symlink anymore for the version and alias variants.
