### PR TITLE
feat(builder): Add annotation changes in the flexibilityBundle

### DIFF
--- a/packages/builder/lib/processors/bundlers/flexChangesBundler.js
+++ b/packages/builder/lib/processors/bundlers/flexChangesBundler.js
@@ -7,6 +7,8 @@ import {createResource} from "@ui5/fs/resourceFactory";
  * @module @ui5/builder/processors/bundlers/flexChangesBundler
  */
 
+const noChangeBundleChangeTypes = [];
+
 /**
  * Bundles all supplied changes.
  *
@@ -77,11 +79,22 @@ export default function({resources, options: {pathPrefix, hasFlexBundleVersion},
 			}
 		});
 
-		if (!hasFlexBundleVersion && (compVariants.length != 0 || variants.length != 0 || variantChanges.length != 0 ||
-				variantDependentControlChanges.length != 0 || variantManagementChanges.length != 0)) {
-			throw new Error(
-				"There are some control variant changes in the changes folder. This only works with a " +
-				"minUI5Version 1.73.0. Please update the minUI5Version in the manifest.json to 1.73.0 or higher");
+		if (!hasFlexBundleVersion) {
+			if (compVariants.length != 0 || variants.length != 0 || variantChanges.length != 0 ||
+					variantDependentControlChanges.length != 0 || variantManagementChanges.length != 0) {
+				throw new Error(
+					"There are some control variant changes in the changes folder. This only works with a " +
+					"minUI5Version 1.73.0. Please update the minUI5Version in the manifest.json to 1.73.0 or higher");
+			}
+
+			const bundleContainsNoChangeBundleChangeTypes =
+				changes.some((change) => noChangeBundleChangeTypes.includes(change.changeType));
+
+			if (bundleContainsNoChangeBundleChangeTypes) {
+				throw new Error(
+					"There are some changes types in the changes folderonly working with a " +
+					"minUI5Version 1.73.0. Please update the minUI5Version in the manifest.json to 1.73.0 or higher");
+			}
 		}
 		// create changes-bundle.json
 		if (!hasFlexBundleVersion) {

--- a/packages/builder/test/lib/processors/bundlers/flexChangesBundler.js
+++ b/packages/builder/test/lib/processors/bundlers/flexChangesBundler.js
@@ -111,6 +111,61 @@ test("flexChangesBundler with 2 changes", async (t) => {
 	t.deepEqual(parsedContent, flexBundle, "Result must contain the content");
 });
 
+test("includes annotation_changes in flexibility-bundle when hasFlexBundleVersion = true", async (t) => {
+	const change = {
+		"fileName": "id_annotation_change",
+		"fileType": "annotation_changes",
+		"changeType": "annotationUpdate",
+		"reference": "test.Component",
+		"packageName": "$TMP",
+		"content": {},
+		"selector": {"id": "a"},
+		"layer": "CUSTOMER",
+		"creation": "2020-01-01T00:00:00.000Z",
+		"support": {"generator": "g", "service": "", "user": "", "sapui5Version": "1.75.0"}
+	};
+
+	const resources = [{
+		name: "flexChange",
+		getBuffer: async () => JSON.stringify(change)
+	}];
+
+	const options = {pathPrefix: "/mypath", hasFlexBundleVersion: true};
+	const aResult = await flexChangesBundler({resources, options});
+	t.is(aResult.length, 1);
+	const parsed = JSON.parse(await aResult[0].getString());
+	t.true(Array.isArray(parsed.annotationChanges));
+	t.is(parsed.annotationChanges.length, 1, "annotation_changes should be included in flex bundle");
+	// ensure the item is preserved
+	t.deepEqual(parsed.annotationChanges[0], change);
+});
+
+test("annotation_changes triggers error when hasFlexBundleVersion = false", async (t) => {
+	const change = {
+		"fileName": "id_annotation_change2",
+		"fileType": "annotation_changes",
+		"changeType": "annotationUpdate",
+		"reference": "test.Component",
+		"packageName": "$TMP",
+		"content": {},
+		"selector": {"id": "a"},
+		"layer": "CUSTOMER",
+		"creation": "2020-01-01T00:00:00.000Z",
+		"support": {"generator": "g", "service": "", "user": "", "sapui5Version": "1.51.0"}
+	};
+
+	const resources = [{
+		name: "flexChange",
+		getBuffer: async () => JSON.stringify(change)
+	}];
+
+	const options = {pathPrefix: "/mypath", hasFlexBundleVersion: false};
+	await t.throwsAsync(
+		() => flexChangesBundler({resources, options}),
+		{message: /1\.73/}
+	);
+});
+
 test("flexChangesBundler has ctrl_variant and hasFlexBundleVersion = true", async (t) => {
 	const changeList = [
 		{


### PR DESCRIPTION
To also reflect annotation changes done on oData models within the development, these changes have to be part of the flexibility bundle to be applied at runtime.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/UI5/cli/blob/main/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/UI5/cli/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/UI5/cli/blob/main/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/UI5/cli/blob/main/docs/Guidelines.md#commit-message-style)
