### PR TITLE
fix: Install deps for audit workflow

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -23,5 +23,8 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Use audit-ci
         run: npm run audit


### PR DESCRIPTION
Imporoves the GitHub Action by running the missed `npm ci` before executing the `audit-ci` script.
Adds on top of https://github.com/UI5/cli/commit/ad1be64d029168472889ad7471b49460ea7a5561