### PR TITLE
refactor(project): Add TaskDefinitions and task-level build signatures

### DIFF
--- a/internal/documentation/.vitepress/config.ts
+++ b/internal/documentation/.vitepress/config.ts
@@ -293,7 +293,7 @@ function guide() {
 				}]
 			}
 
-			for (let file of fs.readdirSync(path.join("docs", "api"))) {
+			for (let file of fs.readdirSync(path.join("docs", "api")).sort()) {
 				file = file.replace(".md", "");
 				const treePath = file.replace("module-", "").split("_");
 				appendToTree(tree, file, treePath, 0);
@@ -302,8 +302,21 @@ function guide() {
 			function appendToTree(tree, file, treePath, index) {
 				// If it's the last leaf
 				if (treePath.length - 1 === index) {
+					const text = treePath[index].replace("module-", "");
+					// If a branch with the same name was already created (e.g. processing
+					// "@ui5_logger_Logger" before "module-@ui5_logger"), attach this leaf
+					// as "main" inside it instead of pushing a duplicate sibling.
+					for (const treeItem of tree.items) {
+						if (treeItem.text === text && !treeItem.link) {
+							treeItem.items.unshift({
+								text: "main",
+								link: "/api/" + file
+							});
+							return;
+						}
+					}
 					tree.items.push({
-						text: treePath[index].replace("module-", ""),
+						text,
 						link: "/api/" + file
 					});
 					return;
@@ -314,6 +327,20 @@ function guide() {
 				// Checks if the leaf does already exist and adds new leafs to it
 				for (const treeItem of tree.items) {
 					if (treeItem.text === treePath[index]) {
+						// If the existing entry is a leaf (no items) — created earlier from a
+						// "module-..." file with the same name as this branch — promote it to
+						// a branch and move the existing leaf to "main" inside it, so the new
+						// child can be attached. Without this the recursive push would crash
+						// on the missing items array (filesystem-order-dependent on Linux CI).
+						if (!treeItem.items) {
+							const existingLink = treeItem.link;
+							delete treeItem.link;
+							treeItem.collapsed = treeItem.text !== "@ui5";
+							treeItem.items = [{
+								text: "main",
+								link: existingLink
+							}];
+						}
 						appendToTree(treeItem, file, treePath, index+1);
 						found = true;
 						break;

--- a/packages/project/lib/build/TaskDefinitions.js
+++ b/packages/project/lib/build/TaskDefinitions.js
@@ -82,7 +82,7 @@ export default class TaskDefinitions {
 		return tasks;
 	}
 
-	async _addCustomTask(taskDef, tasks) {
+	_addCustomTask(taskDef, tasks) {
 		const project = this.#project;
 		const graph = this.#graph;
 

--- a/packages/project/lib/build/TaskDefinitions.js
+++ b/packages/project/lib/build/TaskDefinitions.js
@@ -1,0 +1,189 @@
+import crypto from "node:crypto";
+import {getLogger} from "@ui5/logger";
+
+export default class TaskDefinitions {
+	#graph;
+	#project;
+	#taskUtil;
+	#taskRepository;
+	#standardTasks;
+	#customTasks;
+	#initializingTasks;
+
+	constructor(graph, project, taskUtil, taskRepository) {
+		this.#graph = graph;
+		this.#project = project;
+		this.#taskUtil = taskUtil;
+		this.#taskRepository = taskRepository;
+	}
+
+	/**
+	 * Initializes the task list based on the project type
+	 *
+	 * This method:
+	 * 1. Loads the appropriate build definition for the project type
+	 * 2. Adds all standard tasks from the definition
+	 * 3. Adds any custom tasks configured for the project
+	 *
+	 * @returns {Promise<void>}
+	 */
+	async _initTasks() {
+		if (this.#initializingTasks) {
+			return this.#initializingTasks;
+		}
+		this.#initializingTasks = this._doInitTasks();
+		return this.#initializingTasks;
+	}
+
+	async _doInitTasks() {
+		let buildDefinition;
+
+		switch (this.#project.getType()) {
+		case "application":
+			buildDefinition = "./definitions/application.js";
+			break;
+		case "library":
+			buildDefinition = "./definitions/library.js";
+			break;
+		case "component":
+			buildDefinition = "./definitions/component.js";
+			break;
+		case "module":
+			buildDefinition = "./definitions/module.js";
+			break;
+		case "theme-library":
+			buildDefinition = "./definitions/themeLibrary.js";
+			break;
+		default:
+			throw new Error(`Unknown project type ${this.#project.getType()}`);
+		}
+
+		const {default: getStandardTasks} = await import(buildDefinition);
+
+		this.#standardTasks = getStandardTasks({
+			project: this.#project,
+			taskUtil: this.#taskUtil,
+			getTask: this.#taskRepository.getTask
+		});
+
+		this.#customTasks = await this._getCustomTasks(this.#project, this.#taskUtil);
+	}
+
+	async _getCustomTasks() {
+		const projectCustomTasks = this.#project.getCustomTasks();
+		if (!projectCustomTasks || projectCustomTasks.length === 0) {
+			return new Map(); // No custom tasks defined
+		}
+		const tasks = new Map();
+		for (let i = 0; i < projectCustomTasks.length; i++) {
+			// Add tasks one-by-one to keep order as defined in project configuration
+			await this._addCustomTask(projectCustomTasks[i], tasks);
+		}
+		return tasks;
+	}
+
+	async _addCustomTask(taskDef, tasks) {
+		const project = this.#project;
+		const graph = this.#graph;
+
+		if (!taskDef.name) {
+			throw new Error(`Missing name for custom task in configuration of project ${project.getName()}`);
+		}
+		if (taskDef.beforeTask && taskDef.afterTask) {
+			throw new Error(`Custom task definition ${taskDef.name} of project ${project.getName()} ` +
+				`defines both "beforeTask" and "afterTask" parameters. Only one must be defined.`);
+		}
+		if ((this.#standardTasks.size || tasks.size) && !taskDef.beforeTask && !taskDef.afterTask) {
+			// Iff there are tasks configured, beforeTask or afterTask must be given
+			throw new Error(`Custom task definition ${taskDef.name} of project ${project.getName()} ` +
+				`defines neither a "beforeTask" nor an "afterTask" parameter. One must be defined.`);
+		}
+		const standardTaskNames = this.#taskRepository.getAllTaskNames();
+		if (standardTaskNames.includes(taskDef.name)) {
+			throw new Error(
+				`Custom task configuration of project ${project.getName()} ` +
+				`references standard task ${taskDef.name}. Only custom tasks must be provided here.`);
+		}
+
+		let newTaskName = taskDef.name;
+		if (this.#standardTasks.has(newTaskName) || tasks.has(newTaskName)) {
+			// Task is already known
+			// => add a suffix to allow for multiple configurations of the same task
+			let suffixCounter = 1;
+			while (this.#standardTasks.has(newTaskName) || tasks.has(newTaskName)) {
+				suffixCounter++; // Start at 2
+				newTaskName = `${taskDef.name}--${suffixCounter}`;
+			}
+		}
+		const task = graph.getExtension(taskDef.name);
+		if (!task) {
+			throw new Error(
+				`Could not find custom task ${taskDef.name}, referenced by project ${project.getName()} ` +
+				`in project graph with root node ${graph.getRoot().getName()}`);
+		}
+
+		tasks.set(newTaskName, {taskDef, task});
+	}
+
+	async getBuildSignatures() {
+		await this._initTasks();
+
+		const sigKeys = [];
+		for (const taskDef of this.#standardTasks.values()) {
+			if (taskDef.determineBuildSignature) {
+				const sig = await taskDef.determineBuildSignature();
+				if (sig) {
+					sigKeys.push(sig);
+				}
+			} else {
+				// Fallback to task options
+				sigKeys.push(JSON.stringify(taskDef.options));
+			}
+		}
+
+		const projectName = this.#project.getName();
+		const projectNamespace = this.#project.getNamespace();
+		for (const [taskName, {taskDef, task}] of this.#customTasks) {
+			const specVersion = task.getSpecVersion();
+			const determineBuildSignatureCallback = await task.getDetermineBuildSignatureCallback();
+			if (determineBuildSignatureCallback) {
+				if (specVersion.lt("5.0")) {
+					throw new Error(
+						`Custom task ${taskDef.name} of project ${projectName} uses a ` +
+						`determineBuildSignature callback, which is not supported for tasks with specVersion < 5.0. ` +
+						`Please update the task's specVersion to at least 5.0.`
+					);
+				}
+				const taskUtil = this.#taskUtil.getReadOnlyInterface(specVersion);
+				const log = getLogger(`TaskDefinitions:custom-task:${taskName}`);
+				const sig = await determineBuildSignatureCallback({
+					log,
+					options: {
+						projectName,
+						projectNamespace,
+						configuration: taskDef.configuration,
+						taskName
+					},
+					taskUtil
+				});
+				if (sig) {
+					sigKeys.push(sig);
+				}
+			} else {
+				// Fallback to task configuration
+				sigKeys.push(JSON.stringify(taskDef.configuration));
+			}
+		}
+		const key = sigKeys.join("|");
+		const hash = crypto.createHash("sha256").update(key).digest("hex");
+		return hash;
+	}
+
+	async getTaskDefinitions() {
+		await this._initTasks();
+		return {
+			standardTasks: this.#standardTasks,
+			customTasks: this.#customTasks
+		};
+	}
+}

--- a/packages/project/lib/build/TaskRunner.js
+++ b/packages/project/lib/build/TaskRunner.js
@@ -23,9 +23,11 @@ class TaskRunner {
 	 * @param {@ui5/builder/tasks/taskRepository} parameters.taskRepository Task repository
 	 * @param {@ui5/project/build/ProjectBuilder~BuildConfiguration} parameters.buildConfig
 	 * 			Build configuration
+	 * @param {@ui5/project/build/TaskDefinitions} parameters.taskDefinitions
 	 */
-	constructor({graph, project, log, buildCache, taskUtil, taskRepository, buildConfig}) {
-		if (!graph || !project || !log || !buildCache || !taskUtil || !taskRepository || !buildConfig) {
+	constructor({graph, project, log, buildCache, taskUtil, taskRepository, buildConfig, taskDefinitions}) {
+		if (!graph || !project || !log || !buildCache || !taskUtil || !taskRepository || !buildConfig ||
+			!taskDefinitions) {
 			throw new Error("TaskRunner: One or more mandatory parameters not provided");
 		}
 		this._project = project;
@@ -35,6 +37,7 @@ class TaskRunner {
 		this._buildConfig = buildConfig;
 		this._log = log;
 		this._buildCache = buildCache;
+		this._taskDefinitions = taskDefinitions;
 
 		this._directDependencies = new Set(this._taskUtil.getDependencies());
 	}
@@ -57,42 +60,15 @@ class TaskRunner {
 		this._tasks = Object.create(null);
 		this._taskExecutionOrder = [];
 
-		const project = this._project;
-		let buildDefinition;
+		const {standardTasks, customTasks} = await this._taskDefinitions.getTaskDefinitions();
 
-		switch (project.getType()) {
-		case "application":
-			buildDefinition = "./definitions/application.js";
-			break;
-		case "library":
-			buildDefinition = "./definitions/library.js";
-			break;
-		case "component":
-			buildDefinition = "./definitions/component.js";
-			break;
-		case "module":
-			buildDefinition = "./definitions/module.js";
-			break;
-		case "theme-library":
-			buildDefinition = "./definitions/themeLibrary.js";
-			break;
-		default:
-			throw new Error(`Unknown project type ${project.getType()}`);
+		for (const [taskName, taskDef] of standardTasks) {
+			this._addTask(taskName, taskDef);
 		}
 
-		const {default: getStandardTasks} = await import(buildDefinition);
-
-		const standardTasks = getStandardTasks({
-			project,
-			taskUtil: this._taskUtil,
-			getTask: this._taskRepository.getTask
-		});
-
-		for (const [taskName, params] of standardTasks) {
-			this._addTask(taskName, params);
+		for (const [taskName, {taskDef, task}] of customTasks) {
+			await this._addCustomTask(taskName, taskDef, task);
 		}
-
-		await this._addCustomTasks();
 	}
 
 	/**
@@ -278,79 +254,28 @@ class TaskRunner {
 	}
 
 	/**
-	 * Adds all custom tasks configured for the project
-	 *
-	 * Processes custom tasks in the order they are defined in the project configuration.
-	 *
-	 * @returns {Promise<void>}
-	 */
-	async _addCustomTasks() {
-		const projectCustomTasks = this._project.getCustomTasks();
-		if (!projectCustomTasks || projectCustomTasks.length === 0) {
-			return; // No custom tasks defined
-		}
-		for (let i = 0; i < projectCustomTasks.length; i++) {
-			// Add tasks one-by-one to keep order as defined in project configuration
-			await this._addCustomTask(projectCustomTasks[i]);
-		}
-	}
-	/**
 	 * Adds a single custom task to the task execution order
 	 *
 	 * This method:
-	 * 1. Validates the custom task definition
-	 * 2. Loads the task extension from the project graph
-	 * 3. Determines required dependencies via callback if provided
-	 * 4. Creates a wrapper function for the custom task
-	 * 5. Inserts the task at the correct position based on beforeTask/afterTask configuration
+	 * 1. Determines required dependencies via callback if provided
+	 * 2. Creates a wrapper function for the custom task
+	 * 3. Inserts the task at the correct position based on beforeTask/afterTask configuration
 	 *
+	 * Validation and de-duplication of the task name (incl. resolving the task extension from
+	 * the project graph) is handled upstream by {@link TaskDefinitions#_addCustomTask}.
+	 *
+	 * @param {string} taskName Unique task name
 	 * @param {object} taskDef Custom task definition from project configuration
 	 * @param {string} taskDef.name Name of the custom task
 	 * @param {string} [taskDef.beforeTask] Name of task to insert before
 	 * @param {string} [taskDef.afterTask] Name of task to insert after
 	 * @param {object} [taskDef.configuration] Custom task configuration
+	 * @param {object} task Task extension instance resolved by TaskDefinitions
 	 * @returns {Promise<void>}
 	 */
-	async _addCustomTask(taskDef) {
+	async _addCustomTask(taskName, taskDef, task) {
 		const project = this._project;
-		const graph = this._graph;
 		const taskUtil = this._taskUtil;
-
-		if (!taskDef.name) {
-			throw new Error(`Missing name for custom task in configuration of project ${project.getName()}`);
-		}
-		if (taskDef.beforeTask && taskDef.afterTask) {
-			throw new Error(`Custom task definition ${taskDef.name} of project ${project.getName()} ` +
-				`defines both "beforeTask" and "afterTask" parameters. Only one must be defined.`);
-		}
-		if (this._taskExecutionOrder.length && !taskDef.beforeTask && !taskDef.afterTask) {
-			// Iff there are tasks configured, beforeTask or afterTask must be given
-			throw new Error(`Custom task definition ${taskDef.name} of project ${project.getName()} ` +
-				`defines neither a "beforeTask" nor an "afterTask" parameter. One must be defined.`);
-		}
-		const standardTasks = this._taskRepository.getAllTaskNames();
-		if (standardTasks.includes(taskDef.name)) {
-			throw new Error(
-				`Custom task configuration of project ${project.getName()} ` +
-				`references standard task ${taskDef.name}. Only custom tasks must be provided here.`);
-		}
-
-		let newTaskName = taskDef.name;
-		if (this._tasks[newTaskName]) {
-			// Task is already known
-			// => add a suffix to allow for multiple configurations of the same task
-			let suffixCounter = 1;
-			while (this._tasks[newTaskName]) {
-				suffixCounter++; // Start at 2
-				newTaskName = `${taskDef.name}--${suffixCounter}`;
-			}
-		}
-		const task = graph.getExtension(taskDef.name);
-		if (!task) {
-			throw new Error(
-				`Could not find custom task ${taskDef.name}, referenced by project ${project.getName()} ` +
-				`in project graph with root node ${graph.getRoot().getName()}`);
-		}
 
 		// Tasks can provide an optional callback to tell build process which dependencies they require
 		const requiredDependenciesCallback = await task.getRequiredDependenciesCallback();
@@ -400,7 +325,7 @@ class TaskRunner {
 				projectName: project.getName(),
 				projectNamespace: project.getNamespace(),
 				configuration: taskDef.configuration,
-				taskName: newTaskName
+				taskName
 			};
 
 			requiredDependencies = await requiredDependenciesCallback(dependencyDeterminationParams);
@@ -424,12 +349,12 @@ class TaskRunner {
 			supportsDifferentialBuilds = true;
 		}
 
-		this._tasks[newTaskName] = {
+		this._tasks[taskName] = {
 			task: this._createCustomTaskWrapper({
 				task,
 				project,
 				taskUtil,
-				taskName: newTaskName,
+				taskName,
 				taskConfiguration: taskDef.configuration,
 				provideDependenciesReader,
 				supportsDifferentialBuilds,
@@ -448,22 +373,22 @@ class TaskRunner {
 			if (refTaskIdx === -1) {
 				if (this._taskRepository.getRemovedTaskNames().includes(refTaskName)) {
 					throw new Error(
-						`Standard task ${refTaskName}, referenced by custom task ${newTaskName} ` +
+						`Standard task ${refTaskName}, referenced by custom task ${taskName} ` +
 						`in project ${project.getName()}, ` +
 						`has been removed in this version of UI5 CLI and can't be referenced anymore. ` +
 						`Please see the migration guide at https://ui5.github.io/cli/updates/migrate-v3/`);
 				}
-				throw new Error(`Could not find task ${refTaskName}, referenced by custom task ${newTaskName}, ` +
+				throw new Error(`Could not find task ${refTaskName}, referenced by custom task ${taskName}, ` +
 					`to be scheduled for project ${project.getName()}`);
 			}
 			if (taskDef.afterTask) {
 				// Insert after index of referenced task
 				refTaskIdx++;
 			}
-			this._taskExecutionOrder.splice(refTaskIdx, 0, newTaskName);
+			this._taskExecutionOrder.splice(refTaskIdx, 0, taskName);
 		} else {
 			// There is no task configured so far. Just add the custom task
-			this._taskExecutionOrder.push(newTaskName);
+			this._taskExecutionOrder.push(taskName);
 		}
 	}
 

--- a/packages/project/lib/build/TaskRunner.js
+++ b/packages/project/lib/build/TaskRunner.js
@@ -262,7 +262,8 @@ class TaskRunner {
 	 * 3. Inserts the task at the correct position based on beforeTask/afterTask configuration
 	 *
 	 * Validation and de-duplication of the task name (incl. resolving the task extension from
-	 * the project graph) is handled upstream by {@link TaskDefinitions#_addCustomTask}.
+	 * the project graph) is handled upstream by
+	 * [TaskDefinitions#_addCustomTask]{@link @ui5/project/build/TaskDefinitions#_addCustomTask}.
 	 *
 	 * @param {string} taskName Unique task name
 	 * @param {object} taskDef Custom task definition from project configuration

--- a/packages/project/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/lib/build/cache/ProjectBuildCache.js
@@ -90,6 +90,7 @@ export default class ProjectBuildCache {
 	 * Creates a new ProjectBuildCache instance
 	 * Use ProjectBuildCache.create() instead
 	 *
+	 * @public
 	 * @param {@ui5/project/specifications/Project} project Project instance
 	 * @param {string} buildSignature Build signature for the current build
 	 * @param {object} cacheManager Cache manager instance for reading/writing cache data

--- a/packages/project/lib/build/definitions/library.js
+++ b/packages/project/lib/build/definitions/library.js
@@ -9,6 +9,7 @@ import {enhanceBundlesWithDefaults} from "../../validation/validator.js";
  * @param {object} parameters.project
  * @param {object} parameters.taskUtil
  * @param {Function} parameters.getTask
+ * @returns {Map<string, object>} Map of task names and their configuration
  */
 export default function({project, taskUtil, getTask}) {
 	const tasks = new Map();
@@ -44,6 +45,9 @@ export default function({project, taskUtil, getTask}) {
 
 	tasks.set("generateJsdoc", {
 		requiresDependencies: true,
+		determineBuildSignature: async () => {
+			return project.getVersion();
+		},
 		taskFunction: async ({workspace, dependencies, taskUtil, options}) => {
 			const patterns = ["/resources/**/*.js"];
 			// Add excludes

--- a/packages/project/lib/build/helpers/BuildContext.js
+++ b/packages/project/lib/build/helpers/BuildContext.js
@@ -116,7 +116,7 @@ class BuildContext {
 		}
 		const project = this._graph.getProject(projectName);
 		const projectBuildContext = await ProjectBuildContext.create(
-			this, project, await this.getCacheManager(), this._buildSignatureBase);
+			this, project, this._buildSignatureBase, await this.getCacheManager());
 		this._projectBuildContexts.set(projectName, projectBuildContext);
 		return projectBuildContext;
 	}

--- a/packages/project/lib/build/helpers/ProjectBuildContext.js
+++ b/packages/project/lib/build/helpers/ProjectBuildContext.js
@@ -58,12 +58,13 @@ class ProjectBuildContext {
 	 * Factory method to create and fully initialize a ProjectBuildContext instance.
 	 *
 	 * Performs the async work that the constructor cannot: collecting task build signatures,
-	 * computing the project build signature, and constructing the {@link ProjectBuildCache}.
+	 * computing the project build signature, and constructing the
+	 * [ProjectBuildCache]{@link @ui5/project/build/cache/ProjectBuildCache}.
 	 * This is the only supported way to obtain a usable instance for production code; callers
-	 * must not call {@link getBuildSignature} or {@link getBuildCache} on an instance created
+	 * must not call {@link #getBuildSignature} or {@link #getBuildCache} on an instance created
 	 * via `new` directly.
 	 *
-	 * Source index initialization is deliberately kept separate ({@link initSourceIndex}) so
+	 * Source index initialization is deliberately kept separate ({@link #initSourceIndex}) so
 	 * multiple project contexts can initialize their indices in parallel.
 	 *
 	 * @param {@ui5/project/build/helpers/BuildContext} buildContext Overall build context

--- a/packages/project/lib/build/helpers/ProjectBuildContext.js
+++ b/packages/project/lib/build/helpers/ProjectBuildContext.js
@@ -1,6 +1,7 @@
 import ProjectBuildLogger from "@ui5/logger/internal/loggers/ProjectBuild";
 import TaskUtil from "./TaskUtil.js";
 import TaskRunner from "../TaskRunner.js";
+import TaskDefinitions from "../TaskDefinitions.js";
 import {getProjectSignature} from "./getBuildSignature.js";
 import ProjectBuildCache from "../cache/ProjectBuildCache.js";
 
@@ -12,15 +13,18 @@ import ProjectBuildCache from "../cache/ProjectBuildCache.js";
  */
 class ProjectBuildContext {
 	/**
-	 * Creates a new ProjectBuildContext instance
+	 * Creates a new ProjectBuildContext instance.
+	 *
+	 * Note: This constructor only performs synchronous wiring (logger, TaskUtil, TaskDefinitions).
+	 * It does NOT compute the build signature or initialize the build cache, since both depend on
+	 * `TaskDefinitions#getBuildSignatures()`, which is async. Use the static
+	 * {@link ProjectBuildContext.create} factory to obtain a fully initialized instance.
 	 *
 	 * @param {@ui5/project/build/helpers/BuildContext} buildContext Overall build context
 	 * @param {@ui5/project/specifications/Project} project Project instance to build
-	 * @param {string} buildSignature Signature of the build configuration
-	 * @param {@ui5/project/build/cache/ProjectBuildCache} buildCache Build cache instance
 	 * @throws {Error} If 'buildContext' or 'project' is missing
 	 */
-	constructor(buildContext, project, buildSignature, buildCache) {
+	constructor(buildContext, project) {
 		if (!buildContext) {
 			throw new Error(`Missing parameter 'buildContext'`);
 		}
@@ -34,37 +38,50 @@ class ProjectBuildContext {
 			projectName: project.getName(),
 			projectType: project.getType()
 		});
-		this._buildSignature = buildSignature;
-		this._buildCache = buildCache;
+
+		this._taskUtil = new TaskUtil({
+			projectBuildContext: this
+		});
+		this._taskDefinitions = new TaskDefinitions(
+			buildContext.getGraph(), project, this._taskUtil, buildContext.getTaskRepository());
+
+		// Populated by ProjectBuildContext.create()
+		this._buildSignature = null;
+		this._buildCache = null;
+
 		this._queues = {
 			cleanup: []
 		};
 	}
 
 	/**
-	 * Factory method to create and initialize a ProjectBuildContext instance
+	 * Factory method to create and fully initialize a ProjectBuildContext instance.
 	 *
-	 * This is the recommended way to create a ProjectBuildContext as it ensures
-	 * proper initialization of the build signature and cache.
+	 * Performs the async work that the constructor cannot: collecting task build signatures,
+	 * computing the project build signature, and constructing the {@link ProjectBuildCache}.
+	 * This is the only supported way to obtain a usable instance for production code; callers
+	 * must not call {@link getBuildSignature} or {@link getBuildCache} on an instance created
+	 * via `new` directly.
+	 *
+	 * Source index initialization is deliberately kept separate ({@link initSourceIndex}) so
+	 * multiple project contexts can initialize their indices in parallel.
 	 *
 	 * @param {@ui5/project/build/helpers/BuildContext} buildContext Overall build context
 	 * @param {@ui5/project/specifications/Project} project Project instance to build
-	 * @param {object} cacheManager Cache manager instance
 	 * @param {string} baseSignature Base signature for the build
+	 * @param {object} cacheManager Cache manager instance
 	 * @returns {Promise<@ui5/project/build/helpers/ProjectBuildContext>} Initialized context instance
 	 */
-	static async create(buildContext, project, cacheManager, baseSignature) {
-		const buildSignature = getProjectSignature(
-			baseSignature, project, buildContext.getGraph(), buildContext.getTaskRepository());
+	static async create(buildContext, project, baseSignature, cacheManager) {
+		const ctx = new ProjectBuildContext(buildContext, project);
+
+		const taskSignatures = await ctx._taskDefinitions.getBuildSignatures();
+		ctx._buildSignature = getProjectSignature(
+			baseSignature, taskSignatures, project, buildContext.getGraph(), buildContext.getTaskRepository());
+
 		const cacheMode = buildContext.getBuildConfig().cache;
-		const buildCache = await ProjectBuildCache.create(
-			project, buildSignature, cacheManager, cacheMode);
-		return new ProjectBuildContext(
-			buildContext,
-			project,
-			buildSignature,
-			buildCache
-		);
+		ctx._buildCache = new ProjectBuildCache(project, ctx._buildSignature, cacheManager, cacheMode);
+		return ctx;
 	}
 
 	/**
@@ -192,18 +209,9 @@ class ProjectBuildContext {
 	/**
 	 * Gets the task utility instance for this build context
 	 *
-	 * Creates a TaskUtil instance on first access and caches it for subsequent calls.
-	 * The TaskUtil provides helper functions for tasks during execution.
-	 *
 	 * @returns {@ui5/project/build/helpers/TaskUtil} Task utility instance
 	 */
 	getTaskUtil() {
-		if (!this._taskUtil) {
-			this._taskUtil = new TaskUtil({
-				projectBuildContext: this
-			});
-		}
-
 		return this._taskUtil;
 	}
 
@@ -224,7 +232,8 @@ class ProjectBuildContext {
 				taskUtil: this.getTaskUtil(),
 				graph: this._buildContext.getGraph(),
 				taskRepository: this._buildContext.getTaskRepository(),
-				buildConfig: this._buildContext.getBuildConfig()
+				buildConfig: this._buildContext.getBuildConfig(),
+				taskDefinitions: this._taskDefinitions
 			});
 		}
 		return this._taskRunner;

--- a/packages/project/lib/build/helpers/TaskUtil.js
+++ b/packages/project/lib/build/helpers/TaskUtil.js
@@ -348,6 +348,50 @@ class TaskUtil {
 		}
 		return baseInterface;
 	}
+
+	getReadOnlyInterface(specVersion) {
+		if (specVersion.lte("2.1")) {
+			// Tasks defining specVersion <= 2.1 do not have access to any TaskUtil APIs
+			return undefined;
+		}
+
+		const baseInterface = {
+			STANDARD_TAGS: this.STANDARD_TAGS,
+		};
+		bindFunctions(this, baseInterface, [
+			"getTag", "isRootProject"
+		]);
+
+		if (specVersion.gte("3.0")) {
+			// getProject function, returning an interfaced project instance
+			baseInterface.getProject = (projectName) => {
+				const project = this.getProject(projectName);
+				const baseProjectInterface = {};
+				bindFunctions(project, baseProjectInterface, [
+					"getType", "getName", "getVersion", "getNamespace",
+					"getRootReader", "getReader", "getRootPath", "getSourcePath",
+					"getCustomConfiguration", "isFrameworkProject", "getFrameworkName",
+					"getFrameworkVersion", "getFrameworkDependencies"
+				]);
+				return baseProjectInterface;
+			};
+			// getDependencies function, returning an array of project names
+			baseInterface.getDependencies = (projectName) => {
+				return this.getDependencies(projectName);
+			};
+
+			baseInterface.resourceFactory = Object.create(null);
+			[
+				// Once new functions get added, extract this array into a variable
+				// and enhance based on spec version once new functions get added
+				"createResource", "createReaderCollection", "createReaderCollectionPrioritized",
+				"createFilterReader", "createLinkReader", "createFlatReader",
+			].forEach((factoryFunction) => {
+				baseInterface.resourceFactory[factoryFunction] = this.resourceFactory[factoryFunction];
+			});
+		}
+		return baseInterface;
+	}
 }
 
 function bindFunctions(sourceObject, targetObject, funcNames) {

--- a/packages/project/lib/build/helpers/getBuildSignature.js
+++ b/packages/project/lib/build/helpers/getBuildSignature.js
@@ -16,13 +16,14 @@ export function getBaseSignature(buildConfig) {
  *
  * @private
  * @param {string} baseSignature
+ * @param {string} taskSignatures
  * @param {@ui5/project/lib/Project} project The project to create the cache integrity for
  * @param {@ui5/project/lib/graph/ProjectGraph} graph The project graph
  * @param {@ui5/builder/tasks/taskRepository} taskRepository The task repository (used to determine the effective
  * versions of ui5-builder and ui5-fs)
  */
-export function getProjectSignature(baseSignature, project, graph, taskRepository) {
-	const key = baseSignature + project.getId() + JSON.stringify(project.getConfig()) +
+export function getProjectSignature(baseSignature, taskSignatures, project, graph, taskRepository) {
+	const key = baseSignature + taskSignatures + project.getId() + JSON.stringify(project.getConfig()) +
 		JSON.stringify(taskRepository.getVersions());
 	// TODO: Add signatures of relevant custom tasks
 

--- a/packages/project/lib/build/helpers/getBuildSignature.js
+++ b/packages/project/lib/build/helpers/getBuildSignature.js
@@ -1,5 +1,7 @@
 import crypto from "node:crypto";
 
+// Increment signature version to invalidate all existing build signatures
+// (e.g. after making a change that impacts build contents)
 const BUILD_SIG_VERSION = "0";
 
 export function getBaseSignature(buildConfig) {
@@ -20,7 +22,8 @@ export function getBaseSignature(buildConfig) {
  * versions of ui5-builder and ui5-fs)
  */
 export function getProjectSignature(baseSignature, project, graph, taskRepository) {
-	const key = baseSignature + project.getId() + JSON.stringify(project.getConfig());
+	const key = baseSignature + project.getId() + JSON.stringify(project.getConfig()) +
+		JSON.stringify(taskRepository.getVersions());
 	// TODO: Add signatures of relevant custom tasks
 
 	// Create a hash for all metadata

--- a/packages/project/lib/specifications/extensions/Task.js
+++ b/packages/project/lib/specifications/extensions/Task.js
@@ -21,7 +21,7 @@ class Task extends Extension {
 	* @public
 	*/
 	async getTask() {
-		return (await this._getImplementation()).task;
+		return (await this._getImplementation()).default;
 	}
 
 	/**
@@ -34,7 +34,7 @@ class Task extends Extension {
 	/**
 	* @public
 	*/
-	async getBuildSignatureCallback() {
+	async getDetermineBuildSignatureCallback() {
 		return (await this._getImplementation()).determineBuildSignature;
 	}
 
@@ -57,11 +57,11 @@ class Task extends Extension {
 	 * @private
 	*/
 	async _getImplementation() {
-		const taskPath = path.join(this.getRootPath(), this._config.task.path);
-		const {default: task, determineRequiredDependencies} = await import(pathToFileURL(taskPath));
-		return {
-			task, determineRequiredDependencies
-		};
+		if (!this._modulePromise) {
+			const taskPath = path.join(this.getRootPath(), this._config.task.path);
+			this._modulePromise = import(pathToFileURL(taskPath).href);
+		}
+		return this._modulePromise;
 	}
 
 	/**

--- a/packages/project/test/lib/build/TaskDefinitions.js
+++ b/packages/project/test/lib/build/TaskDefinitions.js
@@ -1,0 +1,615 @@
+import test from "ava";
+import sinonGlobal from "sinon";
+import esmock from "esmock";
+import crypto from "node:crypto";
+
+function noop() {}
+function emptyarray() {
+	return [];
+}
+
+// Returns a project mock that satisfies the inputs of the standard build
+// definitions (application, library, theme-library, ...). The build definitions
+// access many project properties; we only stub what's needed for them to load
+// without throwing.
+function getMockProject(type) {
+	return {
+		getName: () => "project.b",
+		getNamespace: () => "project/b",
+		getType: () => type,
+		getPropertiesFileSourceEncoding: noop,
+		getCopyright: noop,
+		getVersion: noop,
+		getMinificationExcludes: emptyarray,
+		getJsdocExcludes: emptyarray,
+		getSpecVersion: () => {
+			return {
+				gte: () => false,
+				lt: () => false
+			};
+		},
+		getComponentPreloadPaths: emptyarray,
+		getComponentPreloadNamespaces: emptyarray,
+		getComponentPreloadExcludes: emptyarray,
+		getLibraryPreloadExcludes: emptyarray,
+		getBundles: emptyarray,
+		getCachebusterSignatureType: noop,
+		getCustomTasks: emptyarray,
+		isFrameworkProject: () => false,
+	};
+}
+
+test.beforeEach(async (t) => {
+	const sinon = t.context.sinon = sinonGlobal.createSandbox();
+
+	// taskUtil exposes both an internal API (used by build definitions when wiring
+	// standard task options) and the read-only interface (used in build signatures).
+	t.context.taskUtil = {
+		isRootProject: sinon.stub().returns(true),
+		getBuildOption: sinon.stub(),
+		getReadOnlyInterface: sinon.stub().returns("read-only interface"),
+	};
+
+	t.context.taskRepository = {
+		getTask: sinon.stub().callsFake(async (taskName) => {
+			throw new Error(`taskRepository: Unknown Task ${taskName}`);
+		}),
+		getAllTaskNames: sinon.stub().returns(["replaceVersion", "minify"]),
+	};
+
+	t.context.customTaskSpecVersionLtStub = sinon.stub().returns(false);
+	t.context.customTaskSpecVersion = {
+		lt: t.context.customTaskSpecVersionLtStub
+	};
+	t.context.getDetermineBuildSignatureCallbackStub = sinon.stub().resolves(undefined);
+	t.context.customTask = {
+		getName: () => "custom task name",
+		getSpecVersion: () => t.context.customTaskSpecVersion,
+		getDetermineBuildSignatureCallback: t.context.getDetermineBuildSignatureCallbackStub,
+	};
+
+	t.context.graph = {
+		getRoot: () => {
+			return {
+				getName: () => "graph-root"
+			};
+		},
+		getExtension: sinon.stub().returns(t.context.customTask),
+	};
+
+	t.context.TaskDefinitions = (await import("../../../lib/build/TaskDefinitions.js")).default;
+});
+
+test.afterEach.always((t) => {
+	t.context.sinon.restore();
+});
+
+test("_initTasks: Project of type 'application'", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("application");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {standardTasks, customTasks} = await taskDefinitions.getTaskDefinitions();
+	t.true(standardTasks instanceof Map, "standardTasks is a Map");
+	t.true(standardTasks.size > 0, "standardTasks is populated for application project");
+	t.true(customTasks instanceof Map, "customTasks is a Map");
+	t.is(customTasks.size, 0, "No custom tasks defined");
+});
+
+test("_initTasks: Project of type 'library'", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("library");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {standardTasks} = await taskDefinitions.getTaskDefinitions();
+	t.true(standardTasks instanceof Map, "standardTasks is a Map");
+	t.true(standardTasks.size > 0, "standardTasks is populated for library project");
+});
+
+test("_initTasks: Project of type 'component'", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("component");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {standardTasks} = await taskDefinitions.getTaskDefinitions();
+	t.true(standardTasks instanceof Map, "standardTasks is a Map");
+});
+
+test("_initTasks: Project of type 'theme-library'", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("theme-library");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {standardTasks} = await taskDefinitions.getTaskDefinitions();
+	t.true(standardTasks instanceof Map, "standardTasks is a Map");
+	t.true(standardTasks.size > 0, "standardTasks is populated for theme-library project");
+});
+
+test("_initTasks: Project of type 'module'", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {standardTasks} = await taskDefinitions.getTaskDefinitions();
+	t.true(standardTasks instanceof Map, "standardTasks is a Map");
+	t.is(standardTasks.size, 0, "module project defines no standard tasks");
+});
+
+test("_initTasks: Unknown project type", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("pony");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const err = await t.throwsAsync(taskDefinitions._initTasks());
+	t.is(err.message, "Unknown project type pony", "Threw with expected error message");
+});
+
+test("_initTasks: Memoizes initialization across concurrent and subsequent calls", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	const getTypeSpy = t.context.sinon.spy(project, "getType");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+
+	// Multiple concurrent calls and follow-up calls should never trigger more than
+	// a single initialization run.
+	await Promise.all([
+		taskDefinitions._initTasks(),
+		taskDefinitions._initTasks()
+	]);
+	await taskDefinitions._initTasks();
+
+	t.is(getTypeSpy.callCount, 1, "Project type was only resolved once");
+});
+
+test("_initTasks: Calls build definition with expected arguments", async (t) => {
+	const {graph, taskRepository} = t.context;
+	const sinon = t.context.sinon;
+	const taskUtil = {dummy: true};
+	const standardTasks = new Map([["someTask", {options: {foo: "bar"}}]]);
+	const definitionStub = sinon.stub().returns(standardTasks);
+
+	const TaskDefinitions = await esmock.p("../../../lib/build/TaskDefinitions.js", {}, {
+		"../../../lib/build/definitions/module.js": {
+			default: definitionStub
+		}
+	});
+
+	const project = getMockProject("module");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+
+	t.is(definitionStub.callCount, 1, "Build definition got called once");
+	const args = definitionStub.getCall(0).args[0];
+	t.is(args.project, project, "Build definition called with project");
+	t.is(args.taskUtil, taskUtil, "Build definition called with taskUtil");
+	t.is(args.getTask, taskRepository.getTask,
+		"Build definition called with taskRepository.getTask reference");
+
+	const {standardTasks: returnedStandardTasks} = await taskDefinitions.getTaskDefinitions();
+	t.is(returnedStandardTasks, standardTasks, "Standard tasks from definition exposed");
+});
+
+test("_getCustomTasks: No custom tasks defined", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {customTasks} = await taskDefinitions.getTaskDefinitions();
+	t.is(customTasks.size, 0, "No custom tasks");
+});
+
+test("_getCustomTasks: getCustomTasks returns null", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	project.getCustomTasks = () => null;
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {customTasks} = await taskDefinitions.getTaskDefinitions();
+	t.is(customTasks.size, 0, "Returns empty Map when getCustomTasks returns null");
+});
+
+test("_getCustomTasks: Custom tasks are added in configured order", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository, customTask} = t.context;
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask"},
+		{name: "myOtherTask", afterTask: "myTask"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+
+	const {customTasks} = await taskDefinitions.getTaskDefinitions();
+	t.deepEqual(Array.from(customTasks.keys()), ["myTask", "myOtherTask"],
+		"Custom tasks are stored in configured order");
+	t.is(customTasks.get("myTask").task, customTask, "Resolved task extension stored on entry");
+	t.deepEqual(customTasks.get("myTask").taskDef, {name: "myTask"},
+		"Original taskDef stored on entry");
+});
+
+test("_addCustomTask: Custom task without name", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: ""}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const err = await t.throwsAsync(taskDefinitions._initTasks());
+	t.is(err.message,
+		"Missing name for custom task in configuration of project project.b",
+		"Threw with expected error message");
+});
+
+test("_addCustomTask: Custom task defines both beforeTask and afterTask", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("application");
+	project.getCustomTasks = () => [
+		{name: "myTask", beforeTask: "minify", afterTask: "replaceVersion"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const err = await t.throwsAsync(taskDefinitions._initTasks());
+	t.is(err.message,
+		`Custom task definition myTask of project project.b defines both ` +
+		`"beforeTask" and "afterTask" parameters. Only one must be defined.`,
+		"Threw with expected error message");
+});
+
+test("_addCustomTask: Custom task without before-/afterTask in project with standard tasks", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("application");
+	project.getCustomTasks = () => [
+		{name: "myTask"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const err = await t.throwsAsync(taskDefinitions._initTasks());
+	t.is(err.message,
+		`Custom task definition myTask of project project.b defines neither a ` +
+		`"beforeTask" nor an "afterTask" parameter. One must be defined.`,
+		"Threw with expected error message");
+});
+
+test("_addCustomTask: Multiple custom tasks; second one without before-/afterTask", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask"},
+		{name: "myOtherTask"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const err = await t.throwsAsync(taskDefinitions._initTasks());
+	t.is(err.message,
+		`Custom task definition myOtherTask of project project.b defines neither a ` +
+		`"beforeTask" nor an "afterTask" parameter. One must be defined.`,
+		"Threw with expected error message");
+});
+
+test("_addCustomTask: First custom task in module project requires no before-/afterTask", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {customTasks} = await taskDefinitions.getTaskDefinitions();
+	t.deepEqual(Array.from(customTasks.keys()), ["myTask"],
+		"First custom task in a project without standard tasks is accepted");
+});
+
+test("_addCustomTask: Custom task uses name of standard task", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("application");
+	project.getCustomTasks = () => [
+		{name: "replaceVersion", afterTask: "minify"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const err = await t.throwsAsync(taskDefinitions._initTasks());
+	t.is(err.message,
+		"Custom task configuration of project project.b references standard task replaceVersion. " +
+		"Only custom tasks must be provided here.",
+		"Threw with expected error message");
+});
+
+test("_addCustomTask: Custom task is unknown in project graph", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	graph.getExtension.returns(undefined);
+	const project = getMockProject("application");
+	project.getCustomTasks = () => [
+		{name: "myTask", afterTask: "minify"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const err = await t.throwsAsync(taskDefinitions._initTasks());
+	t.is(err.message,
+		"Could not find custom task myTask, referenced by project project.b in project graph " +
+		"with root node graph-root",
+		"Threw with expected error message");
+});
+
+test("_addCustomTask: Custom task with beforeTask is accepted", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("application");
+	project.getCustomTasks = () => [
+		{name: "myTask", beforeTask: "minify"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {customTasks} = await taskDefinitions.getTaskDefinitions();
+	t.deepEqual(Array.from(customTasks.keys()), ["myTask"],
+		"Custom task referencing beforeTask is accepted");
+});
+
+test("_addCustomTask: Multiple custom tasks with same name get suffix", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask"},
+		{name: "myTask", afterTask: "myTask"},
+		{name: "myTask", afterTask: "myTask"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {customTasks} = await taskDefinitions.getTaskDefinitions();
+	t.deepEqual(Array.from(customTasks.keys()), ["myTask", "myTask--2", "myTask--3"],
+		"Suffix is appended to subsequent occurrences of the same task name");
+});
+
+test("_addCustomTask: Suffix collides with existing standard task name", async (t) => {
+	const {graph, taskUtil} = t.context;
+	const sinon = t.context.sinon;
+	const taskRepository = {
+		getTask: sinon.stub(),
+		getAllTaskNames: sinon.stub().returns([]),
+	};
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask", afterTask: "myTask--2"},
+		{name: "myTask", afterTask: "myTask"}
+	];
+	// Inject a build definition where the suffixed name "myTask--2" is already used by a
+	// (synthetic) standard task. The suffix loop must skip it and pick "myTask--3".
+	const standardTasks = new Map([["myTask--2", {}]]);
+	const definitionStub = sinon.stub().returns(standardTasks);
+	const MockedTaskDefinitions = await esmock.p("../../../lib/build/TaskDefinitions.js", {}, {
+		"../../../lib/build/definitions/module.js": {
+			default: definitionStub
+		}
+	});
+
+	const taskDefinitions = new MockedTaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions._initTasks();
+	const {customTasks} = await taskDefinitions.getTaskDefinitions();
+	t.deepEqual(Array.from(customTasks.keys()), ["myTask", "myTask--3"],
+		"Suffix counter skips collisions with names already used by standard tasks");
+});
+
+test("getTaskDefinitions: Returns standard and custom tasks", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository, customTask} = t.context;
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const result = await taskDefinitions.getTaskDefinitions();
+
+	t.true(result.standardTasks instanceof Map, "standardTasks is a Map");
+	t.true(result.customTasks instanceof Map, "customTasks is a Map");
+	t.is(result.customTasks.get("myTask").task, customTask,
+		"Custom task entry resolved from project graph");
+});
+
+test("getTaskDefinitions: Lazily triggers initialization", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	const getTypeSpy = t.context.sinon.spy(project, "getType");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const result = await taskDefinitions.getTaskDefinitions();
+	t.true(result.standardTasks instanceof Map, "Initialization triggered by getTaskDefinitions");
+	t.is(getTypeSpy.callCount, 1, "_initTasks ran exactly once");
+});
+
+test("getBuildSignatures: Standard tasks without determineBuildSignature use options as fallback", async (t) => {
+	const {graph, taskUtil, taskRepository} = t.context;
+	const sinon = t.context.sinon;
+	const standardTasks = new Map([
+		["taskA", {options: {foo: "bar"}}],
+		["taskB", {options: {hello: "world"}}],
+	]);
+	const definitionStub = sinon.stub().returns(standardTasks);
+	const MockedTaskDefinitions = await esmock.p("../../../lib/build/TaskDefinitions.js", {}, {
+		"../../../lib/build/definitions/module.js": {
+			default: definitionStub
+		}
+	});
+
+	const project = getMockProject("module");
+	const taskDefinitions = new MockedTaskDefinitions(graph, project, taskUtil, taskRepository);
+	const sig = await taskDefinitions.getBuildSignatures();
+
+	const expectedKey = [
+		JSON.stringify({foo: "bar"}),
+		JSON.stringify({hello: "world"})
+	].join("|");
+	const expectedHash = crypto.createHash("sha256").update(expectedKey).digest("hex");
+	t.is(sig, expectedHash, "Returns sha256 hash of joined task options");
+});
+
+test("getBuildSignatures: Standard task determineBuildSignature is awaited and used", async (t) => {
+	const {graph, taskUtil, taskRepository} = t.context;
+	const sinon = t.context.sinon;
+	const determineBuildSignatureStub = sinon.stub().resolves("custom-sig");
+	const standardTasks = new Map([
+		["taskA", {determineBuildSignature: determineBuildSignatureStub}],
+	]);
+	const definitionStub = sinon.stub().returns(standardTasks);
+	const MockedTaskDefinitions = await esmock.p("../../../lib/build/TaskDefinitions.js", {}, {
+		"../../../lib/build/definitions/module.js": {
+			default: definitionStub
+		}
+	});
+
+	const project = getMockProject("module");
+	const taskDefinitions = new MockedTaskDefinitions(graph, project, taskUtil, taskRepository);
+	const sig = await taskDefinitions.getBuildSignatures();
+
+	t.is(determineBuildSignatureStub.callCount, 1, "determineBuildSignature got called once");
+	const expectedHash = crypto.createHash("sha256").update("custom-sig").digest("hex");
+	t.is(sig, expectedHash, "Returns sha256 hash of returned signature");
+});
+
+test("getBuildSignatures: Standard task determineBuildSignature returning falsy is skipped", async (t) => {
+	const {graph, taskUtil, taskRepository} = t.context;
+	const sinon = t.context.sinon;
+	const standardTasks = new Map([
+		["taskA", {determineBuildSignature: sinon.stub().resolves(undefined)}],
+		["taskB", {options: {a: 1}}],
+	]);
+	const definitionStub = sinon.stub().returns(standardTasks);
+	const MockedTaskDefinitions = await esmock.p("../../../lib/build/TaskDefinitions.js", {}, {
+		"../../../lib/build/definitions/module.js": {
+			default: definitionStub
+		}
+	});
+
+	const project = getMockProject("module");
+	const taskDefinitions = new MockedTaskDefinitions(graph, project, taskUtil, taskRepository);
+	const sig = await taskDefinitions.getBuildSignatures();
+
+	const expectedHash = crypto.createHash("sha256").update(JSON.stringify({a: 1})).digest("hex");
+	t.is(sig, expectedHash, "Falsy signature returned by callback is skipped");
+});
+
+test("getBuildSignatures: Custom task without determineBuildSignature falls back to configuration", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask", configuration: {hello: "world"}}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const sig = await taskDefinitions.getBuildSignatures();
+
+	const expectedHash = crypto.createHash("sha256").update(
+		JSON.stringify({hello: "world"})
+	).digest("hex");
+	t.is(sig, expectedHash, "Falls back to JSON-stringified configuration");
+});
+
+test("getBuildSignatures: Custom task determineBuildSignature gets invoked correctly", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository, customTask, customTaskSpecVersion, sinon} =
+		t.context;
+	const determineBuildSignatureCallback = sinon.stub().resolves("my-custom-sig");
+	customTask.getDetermineBuildSignatureCallback = sinon.stub().resolves(determineBuildSignatureCallback);
+
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask", configuration: {hello: "world"}}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const sig = await taskDefinitions.getBuildSignatures();
+
+	t.is(determineBuildSignatureCallback.callCount, 1,
+		"determineBuildSignature callback got called once");
+	const args = determineBuildSignatureCallback.getCall(0).args[0];
+	t.truthy(args.log, "log instance provided");
+	t.is(args.taskUtil, "read-only interface", "taskUtil read-only interface forwarded");
+	t.is(taskUtil.getReadOnlyInterface.callCount, 1,
+		"taskUtil#getReadOnlyInterface got called once");
+	t.is(taskUtil.getReadOnlyInterface.getCall(0).args[0], customTaskSpecVersion,
+		"taskUtil#getReadOnlyInterface called with the task's specVersion");
+	t.deepEqual(args.options, {
+		projectName: "project.b",
+		projectNamespace: "project/b",
+		configuration: {hello: "world"},
+		taskName: "myTask"
+	}, "options forwarded to determineBuildSignature callback");
+
+	const expectedHash = crypto.createHash("sha256").update("my-custom-sig").digest("hex");
+	t.is(sig, expectedHash, "Returns sha256 hash of returned signature");
+});
+
+test("getBuildSignatures: Custom task determineBuildSignature returning falsy is skipped", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository, customTask, sinon} = t.context;
+	const determineBuildSignatureCallback = sinon.stub().resolves(null);
+	customTask.getDetermineBuildSignatureCallback = sinon.stub().resolves(determineBuildSignatureCallback);
+
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask", configuration: {hello: "world"}}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const sig = await taskDefinitions.getBuildSignatures();
+
+	// No standard tasks (module) and falsy custom signature => empty key string
+	const expectedHash = crypto.createHash("sha256").update("").digest("hex");
+	t.is(sig, expectedHash, "Falsy signature is omitted from hash input");
+});
+
+test("getBuildSignatures: Custom task with specVersion < 5.0 and determineBuildSignature throws", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository, customTask, sinon} = t.context;
+	const determineBuildSignatureCallback = sinon.stub().resolves("custom-sig");
+	customTask.getDetermineBuildSignatureCallback = sinon.stub().resolves(determineBuildSignatureCallback);
+	t.context.customTaskSpecVersionLtStub.withArgs("5.0").returns(true);
+
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask", configuration: "configuration"}
+	];
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+
+	const err = await t.throwsAsync(taskDefinitions.getBuildSignatures());
+	t.is(err.message,
+		`Custom task myTask of project project.b uses a determineBuildSignature callback, ` +
+		`which is not supported for tasks with specVersion < 5.0. ` +
+		`Please update the task's specVersion to at least 5.0.`,
+		"Threw with expected error message");
+	t.is(determineBuildSignatureCallback.callCount, 0,
+		"determineBuildSignature callback was not invoked");
+});
+
+test("getBuildSignatures: Combines standard and custom task signatures", async (t) => {
+	const {graph, taskUtil, taskRepository, customTask, sinon} = t.context;
+	const standardTasks = new Map([
+		["taskA", {options: {a: 1}}],
+		["taskB", {determineBuildSignature: sinon.stub().resolves("std-sig")}],
+	]);
+	const definitionStub = sinon.stub().returns(standardTasks);
+	const MockedTaskDefinitions = await esmock.p("../../../lib/build/TaskDefinitions.js", {}, {
+		"../../../lib/build/definitions/module.js": {
+			default: definitionStub
+		}
+	});
+
+	const determineBuildSignatureCallback = sinon.stub().resolves("custom-sig");
+	customTask.getDetermineBuildSignatureCallback = sinon.stub().resolves(determineBuildSignatureCallback);
+
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask", afterTask: "taskA"}
+	];
+	const taskDefinitions = new MockedTaskDefinitions(graph, project, taskUtil, taskRepository);
+	const sig = await taskDefinitions.getBuildSignatures();
+
+	const expectedKey = [
+		JSON.stringify({a: 1}),
+		"std-sig",
+		"custom-sig"
+	].join("|");
+	const expectedHash = crypto.createHash("sha256").update(expectedKey).digest("hex");
+	t.is(sig, expectedHash, "Combined hash includes both standard and custom signatures");
+});
+
+test("getBuildSignatures: Triggers task initialization", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module");
+	const getTypeSpy = t.context.sinon.spy(project, "getType");
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	await taskDefinitions.getBuildSignatures();
+	t.is(getTypeSpy.callCount, 1, "_initTasks was triggered");
+});
+
+test("getBuildSignatures: Empty project hashes the empty string", async (t) => {
+	const {TaskDefinitions, graph, taskUtil, taskRepository} = t.context;
+	const project = getMockProject("module"); // module has no standard tasks and no custom tasks
+	const taskDefinitions = new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	const sig = await taskDefinitions.getBuildSignatures();
+
+	const expectedHash = crypto.createHash("sha256").update("").digest("hex");
+	t.is(sig, expectedHash, "Returns sha256 hash of empty key string");
+});

--- a/packages/project/test/lib/build/TaskRunner.js
+++ b/packages/project/test/lib/build/TaskRunner.js
@@ -155,7 +155,29 @@ test.beforeEach(async (t) => {
 		"@ui5/logger": t.context.logger,
 		"@ui5/fs/resourceFactory": t.context.resourceFactory
 	});
+	t.context.TaskDefinitions = (await import("../../../lib/build/TaskDefinitions.js")).default;
 });
+
+// Builds a TaskRunner with a real TaskDefinitions wired up from the test context.
+// All TaskRunner unit tests share the same dependency shape, so this helper avoids
+// repeating the wiring at every call site.
+function createTaskRunner(t, project, overrides = {}) {
+	const {TaskRunner, TaskDefinitions, graph, taskUtil, taskRepository, projectBuildLogger, buildCache} = t.context;
+	const taskDefinitions = overrides.taskDefinitions !== undefined ?
+		overrides.taskDefinitions :
+		new TaskDefinitions(graph, project, taskUtil, taskRepository);
+	return new TaskRunner({
+		project,
+		graph,
+		taskUtil,
+		taskRepository,
+		log: projectBuildLogger,
+		buildCache,
+		buildConfig,
+		taskDefinitions,
+		...overrides
+	});
+}
 
 test.afterEach.always((t) => {
 	t.context.sinon.restore();
@@ -163,13 +185,16 @@ test.afterEach.always((t) => {
 
 test("Missing parameters", (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const taskDefinitions = {}; // contents irrelevant; only its presence is checked by the constructor
 	t.throws(() => {
 		new TaskRunner({
 			graph,
 			taskUtil,
 			taskRepository,
 			log: projectBuildLogger,
-			buildConfig
+			buildCache,
+			buildConfig,
+			taskDefinitions
 		});
 	}, {
 		message: "TaskRunner: One or more mandatory parameters not provided"
@@ -181,7 +206,8 @@ test("Missing parameters", (t) => {
 			taskRepository,
 			log: projectBuildLogger,
 			buildCache,
-			buildConfig
+			buildConfig,
+			taskDefinitions
 		});
 	}, {
 		message: "TaskRunner: One or more mandatory parameters not provided"
@@ -193,7 +219,8 @@ test("Missing parameters", (t) => {
 			taskRepository,
 			log: projectBuildLogger,
 			buildCache,
-			buildConfig
+			buildConfig,
+			taskDefinitions
 		});
 	}, {
 		message: "TaskRunner: One or more mandatory parameters not provided"
@@ -205,7 +232,8 @@ test("Missing parameters", (t) => {
 			taskUtil,
 			log: projectBuildLogger,
 			buildCache,
-			buildConfig
+			buildConfig,
+			taskDefinitions
 		});
 	}, {
 		message: "TaskRunner: One or more mandatory parameters not provided"
@@ -216,7 +244,8 @@ test("Missing parameters", (t) => {
 			graph,
 			taskUtil,
 			taskRepository,
-			buildConfig
+			buildConfig,
+			taskDefinitions
 		});
 	}, {
 		message: "TaskRunner: One or more mandatory parameters not provided"
@@ -229,18 +258,28 @@ test("Missing parameters", (t) => {
 			taskRepository,
 			log: projectBuildLogger,
 			buildCache,
+			taskDefinitions
 		});
 	}, {
 		message: "TaskRunner: One or more mandatory parameters not provided"
 	}, "Threw with expected error message for missing buildConfig parameter");
+	t.throws(() => {
+		new TaskRunner({
+			project: getMockProject("application"),
+			graph,
+			taskUtil,
+			taskRepository,
+			log: projectBuildLogger,
+			buildCache,
+			buildConfig
+		});
+	}, {
+		message: "TaskRunner: One or more mandatory parameters not provided"
+	}, "Threw with expected error message for missing taskDefinitions parameter");
 });
 
 test("_initTasks: Project of type 'application'", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
-	const taskRunner = new TaskRunner({
-		project: getMockProject("application"), graph, taskUtil, taskRepository,
-		log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, getMockProject("application"));
 	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
@@ -261,11 +300,7 @@ test("_initTasks: Project of type 'application'", async (t) => {
 });
 
 test("_initTasks: Project of type 'library'", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
-	const taskRunner = new TaskRunner({
-		project: getMockProject("library"), graph, taskUtil, taskRepository,
-		log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, getMockProject("library"));
 	await taskRunner._initTasks();
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -288,14 +323,10 @@ test("_initTasks: Project of type 'library'", async (t) => {
 });
 
 test("_initTasks: Project of type 'library' (framework project)", async (t) => {
-	const {graph, taskUtil, taskRepository, projectBuildLogger, TaskRunner, buildCache} = t.context;
-
 	const project = getMockProject("library");
 	project.isFrameworkProject = () => true;
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -318,11 +349,7 @@ test("_initTasks: Project of type 'library' (framework project)", async (t) => {
 });
 
 test("_initTasks: Project of type 'theme-library'", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
-	const taskRunner = new TaskRunner({
-		project: getMockProject("theme-library"), graph, taskUtil, taskRepository,
-		log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, getMockProject("theme-library"));
 	await taskRunner._initTasks();
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -335,14 +362,10 @@ test("_initTasks: Project of type 'theme-library'", async (t) => {
 });
 
 test("_initTasks: Project of type 'theme-library' (framework project)", async (t) => {
-	const {graph, taskUtil, taskRepository, projectBuildLogger, buildCache, TaskRunner} = t.context;
-
 	const project = getMockProject("theme-library");
 	project.isFrameworkProject = () => true;
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -355,37 +378,26 @@ test("_initTasks: Project of type 'theme-library' (framework project)", async (t
 });
 
 test("_initTasks: Project of type 'module'", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
-	const taskRunner = new TaskRunner({
-		project: getMockProject("module"), graph, taskUtil, taskRepository,
-		log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, getMockProject("module"));
 	await taskRunner._initTasks();
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [], "Correct standard tasks");
 });
 
 test("_initTasks: Unknown project type", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
-	const taskRunner = new TaskRunner({
-		project: getMockProject("pony"), graph, taskUtil, taskRepository,
-		log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, getMockProject("pony"));
 	const err = await t.throwsAsync(taskRunner._initTasks());
 
 	t.is(err.message, "Unknown project type pony", "Threw with expected error message");
 });
 
 test("_initTasks: Custom tasks", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "minify"},
 		{name: "myOtherTask", beforeTask: "replaceVersion"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
@@ -408,15 +420,12 @@ test("_initTasks: Custom tasks", async (t) => {
 });
 
 test("_initTasks: Custom tasks with no standard tasks", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask"},
 		{name: "myOtherTask", beforeTask: "myTask"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"myOtherTask",
@@ -425,15 +434,12 @@ test("_initTasks: Custom tasks with no standard tasks", async (t) => {
 });
 
 test("_initTasks: Custom tasks with no standard tasks and second task defining no before-/afterTask", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask"},
 		{name: "myOtherTask"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
 	});
@@ -444,14 +450,11 @@ test("_initTasks: Custom tasks with no standard tasks and second task defining n
 });
 
 test("_initTasks: Custom tasks with both, before- and afterTask reference", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", beforeTask: "minify", afterTask: "replaceVersion"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
 	});
@@ -462,14 +465,11 @@ test("_initTasks: Custom tasks with both, before- and afterTask reference", asyn
 });
 
 test("_initTasks: Custom tasks with no before-/afterTask reference", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
 	});
@@ -480,14 +480,11 @@ test("_initTasks: Custom tasks with no before-/afterTask reference", async (t) =
 });
 
 test("_initTasks: Custom tasks without name", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: ""}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
 	});
@@ -497,14 +494,11 @@ test("_initTasks: Custom tasks without name", async (t) => {
 });
 
 test("_initTasks: Custom task with name of standard tasks", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "replaceVersion", afterTask: "minify"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
 	});
@@ -515,16 +509,13 @@ test("_initTasks: Custom task with name of standard tasks", async (t) => {
 });
 
 test("_initTasks: Multiple custom tasks with same name", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "minify"},
 		{name: "myTask", afterTask: "myTask"},
 		{name: "myTask", afterTask: "minify"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
@@ -548,14 +539,11 @@ test("_initTasks: Multiple custom tasks with same name", async (t) => {
 });
 
 test("_initTasks: Custom tasks with unknown beforeTask", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", beforeTask: "unknownTask"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
 	});
@@ -566,14 +554,11 @@ test("_initTasks: Custom tasks with unknown beforeTask", async (t) => {
 });
 
 test("_initTasks: Custom tasks with unknown afterTask", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "unknownTask"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
 	});
@@ -584,15 +569,13 @@ test("_initTasks: Custom tasks with unknown afterTask", async (t) => {
 });
 
 test("_initTasks: Custom tasks is unknown", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {graph} = t.context;
 	graph.getExtension.returns(undefined);
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "minify"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
 	});
@@ -603,14 +586,11 @@ test("_initTasks: Custom tasks is unknown", async (t) => {
 });
 
 test("_initTasks: Custom tasks with removed beforeTask", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", beforeTask: "removedTask"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
 	});
@@ -622,11 +602,9 @@ test("_initTasks: Custom tasks with removed beforeTask", async (t) => {
 });
 
 test("_initTasks: Create dependencies reader for all dependencies", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory, projectBuildLogger, buildCache} = t.context;
+	const {graph, resourceFactory} = t.context;
 	const project = getMockProject("application");
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 	// Dependencies reader is now created lazily via getDependenciesReader
 	// Use forceUpdate=true to bypass the cache shortcut and actually trigger graph traversal
@@ -674,7 +652,7 @@ test("_initTasks: Create dependencies reader for all dependencies", async (t) =>
 });
 
 test("Custom task is called correctly", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {sinon, graph, taskUtil} = t.context;
 	const taskStub = sinon.stub();
 	const specVersionGteStub = sinon.stub().returns(false);
 	const mockSpecVersion = {
@@ -695,9 +673,7 @@ test("Custom task is called correctly", async (t) => {
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
@@ -736,7 +712,7 @@ test("Custom task is called correctly", async (t) => {
 });
 
 test("Custom task with legacy spec version", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {sinon, graph, taskUtil} = t.context;
 	const taskStub = sinon.stub();
 	const specVersionGteStub = sinon.stub().returns(false);
 	const mockSpecVersion = {
@@ -756,9 +732,7 @@ test("Custom task with legacy spec version", async (t) => {
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
@@ -797,7 +771,7 @@ test("Custom task with legacy spec version", async (t) => {
 });
 
 test("Custom task with legacy spec version and requiredDependenciesCallback", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {sinon, graph, taskUtil} = t.context;
 	const taskStub = sinon.stub();
 	const specVersionGteStub = sinon.stub().returns(false);
 	const mockSpecVersion = {
@@ -818,9 +792,7 @@ test("Custom task with legacy spec version and requiredDependenciesCallback", as
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
@@ -870,7 +842,7 @@ test("Custom task with legacy spec version and requiredDependenciesCallback", as
 });
 
 test("Custom task with specVersion 3.0", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {sinon, graph, taskUtil} = t.context;
 	const taskStub = sinon.stub();
 	const specVersionGteStub = sinon.stub().returns(true);
 	const mockSpecVersion = {
@@ -894,9 +866,7 @@ test("Custom task with specVersion 3.0", async (t) => {
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	t.is(requiredDependenciesCallbackStub.callCount, 1, "requiredDependenciesCallback got called once");
@@ -968,7 +938,7 @@ test("Custom task with specVersion 3.0", async (t) => {
 });
 
 test("Custom task with specVersion 3.0 and no requiredDependenciesCallback", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, projectBuildLogger, buildCache, TaskRunner} = t.context;
+	const {sinon, graph, taskUtil} = t.context;
 	const taskStub = sinon.stub();
 	const specVersionGteStub = sinon.stub().returns(true);
 	const mockSpecVersion = {
@@ -991,9 +961,7 @@ test("Custom task with specVersion 3.0 and no requiredDependenciesCallback", asy
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
@@ -1030,7 +998,7 @@ test("Custom task with specVersion 3.0 and no requiredDependenciesCallback", asy
 });
 
 test("Multiple custom tasks with same name are called correctly", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {sinon, graph, taskUtil, projectBuildLogger} = t.context;
 	const taskStubA = sinon.stub();
 	const taskStubB = sinon.stub();
 	const taskStubC = sinon.stub();
@@ -1093,9 +1061,7 @@ test("Multiple custom tasks with same name are called correctly", async (t) => {
 		{name: "myTask", afterTask: "myTask", configuration: "bird"},
 		{name: "myTask", afterTask: "myTask", configuration: "bird"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	// getRequiredDependenciesCallbackStub is only called for specVersion >= 3.0
@@ -1226,7 +1192,7 @@ test("Multiple custom tasks with same name are called correctly", async (t) => {
 });
 
 test("Custom task: requiredDependenciesCallback returns unknown dependency", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {sinon, graph} = t.context;
 	const taskStub = sinon.stub();
 	const specVersionGteStub = sinon.stub().returns(true);
 	const mockSpecVersion = {
@@ -1251,9 +1217,7 @@ test("Custom task: requiredDependenciesCallback returns unknown dependency", asy
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await t.throwsAsync(taskRunner._initTasks(), {
 		message:
 		`'determineRequiredDependencies' callback function of custom task custom.task.a ` +
@@ -1264,7 +1228,7 @@ test("Custom task: requiredDependenciesCallback returns unknown dependency", asy
 
 
 test("Custom task: requiredDependenciesCallback returns Array instead of Set", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {sinon, graph} = t.context;
 	const taskStub = sinon.stub();
 	const specVersionGteStub = sinon.stub().returns(true);
 	const mockSpecVersion = {
@@ -1289,9 +1253,7 @@ test("Custom task: requiredDependenciesCallback returns Array instead of Set", a
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await t.throwsAsync(taskRunner._initTasks(), {
 		message:
 		`'determineRequiredDependencies' callback function of custom task custom.task.a ` +
@@ -1300,7 +1262,7 @@ test("Custom task: requiredDependenciesCallback returns Array instead of Set", a
 });
 
 test("Custom task attached to a disabled task", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache, sinon, customTask} = t.context;
+	const {taskRepository, projectBuildLogger, sinon, customTask} = t.context;
 
 	const project = getMockProject("application");
 	const customTaskFnStub = sinon.stub();
@@ -1312,9 +1274,7 @@ test("Custom task attached to a disabled task", async (t) => {
 	taskRepository.getTask = sinon.stub().returns({task: sinon.stub()});
 	customTask.getTask = () => customTaskFnStub;
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 
 	await taskRunner.runTasks();
 
@@ -1340,7 +1300,7 @@ test("Custom task attached to a disabled task", async (t) => {
 });
 
 test.serial("_addTask", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {sinon, taskUtil, taskRepository} = t.context;
 
 	const taskStub = sinon.stub();
 	taskRepository.getTask.withArgs("standardTask").resolves({
@@ -1348,9 +1308,7 @@ test.serial("_addTask", async (t) => {
 	});
 
 	const project = getMockProject("module");
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	taskRunner._addTask("standardTask");
@@ -1378,13 +1336,11 @@ test.serial("_addTask", async (t) => {
 });
 
 test.serial("_addTask with options", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
+	const {sinon, taskUtil, taskRepository} = t.context;
 	const taskStub = sinon.stub();
 	const project = getMockProject("module");
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	taskRunner._addTask("standardTask", {
@@ -1422,11 +1378,8 @@ test.serial("_addTask with options", async (t) => {
 });
 
 test("_addTask: Duplicate task", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("module");
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	taskRunner._addTask("standardTask", {
@@ -1443,11 +1396,8 @@ test("_addTask: Duplicate task", async (t) => {
 });
 
 test("_addTask: Task already added to execution order", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("module");
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 
 	taskRunner._taskExecutionOrder.push("standardTask");
@@ -1462,81 +1412,61 @@ test("_addTask: Task already added to execution order", async (t) => {
 });
 
 test("getRequiredDependencies: Custom Task", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask"}
 	];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
 		"Project with custom task >= specVersion 3.0 and no requiredDependenciesCallback " +
 		"requires no dependencies");
 });
 
 test("getRequiredDependencies: Default application", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("application");
 	project.getBundles = () => [];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
 		"Default application project does not require dependencies");
 });
 
 test("getRequiredDependencies: Default component", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("component");
 	project.getBundles = () => [];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
 		"Default component project does not require dependencies");
 });
 
 test("getRequiredDependencies: Default library", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("library");
 	project.getBundles = () => [];
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set(["dep.a", "dep.b"]),
 		"Default library project requires dependencies");
 });
 
 test("getRequiredDependencies: Default theme-library", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("theme-library");
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set(["dep.a", "dep.b"]),
 		"Default theme-library project requires dependencies");
 });
 
 test("getRequiredDependencies: Default module", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, projectBuildLogger, buildCache} = t.context;
 	const project = getMockProject("module");
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
 		"Default module project does not require dependencies");
 });
 
 test("getDependenciesReader", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory, projectBuildLogger, buildCache} = t.context;
+	const {graph, resourceFactory} = t.context;
 	const project = getMockProject("module");
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 	graph.traverseBreadthFirst.reset(); // Ignore the call in initTask
 	resourceFactory.createReaderCollection.reset(); // Ignore the call in initTask
@@ -1592,12 +1522,10 @@ test("getDependenciesReader", async (t) => {
 });
 
 test("getDependenciesReader: All dependencies required", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory, projectBuildLogger, buildCache} = t.context;
+	const {graph, resourceFactory} = t.context;
 	const project = getMockProject("module");
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 	// Initialize the cache by calling getDependenciesReader with a subset first to avoid the shortcut
 	// Then call with forceUpdate to populate the cache
@@ -1612,12 +1540,10 @@ test("getDependenciesReader: All dependencies required", async (t) => {
 });
 
 test("getDependenciesReader: No dependencies required", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory, projectBuildLogger, buildCache} = t.context;
+	const {graph, resourceFactory} = t.context;
 	const project = getMockProject("module");
 
-	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, log: projectBuildLogger, buildCache, buildConfig
-	});
+	const taskRunner = createTaskRunner(t, project);
 	await taskRunner._initTasks();
 	graph.traverseBreadthFirst.reset(); // Ignore the call in initTask
 	resourceFactory.createReaderCollection.reset(); // Ignore the call in initTask

--- a/packages/project/test/lib/build/definitions/library.js
+++ b/packages/project/test/lib/build/definitions/library.js
@@ -85,6 +85,7 @@ test("Standard build", async (t) => {
 			supportsDifferentialBuilds: true,
 		},
 		generateJsdoc: {
+			determineBuildSignature: generateJsdocTaskDefinition.determineBuildSignature,
 			requiresDependencies: true,
 			taskFunction: generateJsdocTaskDefinition.taskFunction
 		},
@@ -226,6 +227,7 @@ test("Standard build with legacy spec version", (t) => {
 			supportsDifferentialBuilds: true,
 		},
 		generateJsdoc: {
+			determineBuildSignature: generateJsdocTaskDefinition.determineBuildSignature,
 			requiresDependencies: true,
 			taskFunction: generateJsdocTaskDefinition.taskFunction
 		},
@@ -356,6 +358,7 @@ test("Custom bundles", async (t) => {
 			supportsDifferentialBuilds: true,
 		},
 		generateJsdoc: {
+			determineBuildSignature: generateJsdocTaskDefinition.determineBuildSignature,
 			requiresDependencies: true,
 			taskFunction: generateJsdocTaskDefinition.taskFunction
 		},
@@ -679,6 +682,7 @@ test("Standard build: nulled taskFunction to skip tasks", (t) => {
 	const generateComponentPreloadTaskDefinition = tasks.get("generateComponentPreload");
 	const generateBundleTaskDefinition = tasks.get("generateBundle");
 	const generateThemeDesignerResourcesTaskDefinition = tasks.get("generateThemeDesignerResources");
+	const generateJsdocTaskDefinition = tasks.get("generateJsdoc");
 	t.deepEqual(Object.fromEntries(tasks), {
 		escapeNonAsciiCharacters: {
 			options: {
@@ -706,6 +710,7 @@ test("Standard build: nulled taskFunction to skip tasks", (t) => {
 			supportsDifferentialBuilds: true,
 		},
 		generateJsdoc: {
+			determineBuildSignature: generateJsdocTaskDefinition.determineBuildSignature,
 			requiresDependencies: true,
 			taskFunction: async () => {},
 		},

--- a/packages/project/test/lib/build/helpers/ProjectBuildContext.js
+++ b/packages/project/test/lib/build/helpers/ProjectBuildContext.js
@@ -14,6 +14,17 @@ test.afterEach.always((t) => {
 
 import ProjectBuildContext from "../../../../lib/build/helpers/ProjectBuildContext.js";
 
+// Default stub that satisfies the synchronous wiring done by the
+// ProjectBuildContext constructor (TaskDefinitions needs getGraph + getTaskRepository).
+// Tests that exercise additional buildContext methods spread their own stubs on top.
+function createBuildContextStub(overrides = {}) {
+	return {
+		getGraph: () => ({}),
+		getTaskRepository: () => ({}),
+		...overrides
+	};
+}
+
 test("Missing parameters", (t) => {
 	t.throws(() => {
 		new ProjectBuildContext(
@@ -42,9 +53,9 @@ test("isRootProject: true", (t) => {
 		getName: () => "root project",
 		getType: () => "type",
 	};
-	const buildContext = {
+	const buildContext = createBuildContextStub({
 		getRootProject: () => rootProject
-	};
+	});
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
 		rootProject
@@ -54,9 +65,9 @@ test("isRootProject: true", (t) => {
 });
 
 test("isRootProject: false", (t) => {
-	const buildContext = {
+	const buildContext = createBuildContextStub({
 		getRootProject: () => "root project"
-	};
+	});
 	const project = {
 		getName: () => "not the root project",
 		getType: () => "type",
@@ -71,9 +82,9 @@ test("isRootProject: false", (t) => {
 
 test("getBuildOption", (t) => {
 	const getOptionStub = sinon.stub().returns("pony");
-	const buildContext = {
+	const buildContext = createBuildContextStub({
 		getOption: getOptionStub
-	};
+	});
 	const project = {
 		getName: () => "project",
 		getType: () => "type",
@@ -88,7 +99,7 @@ test("getBuildOption", (t) => {
 });
 
 test("registerCleanupTask", (t) => {
-	const buildContext = {};
+	const buildContext = createBuildContextStub();
 	const project = {
 		getName: () => "project",
 		getType: () => "type",
@@ -105,7 +116,7 @@ test("registerCleanupTask", (t) => {
 });
 
 test("executeCleanupTasks", (t) => {
-	const buildContext = {};
+	const buildContext = createBuildContextStub();
 	const project = {
 		getName: () => "project",
 		getType: () => "type",
@@ -127,7 +138,7 @@ test("executeCleanupTasks", (t) => {
 
 test.serial("getResourceTagCollection", async (t) => {
 	const ProjectBuildContext = (await import("../../../../lib/build/helpers/ProjectBuildContext.js")).default;
-	const buildContext = {};
+	const buildContext = createBuildContextStub();
 	const project = {
 		getName: () => "project",
 		getType: () => "type",
@@ -162,7 +173,7 @@ test("getResourceTagCollection: Assigns project to resource if necessary", (t) =
 		getName: () => "project",
 		getType: () => "type",
 	};
-	const buildContext = {};
+	const buildContext = createBuildContextStub();
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
 		fakeProject
@@ -194,13 +205,13 @@ test("getProject", (t) => {
 		getType: () => "type",
 	};
 	const getProjectStub = sinon.stub().returns("pony");
-	const buildContext = {
+	const buildContext = createBuildContextStub({
 		getGraph: () => {
 			return {
 				getProject: getProjectStub
 			};
 		}
-	};
+	});
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
 		project
@@ -220,13 +231,13 @@ test("getProject: No name provided", (t) => {
 		getType: () => "type",
 	};
 	const getProjectStub = sinon.stub().returns("pony");
-	const buildContext = {
+	const buildContext = createBuildContextStub({
 		getGraph: () => {
 			return {
 				getProject: getProjectStub
 			};
 		}
-	};
+	});
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
 		project
@@ -242,13 +253,13 @@ test("getDependencies", (t) => {
 		getType: () => "type",
 	};
 	const getDependenciesStub = sinon.stub().returns(["dep a", "dep b"]);
-	const buildContext = {
+	const buildContext = createBuildContextStub({
 		getGraph: () => {
 			return {
 				getDependencies: getDependenciesStub
 			};
 		}
-	};
+	});
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
 		project
@@ -266,13 +277,13 @@ test("getDependencies: No name provided", (t) => {
 		getType: () => "type",
 	};
 	const getDependenciesStub = sinon.stub().returns(["dep a", "dep b"]);
-	const buildContext = {
+	const buildContext = createBuildContextStub({
 		getGraph: () => {
 			return {
 				getDependencies: getDependenciesStub
 			};
 		}
-	};
+	});
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
 		project
@@ -285,7 +296,7 @@ test("getDependencies: No name provided", (t) => {
 });
 
 test("getTaskUtil", (t) => {
-	const buildContext = {};
+	const buildContext = createBuildContextStub();
 	const project = {
 		getName: () => "project",
 		getType: () => "type",
@@ -320,7 +331,8 @@ test.serial("getTaskRunner", async (t) => {
 				buildCache: "buildCache",
 				taskUtil: "taskUtil",
 				taskRepository: "taskRepository",
-				buildConfig: "buildConfig"
+				buildConfig: "buildConfig",
+				taskDefinitions: projectBuildContext._taskDefinitions
 			}, "TaskRunner created with expected constructor arguments");
 		}
 	}
@@ -336,10 +348,10 @@ test.serial("getTaskRunner", async (t) => {
 	const buildCache = {};
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
-		project,
-		undefined,
-		buildCache,
+		project
 	);
+	// _buildCache is normally set by ProjectBuildContext.create(); inject directly for this unit test
+	projectBuildContext._buildCache = buildCache;
 
 	projectBuildContext.getTaskUtil = () => "taskUtil";
 
@@ -353,16 +365,15 @@ test("possiblyRequiresBuild: has no build-manifest", (t) => {
 		getType: sinon.stub().returns("bar"),
 		getBuildManifest: () => null
 	};
-	const buildContext = {};
+	const buildContext = createBuildContextStub();
 	const buildCache = {
 		isFresh: sinon.stub().returns(false)
 	};
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
-		project,
-		undefined,
-		buildCache
+		project
 	);
+	projectBuildContext._buildCache = buildCache;
 	t.true(projectBuildContext.possiblyRequiresBuild(), "Project without build-manifest requires to be build");
 });
 
@@ -377,7 +388,7 @@ test("possiblyRequiresBuild: has build-manifest", (t) => {
 			};
 		}
 	};
-	const buildContext = {};
+	const buildContext = createBuildContextStub();
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
 		project
@@ -397,7 +408,7 @@ test.serial("getBuildMetadata", (t) => {
 		}
 	};
 	const getTimeStub = sinon.stub(Date.prototype, "getTime").callThrough().onFirstCall().returns(1659016800000);
-	const buildContext = {};
+	const buildContext = createBuildContextStub();
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
 		project
@@ -416,7 +427,7 @@ test("getBuildMetadata: has no build-manifest", (t) => {
 		getType: sinon.stub().returns("bar"),
 		getBuildManifest: () => null
 	};
-	const buildContext = {};
+	const buildContext = createBuildContextStub();
 	const projectBuildContext = new ProjectBuildContext(
 		buildContext,
 		project

--- a/packages/project/test/lib/specifications/extensions/Task.js
+++ b/packages/project/test/lib/specifications/extensions/Task.js
@@ -100,15 +100,15 @@ test("Task with illegal suffix", async (t) => {
 		"Threw with expected error message");
 });
 
-test("getBuildSignatureCallback (CJS)", async (t) => {
+test("getDetermineBuildSignatureCallback (CJS)", async (t) => {
 	const extension = await Specification.create(clone(basicCjsTaskInput));
-	const callback = await extension.getBuildSignatureCallback();
+	const callback = await extension.getDetermineBuildSignatureCallback();
 	t.is(callback, undefined, "Returns undefined when not exported");
 });
 
-test("getBuildSignatureCallback (ESM)", async (t) => {
+test("getDetermineBuildSignatureCallback (ESM)", async (t) => {
 	const extension = await Specification.create(clone(basicEsmTaskInput));
-	const callback = await extension.getBuildSignatureCallback();
+	const callback = await extension.getDetermineBuildSignatureCallback();
 	t.is(callback, undefined, "Returns undefined when not exported");
 });
 


### PR DESCRIPTION
Extract the task-list construction out of TaskRunner into a new
TaskDefinitions class which owns the project-type to build-definition
switch, the standard task map, and the custom task validation and
de-duplication loop.

Each standard task in a build definition can expose an async
`determineBuildSignature()` returning a string contribution; the
fallback is `JSON.stringify(taskDef.options)`. Custom tasks expose the
same via the `determineBuildSignature` named export of their module,
surfaced through `Task#getDetermineBuildSignatureCallback`, and must
declare specVersion >= 5.0 to use it. `getProjectSignature` mixes the
aggregated string in alongside the existing inputs.

Split ProjectBuildContext into a synchronous wiring phase (logger,
TaskUtil, TaskDefinitions) and a static `create()` that resolves task
signatures, computes the project signature, and constructs the
ProjectBuildCache. `create()` parameters are reordered to
`(buildContext, project, baseSignature, cacheManager)`.

Add `TaskUtil#getReadOnlyInterface(specVersion)` for passing into the
`determineBuildSignature` callback before the task has run.

Also Include builder and fs version into project build signature.
