### PR TITLE
fix(builder): Improve error ESM handling

### DIFF
--- a/packages/builder/lib/lbt/bundle/Builder.js
+++ b/packages/builder/lib/lbt/bundle/Builder.js
@@ -597,10 +597,11 @@ class BundleBuilder {
 		}
 	}
 
-	writeRequires(section) {
+	async writeRequires(section) {
 		if (section.modules.length === 0) {
 			return;
 		}
+
 		this.outW.ensureNewLine();
 		if (section.async === false) {
 			section.modules.forEach( (module) => {
@@ -767,7 +768,7 @@ async function rewriteDefine({moduleName, moduleContent, moduleSourceMap}) {
 	} catch (e) {
 		log.error(`Error while parsing ${moduleName}: ${e.message}`);
 		log.verbose(e.stack);
-		return {};
+		return null;
 	}
 
 	if ( ast.type === Syntax.Program &&

--- a/packages/builder/lib/lbt/bundle/ResolvedBundleDefinition.js
+++ b/packages/builder/lib/lbt/bundle/ResolvedBundleDefinition.js
@@ -67,6 +67,7 @@ class ResolvedBundleDefinition {
 						return pool.getModuleInfo(submodule).then(
 							(subinfo) => {
 								if (!bundleInfo.subModules.includes(subinfo.name) &&
+									subinfo.format !== ModuleInfo.Format.ESM &&
 									(!subinfo.requiresTopLevelScope ||
 										(subinfo.requiresTopLevelScope && allowStringBundling))) {
 									bundleInfo.addSubModule(subinfo);

--- a/packages/builder/lib/lbt/bundle/Resolver.js
+++ b/packages/builder/lib/lbt/bundle/Resolver.js
@@ -4,6 +4,7 @@
 
 import topologicalSort from "../graph/topologicalSort.js";
 import {getRendererName} from "../UI5ClientConstants.js";
+import ModuleInfo from "../resources/ModuleInfo.js";
 import ResourceFilterList from "../resources/ResourceFilterList.js";
 import {SectionType} from "./BundleDefinition.js";
 import ResolvedBundleDefinition from "./ResolvedBundleDefinition.js";
@@ -134,6 +135,16 @@ class BundleResolver {
 						.then( ({resource, isBundle, decomposable}) => {
 							const dependencyInfo = resource && resource.info;
 							let promises = [];
+
+							// Skip ESM modules — they can't be bundled
+							if (resource?.info?.format === ModuleInfo.Format.ESM) {
+								log.error(
+									`Module ${resourceName} is an ECMAScript Module (ESM), ` +
+									`which is not supported for bundling. ` +
+									`The module will be skipped.`
+								);
+								return;
+							}
 
 							if ( isBundle && !decomposable ) {
 								resource.info.subModules.forEach(

--- a/packages/builder/lib/lbt/resources/ModuleInfo.js
+++ b/packages/builder/lib/lbt/resources/ModuleInfo.js
@@ -25,7 +25,8 @@ const CONDITIONAL = 2;
 const Format = {
 	UI5_LEGACY: "ui5-declare",
 	UI5_DEFINE: "ui5-define",
-	AMD: "amd"
+	AMD: "amd",
+	ESM: "esm"
 };
 
 /**

--- a/packages/builder/lib/lbt/resources/ResourcePool.js
+++ b/packages/builder/lib/lbt/resources/ResourcePool.js
@@ -64,6 +64,9 @@ async function determineDependencyInfo(resource, rawInfo, pool) {
 		} catch (err) {
 			log.verbose(`Failed to parse ${resource.name}: ${err.message}`);
 			log.verbose(err.stack);
+			if (err.message.includes("'import' and 'export' may appear only with 'sourceType: module'")) {
+				info.format = ModuleInfo.Format.ESM;
+			}
 		}
 		if (ast) {
 			try {

--- a/packages/builder/lib/lbt/resources/ResourcePool.js
+++ b/packages/builder/lib/lbt/resources/ResourcePool.js
@@ -62,7 +62,7 @@ async function determineDependencyInfo(resource, rawInfo, pool) {
 		try {
 			ast = parseJS(code, {comment: true});
 		} catch (err) {
-			log.error(`Failed to parse ${resource.name}: ${err.message}`);
+			log.verbose(`Failed to parse ${resource.name}: ${err.message}`);
 			log.verbose(err.stack);
 		}
 		if (ast) {
@@ -243,4 +243,3 @@ class ResourcePool {
 }
 
 export default ResourcePool;
-

--- a/packages/builder/lib/lbt/resources/ResourcePool.js
+++ b/packages/builder/lib/lbt/resources/ResourcePool.js
@@ -64,7 +64,8 @@ async function determineDependencyInfo(resource, rawInfo, pool) {
 		} catch (err) {
 			log.verbose(`Failed to parse ${resource.name}: ${err.message}`);
 			log.verbose(err.stack);
-			if (err.message.includes("'import' and 'export' may appear only with 'sourceType: module'")) {
+			if (err.message.includes("'import' and 'export' may appear only with 'sourceType: module'") ||
+				err.message.includes("Cannot use 'import.meta' outside a module")) {
 				info.format = ModuleInfo.Format.ESM;
 			}
 		}

--- a/packages/builder/test/lib/lbt/bundle/Builder.js
+++ b/packages/builder/test/lib/lbt/bundle/Builder.js
@@ -27,7 +27,12 @@ test.beforeEach(async (t) => {
 	t.context.BuilderWithStub = await esmock("../../../../lib/lbt/bundle/Builder", {
 		"@ui5/logger": {
 			getLogger: () => myLoggerInstance
-		}
+		},
+		"../../../../lib/lbt/bundle/Resolver": await esmock("../../../../lib/lbt/bundle/Resolver", {
+			"@ui5/logger": {
+				getLogger: () => myLoggerInstance
+			}
+		}),
 	});
 });
 
@@ -2728,6 +2733,18 @@ test("rewriteDefine (with other module name as template literal)", async (t) => 
 	t.is(moduleSourceMap, undefined);
 });
 
+test("rewriteDefine (with ESM content)", async (t) => {
+	const {rewriteDefine} = __localFunctions__;
+
+	const result = await rewriteDefine({
+		moduleName: "my/test/esm-module.js",
+		moduleContent: `import foo from "./foo.js"; export default foo;`,
+		moduleSourceMap: undefined
+	});
+
+	t.is(result, null, "rewriteDefine should return null for ESM content that can't be parsed");
+});
+
 test("getSourceMapForModule: Source map resource named after module resource (no sourceMappingURL)", async (t) => {
 	const originalSourceMap = {
 		"version": 3,
@@ -3249,13 +3266,127 @@ test.serial("integration: createBundle with ESM module in preload section", asyn
 	t.is(oResult.name, "esm-bundle.js");
 	t.truthy(oResult.content, "Bundle should be created");
 
-	// An error should be logged since this ESM module is actually being bundled
-	// and the content can't be properly rewritten to sap.ui.predefine
+	// ESM module should not appear in the bundle content at all
+	t.false(oResult.content.includes("undefined"),
+		"Bundle should not contain 'undefined' string from ESM module");
+	t.false(oResult.content.includes("import foo"),
+		"Bundle should not contain ESM import statement");
+	t.false(oResult.content.includes("export default"),
+		"Bundle should not contain ESM export statement");
+	t.false(oResult.content.includes("esm-module"),
+		"Bundle should not contain ESM module name in preload content");
+
+	// ESM module should not be in bundleInfo subModules
+	t.false(oResult.bundleInfo.subModules.includes("my/app/thirdparty/esm-module.js"),
+		"ESM module should not be listed as subModule in bundleInfo");
+
+	// An error should be logged about ESM not being supported
 	t.true(errorLogStub.callCount >= 1,
-		"log.error should be called for ESM module that can't be bundled");
+		"log.error should be called for ESM module");
 	t.true(
 		errorLogStub.getCalls().some((call) =>
-			call.args[0].includes("my/app/thirdparty/esm-module.js")
+			call.args[0].includes("my/app/thirdparty/esm-module.js") &&
+			call.args[0].includes("ECMAScript Module (ESM)")
+		),
+		"log.error should mention the ESM module name and that it's an ESM module"
+	);
+});
+
+test.serial("integration: createBundle with ESM module in raw section", async (t) => {
+	const {BuilderWithStub, errorLogStub} = t.context;
+	const pool = new ResourcePool();
+
+	pool.addResource({
+		name: "my/app/thirdparty/esm-module.js",
+		getPath: () => "my/app/thirdparty/esm-module.js",
+		string: function() {
+			return this.buffer();
+		},
+		buffer: async () => `import foo from "./foo.js"; export default foo;`
+	});
+
+	const bundleDefinition = {
+		name: `esm-raw-bundle.js`,
+		defaultFileTypes: [".js"],
+		sections: [{
+			mode: "raw",
+			filters: [
+				"my/app/thirdparty/esm-module.js"
+			]
+		}]
+	};
+
+	const builder = new BuilderWithStub(pool);
+	const oResult = await builder.createBundle(bundleDefinition, {
+		numberOfParts: 1,
+		decorateBootstrapModule: false
+	});
+
+	t.is(oResult.name, "esm-raw-bundle.js");
+	t.truthy(oResult.content, "Bundle should be created");
+
+	// ESM module should not appear in the bundle content
+	t.false(oResult.content.includes("import foo"),
+		"Bundle should not contain ESM import statement");
+	t.false(oResult.content.includes("export default"),
+		"Bundle should not contain ESM export statement");
+
+	// An error should be logged
+	t.true(errorLogStub.callCount >= 1,
+		"log.error should be called for ESM module in raw section");
+	t.true(
+		errorLogStub.getCalls().some((call) =>
+			call.args[0].includes("my/app/thirdparty/esm-module.js") &&
+			call.args[0].includes("ECMAScript Module (ESM)")
+		),
+		"log.error should mention the ESM module name"
+	);
+});
+
+test.serial("integration: createBundle with ESM module in require section", async (t) => {
+	const {BuilderWithStub, errorLogStub} = t.context;
+	const pool = new ResourcePool();
+
+	pool.addResource({
+		name: "my/app/thirdparty/esm-module.js",
+		getPath: () => "my/app/thirdparty/esm-module.js",
+		string: function() {
+			return this.buffer();
+		},
+		buffer: async () => `import foo from "./foo.js"; export default foo;`
+	});
+
+	const bundleDefinition = {
+		name: `esm-require-bundle.js`,
+		defaultFileTypes: [".js"],
+		sections: [{
+			mode: "require",
+			filters: [
+				"my/app/thirdparty/esm-module.js"
+			]
+		}]
+	};
+
+	const builder = new BuilderWithStub(pool);
+	const oResult = await builder.createBundle(bundleDefinition, {
+		numberOfParts: 1,
+		decorateBootstrapModule: false
+	});
+
+	t.is(oResult.name, "esm-require-bundle.js");
+	t.truthy(oResult.content, "Bundle should be created");
+
+	// ESM module should not appear in require calls
+	t.false(oResult.content.includes("esm-module"),
+		"Bundle should not contain require call for ESM module");
+
+	// An error should be logged
+	t.true(errorLogStub.callCount >= 1,
+		"log.error should be called for ESM module in require section");
+	t.true(
+		errorLogStub.getCalls().some((call) =>
+			call.args[0].includes("my/app/thirdparty/esm-module.js") &&
+			call.args[0].includes("ECMAScript Module (ESM)")
 		),
 		"log.error should mention the ESM module name"
 	);

--- a/packages/builder/test/lib/lbt/bundle/Builder.js
+++ b/packages/builder/test/lib/lbt/bundle/Builder.js
@@ -3214,3 +3214,49 @@ test.serial("getEffectiveUi5MajorVersion with cache", async (t) => {
 	t.is(getEffectiveUi5MajorVersionUI5v2WithCacheSpy.getCall(1).returnValue, 2, "UI5 Major Version correctly determined");
 	t.is(mySemverParseSpy.callCount, 1, "semver.parse has been called only once");
 });
+
+test.serial("integration: createBundle with ESM module in preload section", async (t) => {
+	const {BuilderWithStub, errorLogStub} = t.context;
+	const pool = new ResourcePool();
+
+	pool.addResource({
+		name: "my/app/thirdparty/esm-module.js",
+		getPath: () => "my/app/thirdparty/esm-module.js",
+		string: function() {
+			return this.buffer();
+		},
+		buffer: async () => `import foo from "./foo.js"; export default foo;`
+	});
+
+	const bundleDefinition = {
+		name: `esm-bundle.js`,
+		defaultFileTypes: [".js"],
+		sections: [{
+			mode: "preload",
+			name: "preload-section",
+			filters: [
+				"my/app/thirdparty/esm-module.js"
+			]
+		}]
+	};
+
+	const builder = new BuilderWithStub(pool);
+	const oResult = await builder.createBundle(bundleDefinition, {
+		numberOfParts: 1,
+		decorateBootstrapModule: true
+	});
+
+	t.is(oResult.name, "esm-bundle.js");
+	t.truthy(oResult.content, "Bundle should be created");
+
+	// An error should be logged since this ESM module is actually being bundled
+	// and the content can't be properly rewritten to sap.ui.predefine
+	t.true(errorLogStub.callCount >= 1,
+		"log.error should be called for ESM module that can't be bundled");
+	t.true(
+		errorLogStub.getCalls().some((call) =>
+			call.args[0].includes("my/app/thirdparty/esm-module.js")
+		),
+		"log.error should mention the ESM module name"
+	);
+});

--- a/packages/builder/test/lib/lbt/resources/ResourcePool.js
+++ b/packages/builder/test/lib/lbt/resources/ResourcePool.js
@@ -405,6 +405,7 @@ test("getModuleInfo: determineDependencyInfo for ESM js resource", async (t) => 
 
 	t.is(info.name, "thirdparty/esm-module.js", "name should be set");
 	t.is(info.size, esmCode.length, "size should be set");
+	t.is(info.format, "esm", "format should be set to ESM");
 	t.deepEqual(info.dependencies, [], "no dependencies should be found since parsing failed");
 
 	t.is(errorLogStub.callCount, 0, "log.error should not be called for ESM parse failure");

--- a/packages/builder/test/lib/lbt/resources/ResourcePool.js
+++ b/packages/builder/test/lib/lbt/resources/ResourcePool.js
@@ -7,9 +7,20 @@ import esmock from "esmock";
 test.beforeEach(async (t) => {
 	const sinon = t.context.sinon = sinonGlobal.createSandbox();
 	t.context.LibraryFileAnalyzerGetDependencyInfosStub = sinon.stub().returns({});
+	t.context.verboseLogStub = sinon.stub();
+	t.context.errorLogStub = sinon.stub();
+	t.context.loggerInstance = {
+		silly: sinon.stub(),
+		verbose: t.context.verboseLogStub,
+		warn: sinon.stub(),
+		error: t.context.errorLogStub,
+	};
 	t.context.ResourcePool = await esmock("../../../../lib/lbt/resources/ResourcePool.js", {
 		"../../../../lib/lbt/resources/LibraryFileAnalyzer.js": {
 			getDependencyInfos: t.context.LibraryFileAnalyzerGetDependencyInfosStub
+		},
+		"@ui5/logger": {
+			getLogger: () => t.context.loggerInstance
 		}
 	});
 });
@@ -380,5 +391,30 @@ test.serial("addResource: library and eval raw module info", async (t) => {
 	t.true(actualResourceB.info.requiresTopLevelScope);
 	t.deepEqual(actualResourceB.info.exposedGlobals, ["foo", "bar", "some"],
 		"global names should be known from analsyis step");
+});
+
+test("getModuleInfo: determineDependencyInfo for ESM js resource", async (t) => {
+	const {ResourcePool, verboseLogStub, errorLogStub} = t.context;
+
+	const resourcePool = new ResourcePool();
+	const esmCode = `import foo from "./foo.js"; export default foo;`;
+	const inputJsResource = {name: "thirdparty/esm-module.js", buffer: async () => esmCode};
+	resourcePool.addResource(inputJsResource);
+
+	const info = await resourcePool.getModuleInfo("thirdparty/esm-module.js");
+
+	t.is(info.name, "thirdparty/esm-module.js", "name should be set");
+	t.is(info.size, esmCode.length, "size should be set");
+	t.deepEqual(info.dependencies, [], "no dependencies should be found since parsing failed");
+
+	t.is(errorLogStub.callCount, 0, "log.error should not be called for ESM parse failure");
+	t.true(verboseLogStub.callCount >= 1, "log.verbose should be called");
+	t.true(
+		verboseLogStub.getCalls().some((call) =>
+			call.args[0].includes("Failed to parse thirdparty/esm-module.js") &&
+			call.args[0].includes("'import' and 'export' may appear only with 'sourceType: module'")
+		),
+		"log.verbose should contain the parse error message"
+	);
 });
 

--- a/packages/builder/test/lib/lbt/resources/ResourcePool.js
+++ b/packages/builder/test/lib/lbt/resources/ResourcePool.js
@@ -419,3 +419,131 @@ test("getModuleInfo: determineDependencyInfo for ESM js resource", async (t) => 
 	);
 });
 
+test("getModuleInfo: determineDependencyInfo for ESM js resource using import.meta", async (t) => {
+	const {ResourcePool, verboseLogStub, errorLogStub} = t.context;
+
+	const resourcePool = new ResourcePool();
+	const esmCode = `const url = import.meta.url;`;
+	const inputJsResource = {name: "thirdparty/esm-meta-module.js", buffer: async () => esmCode};
+	resourcePool.addResource(inputJsResource);
+
+	const info = await resourcePool.getModuleInfo("thirdparty/esm-meta-module.js");
+
+	t.is(info.name, "thirdparty/esm-meta-module.js", "name should be set");
+	t.is(info.size, esmCode.length, "size should be set");
+	t.is(info.format, "esm", "format should be set to ESM");
+	t.deepEqual(info.dependencies, [], "no dependencies should be found since parsing failed");
+
+	t.is(errorLogStub.callCount, 0, "log.error should not be called for ESM parse failure");
+	t.true(verboseLogStub.callCount >= 1, "log.verbose should be called");
+	t.true(
+		verboseLogStub.getCalls().some((call) =>
+			call.args[0].includes("Failed to parse thirdparty/esm-meta-module.js") &&
+			call.args[0].includes("Cannot use 'import.meta' outside a module")
+		),
+		"log.verbose should contain the import.meta parse error message"
+	);
+});
+
+test("getModuleInfo: determineDependencyInfo for ESM js resource using side-effect import", async (t) => {
+	const {ResourcePool, errorLogStub} = t.context;
+
+	const resourcePool = new ResourcePool();
+	const esmCode = `import "./side-effect.js";`;
+	const inputJsResource = {name: "thirdparty/esm-side-effect.js", buffer: async () => esmCode};
+	resourcePool.addResource(inputJsResource);
+
+	const info = await resourcePool.getModuleInfo("thirdparty/esm-side-effect.js");
+
+	t.is(info.format, "esm", "format should be set to ESM for side-effect import");
+	t.is(errorLogStub.callCount, 0, "log.error should not be called");
+});
+
+test("getModuleInfo: determineDependencyInfo for ESM js resource using re-export", async (t) => {
+	const {ResourcePool, errorLogStub} = t.context;
+
+	const resourcePool = new ResourcePool();
+	const esmCode = `export { foo } from "./foo.js";`;
+	const inputJsResource = {name: "thirdparty/esm-reexport.js", buffer: async () => esmCode};
+	resourcePool.addResource(inputJsResource);
+
+	const info = await resourcePool.getModuleInfo("thirdparty/esm-reexport.js");
+
+	t.is(info.format, "esm", "format should be set to ESM for re-export");
+	t.is(errorLogStub.callCount, 0, "log.error should not be called");
+});
+
+test("getModuleInfo: determineDependencyInfo for ESM js resource using export *", async (t) => {
+	const {ResourcePool, errorLogStub} = t.context;
+
+	const resourcePool = new ResourcePool();
+	const esmCode = `export * from "./foo.js";`;
+	const inputJsResource = {name: "thirdparty/esm-export-star.js", buffer: async () => esmCode};
+	resourcePool.addResource(inputJsResource);
+
+	const info = await resourcePool.getModuleInfo("thirdparty/esm-export-star.js");
+
+	t.is(info.format, "esm", "format should be set to ESM for export *");
+	t.is(errorLogStub.callCount, 0, "log.error should not be called");
+});
+
+test("getModuleInfo: determineDependencyInfo for ESM js resource using named export", async (t) => {
+	const {ResourcePool, errorLogStub} = t.context;
+
+	const resourcePool = new ResourcePool();
+	const esmCode = `export const myVar = 42;`;
+	const inputJsResource = {name: "thirdparty/esm-named-export.js", buffer: async () => esmCode};
+	resourcePool.addResource(inputJsResource);
+
+	const info = await resourcePool.getModuleInfo("thirdparty/esm-named-export.js");
+
+	t.is(info.format, "esm", "format should be set to ESM for named export");
+	t.is(errorLogStub.callCount, 0, "log.error should not be called");
+});
+
+test("getModuleInfo: determineDependencyInfo for ESM js resource using import.meta.resolve", async (t) => {
+	const {ResourcePool, errorLogStub} = t.context;
+
+	const resourcePool = new ResourcePool();
+	const esmCode = `const resolved = import.meta.resolve("./foo.js");`;
+	const inputJsResource = {name: "thirdparty/esm-meta-resolve.js", buffer: async () => esmCode};
+	resourcePool.addResource(inputJsResource);
+
+	const info = await resourcePool.getModuleInfo("thirdparty/esm-meta-resolve.js");
+
+	t.is(info.format, "esm", "format should be set to ESM for import.meta.resolve");
+	t.is(errorLogStub.callCount, 0, "log.error should not be called");
+});
+
+test("getModuleInfo: determineDependencyInfo for ESM js resource using top-level await", async (t) => {
+	const {ResourcePool} = t.context;
+
+	// Top-level await is ESM-only syntax, but the parser produces a generic "Unexpected token"
+	// error that cannot be reliably distinguished from actual syntax errors.
+	// Therefore, the module is NOT detected as ESM.
+	const resourcePool = new ResourcePool();
+	const esmCode = `const x = await Promise.resolve(1);`;
+	const inputJsResource = {name: "thirdparty/esm-top-level-await.js", buffer: async () => esmCode};
+	resourcePool.addResource(inputJsResource);
+
+	const info = await resourcePool.getModuleInfo("thirdparty/esm-top-level-await.js");
+
+	t.is(info.format, undefined, "format should not be set for top-level await (not detectable)");
+});
+
+test("getModuleInfo: determineDependencyInfo for js resource using dynamic import()", async (t) => {
+	const {ResourcePool, errorLogStub} = t.context;
+
+	// Dynamic import() is valid in both scripts and modules, so it parses successfully
+	// and should NOT be flagged as ESM.
+	const resourcePool = new ResourcePool();
+	const code = `const m = import("./foo.js");`;
+	const inputJsResource = {name: "thirdparty/dynamic-import.js", buffer: async () => code};
+	resourcePool.addResource(inputJsResource);
+
+	const info = await resourcePool.getModuleInfo("thirdparty/dynamic-import.js");
+
+	t.not(info.format, "esm", "format should not be ESM for dynamic import()");
+	t.is(errorLogStub.callCount, 0, "log.error should not be called");
+});
+


### PR DESCRIPTION
Up-port of https://github.com/SAP/ui5-builder/pull/1203

- **fix(builder): Reduce noise from ESM parse errors**
- **fix(builder): Skip ESM modules during bundling and log errors**
- **fix(builder): Also detect import.meta as ESM indicator**
