### PR TITLE
Resolve minor linter findings

### DIFF
--- a/packages/builder/lib/lbt/calls/SapUiDefine.js
+++ b/packages/builder/lib/lbt/calls/SapUiDefine.js
@@ -39,7 +39,7 @@ class SapUiDefineCall {
 			this.dependencies = this.dependencyArray.elements.map( (elem) => {
 				const value = getStringValue(elem);
 				if ( !value ) {
-					throw new TypeError();
+					throw new TypeError(`dependency element is not a string literal in module ${this.name}`);
 				}
 				return resolveRelativeRequireJSName(this.name, value);
 			});

--- a/packages/server/lib/middleware/MiddlewareManager.js
+++ b/packages/server/lib/middleware/MiddlewareManager.js
@@ -245,7 +245,7 @@ class MiddlewareManager {
 	async addCustomMiddleware() {
 		const project = this.graph.getRoot();
 		const projectCustomMiddleware = project.getCustomMiddleware();
-		if (!projectCustomMiddleware.length === 0) {
+		if (projectCustomMiddleware.length === 0) {
 			return; // No custom middleware defined
 		}
 


### PR DESCRIPTION
Prompted by https://github.com/UI5/cli/pull/1391 (credit to @EdrilanBerisha) I ran the "recommended" rules of https://github.com/sindresorhus/eslint-plugin-unicorn (which includes a ["no-negation-in-equality-check"](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-negation-in-equality-check.md) rule that is missing from eslint).

There are a lot of stylistic findings, and only two seem to have actual impact at runtime. Hence **not** adding unicorn as a plugin but fixing the two identified problems.