### PR TITLE
ci: Harden workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.auto_merge == null }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.auto_merge == null }}
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/deploy-vitepress-docs.yaml
+++ b/.github/workflows/deploy-vitepress-docs.yaml
@@ -28,11 +28,13 @@ jobs:
             GIT_COMMITTER_NAME: "OpenUI5 Bot"
             GIT_COMMITTER_EMAIL: "openui5@sap.com"
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            REPO_NAME: ${{ github.event.repository.name }}
         steps:
             - name: Checkout
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
+                  persist-credentials: false
             - name: Setup Node
               uses: actions/setup-node@v6
               with:
@@ -57,10 +59,10 @@ jobs:
               working-directory: internal/documentation
               run: |
                 # The base output
-                npm run build:vitepress -- --base="/${{ github.event.repository.name }}/${DOC_VERSION}/"
+                npm run build:vitepress -- --base="/${REPO_NAME}/${DOC_VERSION}/"
                 npm run build:assets -- ./dist
                 # The alias output
-                npm run build:vitepress -- --base="/${{ github.event.repository.name }}/${DOC_ALIAS}/" --outDir="dist-${DOC_ALIAS}"
+                npm run build:vitepress -- --base="/${REPO_NAME}/${DOC_ALIAS}/" --outDir="dist-${DOC_ALIAS}"
                 npm run build:assets -- ./dist-${DOC_ALIAS}
             - name: Build Schema
               working-directory: internal/documentation

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,13 +5,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:


### PR DESCRIPTION
- Scope release-please contents/pull-requests write permissions to the
  release-please job; publish jobs only need id-token: write
- Disable persist-credentials on checkouts that don't push to git
- Move repository.name interpolation into env var to avoid template
  injection in run blocks
- Replace spoofable github.actor check in dependabot-auto-merge with
  github.event.pull_request.user.login. Note: spoofing the dependabot
  actor alone is not sufficient to trigger the auto-merge step. The
  dependabot/fetch-metadata action only emits outputs for genuine
  dependabot PRs, so the merge step's check on
  steps.metadata.outputs.update-type would no-op on a spoofed run. The
  change closes the gap defensively.
