### PR TITLE
ci: Remove engine-strict flag from vitepress workflow

### DIFF
--- a/.github/workflows/deploy-vitepress-docs.yaml
+++ b/.github/workflows/deploy-vitepress-docs.yaml
@@ -41,7 +41,7 @@ jobs:
             - name: Setup Pages
               uses: actions/configure-pages@v6
             - name: Install dependencies
-              run: npm ci --engine-strict
+              run: npm ci
             - name: Fetch gh-pages branch
               run: git fetch origin gh-pages --depth=1
             - name: generate CLI doc


### PR DESCRIPTION
Dependency "licensee" (not relevant to this workflow) requires Node
v22.22
