### PR TITLE
ci: Add engine compatibility check for PRs

### DIFF
--- a/.github/workflows/engine-compat.yml
+++ b/.github/workflows/engine-compat.yml
@@ -25,6 +25,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NODE_VERSIONS: ${{ inputs.node-versions }}
       run: |
+        # Load nvm (pre-installed on GitHub runners)
         export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh"
 
         PR="${{ github.event.pull_request.number }}"
@@ -32,6 +33,7 @@ jobs:
         FAILED=false
         TABLE="| Node | Result | Incompatible Packages |\n|---|---|---|"
 
+        # Loop through each requested Node version
         IFS=',' read -ra VERSIONS <<< "$NODE_VERSIONS"
         for V in "${VERSIONS[@]}"; do
           V=$(echo "$V" | xargs)  # trim whitespace
@@ -39,12 +41,16 @@ jobs:
           nvm use "$V" > /dev/null 2>&1
           VER=$(node --version)
 
+          # Dry-run install to collect EBADENGINE warnings without actually installing.
+          # awk extracts "package@version (node range)" from multi-line warning blocks.
+          # sort -u deduplicates (npm may warn about the same package multiple times).
           PKGS=$(npm ci --dry-run 2>&1 \
             | awk -F"'" '/EBADENGINE.*package:/{pkg=$2} /EBADENGINE.*node:/{if(pkg){print pkg" (node "$2")"; pkg=""}}' \
             | sort -u | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
 
           if [ -n "$PKGS" ]; then
             FAILED=true
+            # Escape pipe characters so they don't break the markdown table
             SAFE=$(echo "$PKGS" | sed 's/|/\\|/g')
             TABLE="$TABLE\n| $VER | ❌ Fail | $SAFE |"
           else
@@ -52,9 +58,11 @@ jobs:
           fi
         done
 
+        # Build the comment body
         if [ "$FAILED" = true ]; then ICON="❌"; else ICON="✅"; fi
         printf '%s\n## %s Engine Compatibility\n\n%b\n' "$MARKER" "$ICON" "$TABLE" > /tmp/comment.md
 
+        # Update existing comment (matched by HTML marker) or create a new one
         OLD=$(gh api "repos/${{ github.repository }}/issues/${PR}/comments" \
           --jq "[.[] | select(.body | contains(\"$MARKER\"))][0].id" 2>/dev/null || true)
         if [ -n "$OLD" ] && [ "$OLD" != "null" ]; then
@@ -63,6 +71,7 @@ jobs:
           gh pr comment "$PR" --body-file /tmp/comment.md
         fi
 
+        # Add "blocked" label on failure, remove it on success
         if [ "$FAILED" = true ]; then
           gh label create blocked --color D93F0B 2>/dev/null || true
           gh pr edit "$PR" --add-label blocked

--- a/.github/workflows/engine-compat.yml
+++ b/.github/workflows/engine-compat.yml
@@ -1,0 +1,71 @@
+name: Node Packages Engine Compatibility Check
+
+on:
+  workflow_call:
+    inputs:
+      node-versions:
+        description: 'Comma-separated Node.js versions, e.g. 22.20.0, 22, 24.0.0, 24'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  engine-compat:
+    name: Engine compatibility
+    runs-on: ubuntu-24.04
+    steps:
+
+    - uses: actions/checkout@v6
+
+    - name: Check engines and report
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NODE_VERSIONS: ${{ inputs.node-versions }}
+      run: |
+        export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh"
+
+        PR="${{ github.event.pull_request.number }}"
+        MARKER="<!-- engine-compat -->"
+        FAILED=false
+        TABLE="| Node | Result | Incompatible Packages |\n|---|---|---|"
+
+        IFS=',' read -ra VERSIONS <<< "$NODE_VERSIONS"
+        for V in "${VERSIONS[@]}"; do
+          V=$(echo "$V" | xargs)  # trim whitespace
+          nvm install "$V" --no-progress > /dev/null 2>&1
+          nvm use "$V" > /dev/null 2>&1
+          VER=$(node --version)
+
+          PKGS=$(npm ci --dry-run 2>&1 \
+            | awk -F"'" '/EBADENGINE.*package:/{pkg=$2} /EBADENGINE.*node:/{if(pkg){print pkg" (node "$2")"; pkg=""}}' \
+            | sort -u | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
+
+          if [ -n "$PKGS" ]; then
+            FAILED=true
+            SAFE=$(echo "$PKGS" | sed 's/|/\\|/g')
+            TABLE="$TABLE\n| $VER | ❌ Fail | $SAFE |"
+          else
+            TABLE="$TABLE\n| $VER | ✅ Pass | — |"
+          fi
+        done
+
+        if [ "$FAILED" = true ]; then ICON="❌"; else ICON="✅"; fi
+        printf '%s\n## %s Engine Compatibility\n\n%b\n' "$MARKER" "$ICON" "$TABLE" > /tmp/comment.md
+
+        OLD=$(gh api "repos/${{ github.repository }}/issues/${PR}/comments" \
+          --jq "[.[] | select(.body | contains(\"$MARKER\"))][0].id" 2>/dev/null || true)
+        if [ -n "$OLD" ] && [ "$OLD" != "null" ]; then
+          gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$OLD" -F body=@/tmp/comment.md
+        else
+          gh pr comment "$PR" --body-file /tmp/comment.md
+        fi
+
+        if [ "$FAILED" = true ]; then
+          gh label create blocked --color D93F0B 2>/dev/null || true
+          gh pr edit "$PR" --add-label blocked
+        else
+          gh pr edit "$PR" --remove-label blocked 2>/dev/null || true
+        fi

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -24,8 +24,14 @@ jobs:
       with:
         node-version: 22.20.0
 
+    - name: Engine compatibility check
+      if: github.event_name == 'pull_request'
+      uses: ./.github/workflows/engine-compat.yml
+      with:
+        node-versions: '22.20.0, 22, 24.0.0, 24'
+
     - name: Install dependencies
-      run: npm ci --engine-strict # --engine-strict is used to fail-fast if deps require node versions unsupported by the repo
+      run: npm ci
 
     - name: Check package.json "engines" consistency
       run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -10,8 +10,15 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
+  engine-compat:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/engine-compat.yml
+    with:
+      node-versions: '22.20.0, 22, 24.0.0, 24'
+
   test:
     name: General checks and tests
     runs-on: ubuntu-24.04
@@ -23,12 +30,6 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 22.20.0
-
-    - name: Engine compatibility check
-      if: github.event_name == 'pull_request'
-      uses: ./.github/workflows/engine-compat.yml
-      with:
-        node-versions: '22.20.0, 22, 24.0.0, 24'
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
Reusable workflow that runs `npm ci --dry-run` against boundary Node versions and posts a consolidated PR comment with incompatible packages. Adds `blocked` label on failure with detailed Github Bot comment with the failing packages and their node engines.

Approaches evaluated:

- `npm ci --engine-strict`: runtime check only, stops at first failure, misses remaining incompatible packages
- `check-engine` (npm): only checks running Node against root engines, doesn't inspect dependency tree
- `check-engine-light` (npm): range-vs-range via semver.subset(), but v0.x, only 4 releases, unstable
- `ls-engines` (npm): range-vs-range capable, but v0.x, 17-month release gap, 7 prod dependencies

**Selected approach:** single-job nvm loop using `npm ci --dry-run` (without `--engine-strict`). Reports all EBADENGINE warnings as a table in one PR comment. No extra dependencies, no matrix, no artifacts — just shell and tools already on the runner. 
**Note:** NVM seems to come bundled in the GitHub action images

PoC of the implementation: https://github.com/d3xter666/test-ci/pull/1
JIRA: CPOUI5FOUNDATION-1225
