### PR TITLE
fix(server): correct early-return condition in addCustomMiddleware

### DIFF
--- a/packages/server/lib/middleware/MiddlewareManager.js
+++ b/packages/server/lib/middleware/MiddlewareManager.js
@@ -245,7 +245,7 @@ class MiddlewareManager {
 	async addCustomMiddleware() {
 		const project = this.graph.getRoot();
 		const projectCustomMiddleware = project.getCustomMiddleware();
-		if (!projectCustomMiddleware.length === 0) {
+		if (projectCustomMiddleware.length === 0) {
 			return; // No custom middleware defined
 		}
 

--- a/packages/server/test/lib/server/middleware/MiddlewareManager.js
+++ b/packages/server/test/lib/server/middleware/MiddlewareManager.js
@@ -376,6 +376,78 @@ test("addCustomMiddleware: No custom middleware defined", async (t) => {
 	t.is(graph.getExtension.callCount, 0, "graph#getExtension was not called");
 });
 
+// Regression test for https://github.com/UI5/cli/issues/647
+// The condition `!projectCustomMiddleware.length === 0` was always false due to operator
+// precedence (`!` applies first, yielding a boolean, which is never strictly equal to 0).
+// This caused addCustomMiddleware() to iterate even when the array was empty instead of
+// returning early, which could lead to unexpected processing.
+test("addCustomMiddleware: Empty custom middleware array returns early without processing", async (t) => {
+	const {sinon} = t.context;
+	// Explicitly test that an empty array (length === 0) causes an early return.
+	const getCustomMiddlewareStub = sinon.stub().returns([]);
+	const graph = {
+		getRoot: () => {
+			return {
+				getName: () => "my project",
+				getCustomMiddleware: getCustomMiddlewareStub
+			};
+		},
+		getExtension: sinon.stub(),
+	};
+	const middlewareManager = new MiddlewareManager({
+		graph,
+		rootProject: "root project",
+		resources: {
+			all: "I",
+			rootProject: "like",
+			dependencies: "ponies"
+		}
+	});
+	const addMiddlewareStub = sinon.stub(middlewareManager, "addMiddleware").resolves();
+
+	// Should not throw and should not call addMiddleware or getExtension
+	await middlewareManager.addCustomMiddleware();
+
+	t.is(getCustomMiddlewareStub.callCount, 1, "getCustomMiddleware was called once");
+	t.is(addMiddlewareStub.callCount, 0,
+		"addMiddleware was NOT called when custom middleware list is empty");
+	t.is(graph.getExtension.callCount, 0,
+		"graph#getExtension was NOT called when custom middleware list is empty");
+});
+
+test("addCustomMiddleware: Non-empty custom middleware array is processed correctly", async (t) => {
+	const {sinon} = t.context;
+	// Verify that a non-empty array is still processed (the fix did not break the normal flow)
+	const graph = {
+		getRoot: () => {
+			return {
+				getName: () => "my project",
+				getCustomMiddleware: () => [{
+					name: "my custom middleware A",
+					afterMiddleware: "serveIndex"
+				}]
+			};
+		},
+		getExtension: sinon.stub().returns("extension"),
+	};
+	const middlewareManager = new MiddlewareManager({
+		graph,
+		rootProject: "root project",
+		resources: {
+			all: "I",
+			rootProject: "like",
+			dependencies: "ponies"
+		}
+	});
+	const addMiddlewareStub = sinon.stub(middlewareManager, "addMiddleware").resolves();
+	await middlewareManager.addCustomMiddleware();
+
+	t.is(addMiddlewareStub.callCount, 1, "addMiddleware was called once for the one custom middleware");
+	t.is(graph.getExtension.callCount, 1, "graph#getExtension was called once");
+	t.is(graph.getExtension.firstCall.firstArg, "my custom middleware A",
+		"graph#getExtension was called with the correct middleware name");
+});
+
 test("addCustomMiddleware: Unknown custom middleware", async (t) => {
 	const {sinon} = t.context;
 	const graph = {


### PR DESCRIPTION
The condition !projectCustomMiddleware.length === 0 was always false due to JavaScript operator precedence: the ! unary operator converts length to a boolean first (yielding true for an empty array), and true === 0 is always false. As a result the early-return guard never fired, so addCustomMiddleware() always iterated the array even when it was empty.

Fixed it by using the correct expression projectCustomMiddleware.length === 0.

Add two regression tests that explicitly cover:
- an empty custom middleware array causes an early return (no calls to addMiddleware or getExtension)
- a non-empty custom middleware array is still processed correctly

Fixes https://github.com/UI5/cli/issues/647
