### PR TITLE
refactor(project): Prevent concurrent writes to cache DB

### DIFF
--- a/packages/project/lib/build/cache/BuildCacheStorage.js
+++ b/packages/project/lib/build/cache/BuildCacheStorage.js
@@ -21,8 +21,7 @@ export default class BuildCacheStorage {
 	#db;
 	#stmts;
 	#dbPath;
-	#inMetadataBatch = false;
-	#inContentBatch = false;
+	#inTransaction = false;
 
 	/**
 	 * @param {string} dbDir Directory in which to create the cache.db file
@@ -395,85 +394,47 @@ export default class BuildCacheStorage {
 		);
 	}
 
-	// ===== Batch transactions =====
+	// ===== Transactions =====
 
 	/**
-	 * Begins a metadata batch transaction (outer transaction)
+	 * Runs the given synchronous callback inside a database transaction.
+	 *
+	 * The transaction is committed when the callback returns and rolled back if it throws.
+	 * Callers do not have to manage BEGIN/COMMIT/ROLLBACK themselves — passing a
+	 * callback that performs both metadata and content writes is sufficient.
+	 *
+	 * Nested calls are not supported and will throw.
+	 * Async callbacks (or any callback that returns a thenable) are not supported
+	 * and will throw, rolling back the transaction.
+	 *
+	 * @param {Function} fn Synchronous callback that performs the writes
+	 * @returns {*} Whatever the callback returns
 	 */
-	beginMetadataBatch() {
-		if (!this.#inMetadataBatch) {
-			this.#db.exec("BEGIN");
-			this.#inMetadataBatch = true;
+	transaction(fn) {
+		if (this.#inTransaction) {
+			throw new Error("BuildCacheStorage#transaction: Nested transactions are not supported");
 		}
-	}
-
-	/**
-	 * Commits the current metadata batch transaction
-	 */
-	endMetadataBatch() {
-		if (this.#inMetadataBatch) {
+		this.#db.exec("BEGIN");
+		this.#inTransaction = true;
+		try {
+			const result = fn();
+			if (result && typeof result.then === "function") {
+				throw new Error(
+					"BuildCacheStorage#transaction: Async callbacks are not supported. " +
+					"The callback must be synchronous."
+				);
+			}
 			this.#db.exec("COMMIT");
-			this.#inMetadataBatch = false;
+			this.#inTransaction = false;
+			return result;
+		} catch (err) {
+			try {
+				this.#db.exec("ROLLBACK");
+			} finally {
+				this.#inTransaction = false;
+			}
+			throw err;
 		}
-	}
-
-	/**
-	 * Rolls back the current metadata batch transaction
-	 */
-	rollbackMetadataBatch() {
-		if (this.#inMetadataBatch) {
-			this.#db.exec("ROLLBACK");
-			this.#inMetadataBatch = false;
-		}
-	}
-
-	/**
-	 * Begins a content batch transaction.
-	 * Uses SAVEPOINT when nested inside a metadata batch, plain BEGIN otherwise.
-	 */
-	beginContentBatch() {
-		if (this.#inContentBatch) {
-			return;
-		}
-		if (this.#inMetadataBatch) {
-			this.#db.exec("SAVEPOINT content_batch");
-		} else {
-			this.#db.exec("BEGIN");
-		}
-		this.#inContentBatch = true;
-	}
-
-	/**
-	 * Commits the current content batch transaction.
-	 * Uses RELEASE when nested inside a metadata batch, plain COMMIT otherwise.
-	 */
-	endContentBatch() {
-		if (!this.#inContentBatch) {
-			return;
-		}
-		if (this.#inMetadataBatch) {
-			this.#db.exec("RELEASE content_batch");
-		} else {
-			this.#db.exec("COMMIT");
-		}
-		this.#inContentBatch = false;
-	}
-
-	/**
-	 * Rolls back the current content batch transaction.
-	 * Uses ROLLBACK TO + RELEASE when nested inside a metadata batch, plain ROLLBACK otherwise.
-	 */
-	rollbackContentBatch() {
-		if (!this.#inContentBatch) {
-			return;
-		}
-		if (this.#inMetadataBatch) {
-			this.#db.exec("ROLLBACK TO content_batch");
-			this.#db.exec("RELEASE content_batch");
-		} else {
-			this.#db.exec("ROLLBACK");
-		}
-		this.#inContentBatch = false;
 	}
 
 	// ===== Batch existence checks =====
@@ -554,11 +515,12 @@ export default class BuildCacheStorage {
 	 * Closes the database connection
 	 */
 	close() {
-		if (this.#inContentBatch) {
-			this.rollbackContentBatch();
-		}
-		if (this.#inMetadataBatch) {
-			this.rollbackMetadataBatch();
+		if (this.#inTransaction) {
+			try {
+				this.#db.exec("ROLLBACK");
+			} finally {
+				this.#inTransaction = false;
+			}
 		}
 		this.#db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
 		this.#db.close();

--- a/packages/project/lib/build/cache/CacheManager.js
+++ b/packages/project/lib/build/cache/CacheManager.js
@@ -313,45 +313,18 @@ export default class CacheManager {
 	}
 
 	/**
-	 * Begins a batch transaction for multiple content writes
+	 * Runs the given synchronous callback inside a database transaction.
+	 *
+	 * The transaction is committed when the callback returns and rolled back if it throws.
+	 * Callers do not need to manage begin/commit/rollback themselves — any combination of
+	 * metadata and content writes performed in the callback is committed atomically.
+	 *
+	 * @public
+	 * @param {Function} fn Synchronous callback performing the writes
+	 * @returns {*} Whatever the callback returns
 	 */
-	beginContentBatch() {
-		this.#storage.beginContentBatch();
-	}
-
-	/**
-	 * Commits the current content batch transaction
-	 */
-	endContentBatch() {
-		this.#storage.endContentBatch();
-	}
-
-	/**
-	 * Rolls back the current content batch transaction
-	 */
-	rollbackContentBatch() {
-		this.#storage.rollbackContentBatch();
-	}
-
-	/**
-	 * Begins a batch transaction for multiple metadata writes
-	 */
-	beginMetadataBatch() {
-		this.#storage.beginMetadataBatch();
-	}
-
-	/**
-	 * Commits the current metadata batch transaction
-	 */
-	endMetadataBatch() {
-		this.#storage.endMetadataBatch();
-	}
-
-	/**
-	 * Rolls back the current metadata batch transaction
-	 */
-	rollbackMetadataBatch() {
-		this.#storage.rollbackMetadataBatch();
+	transaction(fn) {
+		return this.#storage.transaction(fn);
 	}
 
 	/**

--- a/packages/project/lib/build/cache/CacheManager.js
+++ b/packages/project/lib/build/cache/CacheManager.js
@@ -291,22 +291,6 @@ export default class CacheManager {
 	}
 
 	/**
-	 * Writes a resource to the content-addressable storage
-	 *
-	 * If the resource content (identified by integrity hash) already exists,
-	 * the write is skipped (deduplication).
-	 *
-	 * @public
-	 * @param {@ui5/fs/Resource} resource Resource to cache
-	 * @returns {Promise<void>}
-	 */
-	async writeStageResource(resource) {
-		const integrity = await resource.getIntegrity();
-		const buffer = await resource.getBuffer();
-		this.#storage.putContent(integrity, buffer);
-	}
-
-	/**
 	 * Writes content directly to the CAS with pre-fetched integrity and buffer
 	 *
 	 * @public

--- a/packages/project/lib/build/cache/CacheManager.js
+++ b/packages/project/lib/build/cache/CacheManager.js
@@ -103,9 +103,9 @@ export default class CacheManager {
 	 * @param {string} projectId Project identifier
 	 * @param {string} buildSignature Build signature hash
 	 * @param {string} kind "source" or "result"
-	 * @returns {Promise<object|null>} Parsed index cache object or null if not found
+	 * @returns {object|null} Parsed index cache object or null if not found
 	 */
-	async readIndexCache(projectId, buildSignature, kind) {
+	readIndexCache(projectId, buildSignature, kind) {
 		return this.#storage.readIndexCache(projectId, buildSignature, kind);
 	}
 
@@ -117,9 +117,8 @@ export default class CacheManager {
 	 * @param {string} buildSignature Build signature hash
 	 * @param {string} kind "source" or "result"
 	 * @param {object} index Index object containing resource tree and task metadata
-	 * @returns {Promise<void>}
 	 */
-	async writeIndexCache(projectId, buildSignature, kind, index) {
+	writeIndexCache(projectId, buildSignature, kind, index) {
 		this.#storage.writeIndexCache(projectId, buildSignature, kind, index);
 	}
 
@@ -131,9 +130,9 @@ export default class CacheManager {
 	 * @param {string} buildSignature Build signature hash
 	 * @param {string} stageId Stage identifier
 	 * @param {string} stageSignature Stage signature hash
-	 * @returns {Promise<object|null>} Parsed stage metadata or null if not found
+	 * @returns {object|null} Parsed stage metadata or null if not found
 	 */
-	async readStageCache(projectId, buildSignature, stageId, stageSignature) {
+	readStageCache(projectId, buildSignature, stageId, stageSignature) {
 		return this.#storage.readStageCache(projectId, buildSignature, stageId, stageSignature);
 	}
 
@@ -146,9 +145,8 @@ export default class CacheManager {
 	 * @param {string} stageId Stage identifier
 	 * @param {string} stageSignature Stage signature hash
 	 * @param {object} metadata Stage metadata object to serialize
-	 * @returns {Promise<void>}
 	 */
-	async writeStageCache(projectId, buildSignature, stageId, stageSignature, metadata) {
+	writeStageCache(projectId, buildSignature, stageId, stageSignature, metadata) {
 		this.#storage.writeStageCache(projectId, buildSignature, stageId, stageSignature, metadata);
 	}
 
@@ -160,9 +158,9 @@ export default class CacheManager {
 	 * @param {string} buildSignature Build signature hash
 	 * @param {string} taskName Task name
 	 * @param {string} type "project" or "dependency"
-	 * @returns {Promise<object|null>} Parsed task metadata or null if not found
+	 * @returns {object|null} Parsed task metadata or null if not found
 	 */
-	async readTaskMetadata(projectId, buildSignature, taskName, type) {
+	readTaskMetadata(projectId, buildSignature, taskName, type) {
 		return this.#storage.readTaskMetadata(projectId, buildSignature, taskName, type);
 	}
 
@@ -175,9 +173,8 @@ export default class CacheManager {
 	 * @param {string} taskName Task name
 	 * @param {string} type "project" or "dependency"
 	 * @param {object} metadata Task metadata object to serialize
-	 * @returns {Promise<void>}
 	 */
-	async writeTaskMetadata(projectId, buildSignature, taskName, type, metadata) {
+	writeTaskMetadata(projectId, buildSignature, taskName, type, metadata) {
 		this.#storage.writeTaskMetadata(projectId, buildSignature, taskName, type, metadata);
 	}
 
@@ -188,9 +185,9 @@ export default class CacheManager {
 	 * @param {string} projectId Project identifier
 	 * @param {string} buildSignature Build signature hash
 	 * @param {string} stageSignature Stage signature hash
-	 * @returns {Promise<object|null>} Parsed result metadata or null if not found
+	 * @returns {object|null} Parsed result metadata or null if not found
 	 */
-	async readResultMetadata(projectId, buildSignature, stageSignature) {
+	readResultMetadata(projectId, buildSignature, stageSignature) {
 		return this.#storage.readResultMetadata(projectId, buildSignature, stageSignature);
 	}
 
@@ -202,9 +199,8 @@ export default class CacheManager {
 	 * @param {string} buildSignature Build signature hash
 	 * @param {string} stageSignature Stage signature hash
 	 * @param {object} metadata Result metadata object to serialize
-	 * @returns {Promise<void>}
 	 */
-	async writeResultMetadata(projectId, buildSignature, stageSignature, metadata) {
+	writeResultMetadata(projectId, buildSignature, stageSignature, metadata) {
 		this.#storage.writeResultMetadata(projectId, buildSignature, stageSignature, metadata);
 	}
 

--- a/packages/project/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/lib/build/cache/ProjectBuildCache.js
@@ -233,7 +233,7 @@ export default class ProjectBuildCache {
 		if (this.#resultCacheState === RESULT_CACHE_STATES.PENDING_VALIDATION) {
 			log.verbose(`Project ${this.#project.getName()} cache requires validation due to detected changes.`);
 			const findStart = performance.now();
-			const changedResourcesOrFalse = await this.#findResultCache();
+			const changedResourcesOrFalse = this.#findResultCache();
 			if (log.isLevelEnabled("perf")) {
 				log.perf(
 					`Validated result cache for project ${this.#project.getName()} ` +
@@ -345,11 +345,11 @@ export default class ProjectBuildCache {
 	 * If found, creates a reader for the cached stage and sets it as the project's
 	 * result stage.
 	 *
-	 * @returns {Promise<string[]|false>}
+	 * @returns {string[]|false}
 	 *   Array of resource paths written by the cached result stage (empty if the result stage remains unchanged),
 	 *   or false if no cache found
 	 */
-	async #findResultCache() {
+	#findResultCache() {
 		const resultSignatures = this.#getPossibleResultStageSignatures();
 		if (resultSignatures.includes(this.#currentResultSignature)) {
 			log.verbose(
@@ -382,7 +382,7 @@ export default class ProjectBuildCache {
 		const {stageSignatures, sourceStageSignature} = resultMetadata;
 
 		const importStagesStart = log.isLevelEnabled("perf") ? performance.now() : 0;
-		const writtenResourcePaths = await this.#importStages(stageSignatures);
+		const writtenResourcePaths = this.#importStages(stageSignatures);
 		if (log.isLevelEnabled("perf")) {
 			log.perf(
 				`#findResultCache importStages for project ${this.#project.getName()} ` +
@@ -392,7 +392,7 @@ export default class ProjectBuildCache {
 
 		// Restore CAS-backed source reader from the stored source stage
 		const restoreSourcesStart = log.isLevelEnabled("perf") ? performance.now() : 0;
-		await this.#restoreFrozenSources(sourceStageSignature);
+		this.#restoreFrozenSources(sourceStageSignature);
 		if (log.isLevelEnabled("perf")) {
 			log.perf(
 				`#findResultCache restoreFrozenSources for project ${this.#project.getName()} ` +
@@ -410,23 +410,23 @@ export default class ProjectBuildCache {
 	 * Imports cached stages and sets them in the project
 	 *
 	 * @param {Object<string, string>} stageSignatures Map of stage names to their signatures
-	 * @returns {Promise<string[]>} Array of resource paths written by all imported stages
+	 * @returns {string[]} Array of resource paths written by all imported stages
 	 */
-	async #importStages(stageSignatures) {
+	#importStages(stageSignatures) {
 		const stageNames = Object.keys(stageSignatures);
 		if (this.#project.getProjectResources().getStage()?.getId() === "initial") {
 			// Only initialize stages once
 			this.#project.getProjectResources().initStages(stageNames);
 		}
-		const importedStages = await Promise.all(stageNames.map(async (stageName) => {
+		const importedStages = stageNames.map((stageName) => {
 			const stageSignature = stageSignatures[stageName];
-			const stageCache = await this.#findStageCache(stageName, [stageSignature]);
+			const stageCache = this.#findStageCache(stageName, [stageSignature]);
 			if (!stageCache) {
 				throw new Error(`Inconsistent result cache: Could not find cached stage ` +
 					`${stageName} with signature ${stageSignature} for project ${this.#project.getName()}`);
 			}
 			return [stageName, stageCache];
-		}));
+		});
 		this.#project.getProjectResources().useResultStage();
 
 		// When #currentStageSignatures is empty, this is the initial import from persistent cache.
@@ -555,7 +555,7 @@ export default class ProjectBuildCache {
 			return createStageSignature(...signaturePair);
 		});
 
-		const stageCache = await this.#findStageCache(stageName, stageSignatures);
+		const stageCache = this.#findStageCache(stageName, stageSignatures);
 		const oldStageSig = this.#currentStageSignatures.get(stageName)?.join("-");
 		if (stageCache) {
 			this.#project.getProjectResources().setStage(stageName, stageCache.stage,
@@ -604,7 +604,7 @@ export default class ProjectBuildCache {
 				return createStageSignature(...signaturePair);
 			});
 			const deltaSignatures = [...projDeltaSignatures, ...depDeltaSignatures, ...deltaDeltaSignatures];
-			const deltaStageCache = await this.#findStageCache(stageName, deltaSignatures);
+			const deltaStageCache = this.#findStageCache(stageName, deltaSignatures);
 			if (deltaStageCache) {
 				// Store dependency signature for later use in result stage signature calculation
 				const [foundProjectSig, foundDepSig] = deltaStageCache.signature.split("-");
@@ -708,10 +708,10 @@ export default class ProjectBuildCache {
 	 *
 	 * @param {string} stageName Name of the stage to find
 	 * @param {string[]} stageSignatures Possible signatures for the stage
-	 * @returns {Promise<@ui5/project/build/cache/ProjectBuildCache~StageCacheEntry|undefined>}
+	 * @returns {@ui5/project/build/cache/ProjectBuildCache~StageCacheEntry|undefined}
 	 *   Cached stage entry or undefined if not found
 	 */
-	async #findStageCache(stageName, stageSignatures) {
+	#findStageCache(stageName, stageSignatures) {
 		if (!stageSignatures.length) {
 			return;
 		}
@@ -1013,9 +1013,8 @@ export default class ProjectBuildCache {
 	 *
 	 * @public
 	 * @param {string[]} taskNames Array of task names to initialize stages for
-	 * @returns {Promise<void>}
 	 */
-	async setTasks(taskNames) {
+	setTasks(taskNames) {
 		const stageNames = taskNames.map((taskName) => this.#getStageNameForTask(taskName));
 		this.#project.getProjectResources().initStages(stageNames);
 
@@ -1210,7 +1209,7 @@ export default class ProjectBuildCache {
 	 * @param {string} sourceStageSignature The source index signature used when the source
 	 *   stage was persisted
 	 */
-	async #restoreFrozenSources(sourceStageSignature) {
+	#restoreFrozenSources(sourceStageSignature) {
 		const stageMetadata = this.#cacheManager.readStageCache(
 			this.#project.getId(), this.#buildSignature, "source", sourceStageSignature);
 

--- a/packages/project/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/lib/build/cache/ProjectBuildCache.js
@@ -1164,29 +1164,14 @@ export default class ProjectBuildCache {
 			resourceMetadata[path] = meta;
 		}
 
-		const hasContentWrites = prepared.casRows.length > 0;
-		this.#cacheManager.beginMetadataBatch();
-		try {
-			if (hasContentWrites) {
-				this.#cacheManager.beginContentBatch();
-				for (const {integrity, compressedBuffer} of prepared.casRows) {
-					this.#cacheManager.putCompressedContent(integrity, compressedBuffer);
-				}
+		this.#cacheManager.transaction(() => {
+			for (const {integrity, compressedBuffer} of prepared.casRows) {
+				this.#cacheManager.putCompressedContent(integrity, compressedBuffer);
 			}
 			this.#cacheManager.writeStageCache(
 				this.#project.getId(), this.#buildSignature, "source", sourceSignature,
 				{resourceMetadata});
-			if (hasContentWrites) {
-				this.#cacheManager.endContentBatch();
-			}
-			this.#cacheManager.endMetadataBatch();
-		} catch (err) {
-			if (hasContentWrites) {
-				this.#cacheManager.rollbackContentBatch();
-			}
-			this.#cacheManager.rollbackMetadataBatch();
-			throw err;
-		}
+		});
 
 		this.#collectKnownIntegrities(resourceMetadata);
 
@@ -1504,15 +1489,9 @@ export default class ProjectBuildCache {
 			}
 		}
 
-		const hasContentWrites = allCasRows.length > 0;
-		this.#cacheManager.beginMetadataBatch();
-		try {
-			if (hasContentWrites) {
-				this.#cacheManager.beginContentBatch();
-				for (const {integrity, compressedBuffer} of allCasRows) {
-					this.#cacheManager.putCompressedContent(integrity, compressedBuffer);
-				}
-				this.#cacheManager.endContentBatch();
+		this.#cacheManager.transaction(() => {
+			for (const {integrity, compressedBuffer} of allCasRows) {
+				this.#cacheManager.putCompressedContent(integrity, compressedBuffer);
 			}
 			if (resultPrepared) {
 				this.#cacheManager.writeResultMetadata(
@@ -1533,17 +1512,7 @@ export default class ProjectBuildCache {
 					sourceIndexPrepared.projectId, sourceIndexPrepared.buildSignature,
 					sourceIndexPrepared.kind, sourceIndexPrepared.index);
 			}
-			if (hasContentWrites) {
-				this.#cacheManager.endContentBatch();
-			}
-			this.#cacheManager.endMetadataBatch();
-		} catch (err) {
-			if (hasContentWrites) {
-				this.#cacheManager.rollbackContentBatch();
-			}
-			this.#cacheManager.rollbackMetadataBatch();
-			throw err;
-		}
+		});
 
 		if (log.isLevelEnabled("perf")) {
 			log.perf(

--- a/packages/project/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/lib/build/cache/ProjectBuildCache.js
@@ -369,7 +369,7 @@ export default class ProjectBuildCache {
 		}
 
 		const resultSignature = existingSignatures[0];
-		const resultMetadata = await this.#cacheManager.readResultMetadata(
+		const resultMetadata = this.#cacheManager.readResultMetadata(
 			this.#project.getId(), this.#buildSignature, resultSignature);
 
 		if (!resultMetadata) {
@@ -690,7 +690,7 @@ export default class ProjectBuildCache {
 			return;
 		}
 
-		// Only read signatures that exist — store promises, don't await
+		// Only read signatures that exist
 		const prefetchMap = new Map();
 		for (const sig of existingSignatures) {
 			prefetchMap.set(sig, this.#cacheManager.readStageCache(
@@ -730,14 +730,11 @@ export default class ProjectBuildCache {
 		if (prefetchMap) {
 			this.#prefetchedStageReads.delete(stageName);
 			for (const stageSignature of stageSignatures) {
-				const promise = prefetchMap.get(stageSignature);
-				if (promise) {
-					const stageMetadata = await promise;
-					if (stageMetadata) {
-						log.verbose(`Found prefetched cached stage for task ${stageName} ` +
-							`with signature ${stageSignature}`);
-						return this.#processStageCacheMetadata(stageName, stageSignature, stageMetadata);
-					}
+				const stageMetadata = prefetchMap.get(stageSignature);
+				if (stageMetadata) {
+					log.verbose(`Found prefetched cached stage for task ${stageName} ` +
+						`with signature ${stageSignature}`);
+					return this.#processStageCacheMetadata(stageName, stageSignature, stageMetadata);
 				}
 			}
 			// Filter out already-checked signatures from disk lookup
@@ -754,7 +751,7 @@ export default class ProjectBuildCache {
 			return;
 		}
 		const stageSignature = existingSignatures[0];
-		const stageMetadata = await this.#cacheManager.readStageCache(
+		const stageMetadata = this.#cacheManager.readStageCache(
 			this.#project.getId(), this.#buildSignature, stageName, stageSignature);
 		if (!stageMetadata) {
 			return;
@@ -1113,11 +1110,10 @@ export default class ProjectBuildCache {
 		const sourceSignature = this.#sourceIndex.getSignature();
 		const previousMetadata = this.#cachedFrozenSourceMetadata;
 
-		let resourceMetadata;
+		let pathsToRead;
+		const reusedMetadata = Object.create(null);
 		if (previousMetadata) {
-			// Delta path: reuse previous metadata for unchanged untransformed paths
-			const pathsToRead = [];
-			const reusedMetadata = Object.create(null);
+			pathsToRead = [];
 			for (const p of untransformedPaths) {
 				if (previousMetadata[p]) {
 					reusedMetadata[p] = previousMetadata[p];
@@ -1125,56 +1121,15 @@ export default class ProjectBuildCache {
 					pathsToRead.push(p);
 				}
 			}
-
-			if (pathsToRead.length === 0) {
-				// Fast path: all metadata reused from previous build
-				resourceMetadata = reusedMetadata;
-				if (log.isLevelEnabled("perf")) {
-					log.perf(
-						`#freezeUntransformedSources for project ${this.#project.getName()}: ` +
-						`reused all ${untransformedPaths.length} entries from previous metadata`);
-				}
-			} else {
-				// Delta path: read only new/newly-untransformed paths
-				const sourceReader = this.#project.getSourceReader();
-				const readStart = log.isLevelEnabled("perf") ? performance.now() : 0;
-				const resources = await Promise.all(pathsToRead.map(async (resourcePath) => {
-					const resource = await sourceReader.byPath(resourcePath);
-					if (!resource) {
-						throw new Error(
-							`Source file ${resourcePath} not found during CAS freeze ` +
-							`for project ${this.#project.getName()}`);
-					}
-					return resource;
-				}));
-				if (log.isLevelEnabled("perf")) {
-					log.perf(
-						`#freezeUntransformedSources byPath reads for project ${this.#project.getName()} ` +
-						`completed in ${(performance.now() - readStart).toFixed(2)} ms ` +
-						`(${resources.length} of ${untransformedPaths.length} resources)`);
-				}
-
-				const writeStart = log.isLevelEnabled("perf") ? performance.now() : 0;
-				const deltaMetadata = await this.#writeStageResources(
-					resources, "source", sourceSignature, this.#knownCasIntegrities);
-				if (log.isLevelEnabled("perf")) {
-					log.perf(
-						`#freezeUntransformedSources writeStageResources for project ` +
-						`${this.#project.getName()} ` +
-						`completed in ${(performance.now() - writeStart).toFixed(2)} ms`);
-				}
-
-				// Merge: reused entries + delta entries
-				resourceMetadata = reusedMetadata;
-				for (const [path, meta] of Object.entries(deltaMetadata)) {
-					resourceMetadata[path] = meta;
-				}
-			}
 		} else {
-			// Cold cache: read all untransformed sources (no previous metadata available)
+			pathsToRead = untransformedPaths;
+		}
+
+		let prepared = {resourceMetadata: Object.create(null), casRows: []};
+		if (pathsToRead.length > 0) {
 			const sourceReader = this.#project.getSourceReader();
 			const readStart = log.isLevelEnabled("perf") ? performance.now() : 0;
-			const resources = await Promise.all(untransformedPaths.map(async (resourcePath) => {
+			const resources = await Promise.all(pathsToRead.map(async (resourcePath) => {
 				const resource = await sourceReader.byPath(resourcePath);
 				if (!resource) {
 					throw new Error(
@@ -1187,26 +1142,54 @@ export default class ProjectBuildCache {
 				log.perf(
 					`#freezeUntransformedSources byPath reads for project ${this.#project.getName()} ` +
 					`completed in ${(performance.now() - readStart).toFixed(2)} ms ` +
-					`(${resources.length} resources)`);
+					`(${resources.length} of ${untransformedPaths.length} resources)`);
 			}
 
-			const writeStart = log.isLevelEnabled("perf") ? performance.now() : 0;
-			resourceMetadata = await this.#writeStageResources(
-				resources, "source", sourceSignature, this.#knownCasIntegrities);
+			const prepStart = log.isLevelEnabled("perf") ? performance.now() : 0;
+			prepared = await this.#prepareStageResources(resources, "source");
 			if (log.isLevelEnabled("perf")) {
 				log.perf(
-					`#freezeUntransformedSources writeStageResources for project ` +
+					`#freezeUntransformedSources prepareStageResources for project ` +
 					`${this.#project.getName()} ` +
-					`completed in ${(performance.now() - writeStart).toFixed(2)} ms`);
+					`completed in ${(performance.now() - prepStart).toFixed(2)} ms`);
 			}
+		} else if (log.isLevelEnabled("perf")) {
+			log.perf(
+				`#freezeUntransformedSources for project ${this.#project.getName()}: ` +
+				`reused all ${untransformedPaths.length} entries from previous metadata`);
+		}
+
+		// Merge reused entries with freshly-prepared entries
+		const resourceMetadata = reusedMetadata;
+		for (const [path, meta] of Object.entries(prepared.resourceMetadata)) {
+			resourceMetadata[path] = meta;
+		}
+
+		const hasContentWrites = prepared.casRows.length > 0;
+		this.#cacheManager.beginMetadataBatch();
+		try {
+			if (hasContentWrites) {
+				this.#cacheManager.beginContentBatch();
+				for (const {integrity, compressedBuffer} of prepared.casRows) {
+					this.#cacheManager.putCompressedContent(integrity, compressedBuffer);
+				}
+			}
+			this.#cacheManager.writeStageCache(
+				this.#project.getId(), this.#buildSignature, "source", sourceSignature,
+				{resourceMetadata});
+			if (hasContentWrites) {
+				this.#cacheManager.endContentBatch();
+			}
+			this.#cacheManager.endMetadataBatch();
+		} catch (err) {
+			if (hasContentWrites) {
+				this.#cacheManager.rollbackContentBatch();
+			}
+			this.#cacheManager.rollbackMetadataBatch();
+			throw err;
 		}
 
 		this.#collectKnownIntegrities(resourceMetadata);
-
-		// Persist source stage metadata in the stage cache
-		await this.#cacheManager.writeStageCache(
-			this.#project.getId(), this.#buildSignature, "source", sourceSignature,
-			{resourceMetadata});
 
 		log.verbose(
 			`Stored ${untransformedPaths.length} untransformed source files of project ` +
@@ -1228,7 +1211,7 @@ export default class ProjectBuildCache {
 	 *   stage was persisted
 	 */
 	async #restoreFrozenSources(sourceStageSignature) {
-		const stageMetadata = await this.#cacheManager.readStageCache(
+		const stageMetadata = this.#cacheManager.readStageCache(
 			this.#project.getId(), this.#buildSignature, "source", sourceStageSignature);
 
 		if (!stageMetadata) {
@@ -1357,10 +1340,8 @@ export default class ProjectBuildCache {
 		this.#changedProjectSourcePaths = [];
 
 		const sourceReader = this.#project.getSourceReader();
-		const [resources, indexCache] = await Promise.all([
-			await sourceReader.byGlob("/**/*"),
-			await this.#cacheManager.readIndexCache(this.#project.getId(), this.#buildSignature, "source"),
-		]);
+		const resources = await sourceReader.byGlob("/**/*");
+		const indexCache = this.#cacheManager.readIndexCache(this.#project.getId(), this.#buildSignature, "source");
 		if (indexCache) {
 			log.verbose(`Using cached resource index for project ${this.#project.getName()}`);
 			// Create and diff resource index
@@ -1375,7 +1356,7 @@ export default class ProjectBuildCache {
 			// that were never written to CAS).
 			const cachedSourceSignature = indexCache.indexTree.root.hash;
 			if (cachedSourceSignature) {
-				const sourceStageMetadata = await this.#cacheManager.readStageCache(
+				const sourceStageMetadata = this.#cacheManager.readStageCache(
 					this.#project.getId(), this.#buildSignature, "source", cachedSourceSignature);
 				if (sourceStageMetadata?.resourceMetadata) {
 					this.#collectKnownIntegrities(sourceStageMetadata.resourceMetadata);
@@ -1386,13 +1367,13 @@ export default class ProjectBuildCache {
 			// Import task caches
 			const buildTaskCaches = await Promise.all(
 				indexCache.tasks.map(async ([taskName, supportsDifferentialBuilds]) => {
-					const projectRequests = await this.#cacheManager.readTaskMetadata(
+					const projectRequests = this.#cacheManager.readTaskMetadata(
 						this.#project.getId(), this.#buildSignature, taskName, "project");
 					if (!projectRequests) {
 						throw new Error(`Failed to load project request cache for task ` +
 							`${taskName} in project ${this.#project.getName()}`);
 					}
-					const dependencyRequests = await this.#cacheManager.readTaskMetadata(
+					const dependencyRequests = this.#cacheManager.readTaskMetadata(
 						this.#project.getId(), this.#buildSignature, taskName, "dependencies");
 					if (!dependencyRequests) {
 						throw new Error(`Failed to load dependency request cache for task ` +
@@ -1505,21 +1486,66 @@ export default class ProjectBuildCache {
 
 		// Default and Force modes: Write cache normally
 		const cacheWriteStart = performance.now();
+
+		// Gather all cache data before opening any transactions
+		const stagePrepared = await this.#prepareTaskStageCache();
+		const resultPrepared = this.#prepareResultCache();
+		const taskRequestPrepared = this.#prepareTaskRequestCache();
+		const sourceIndexPrepared = this.#prepareSourceIndex();
+
+		// Calculate CAS rows - dedupe across stages (identical integrity produced by two stages writes once)
+		const seenIntegrities = new Set();
+		const allCasRows = [];
+		for (const {casRows} of stagePrepared) {
+			for (const row of casRows) {
+				if (!seenIntegrities.has(row.integrity)) {
+					seenIntegrities.add(row.integrity);
+					allCasRows.push(row);
+				}
+			}
+		}
+
+		const hasContentWrites = allCasRows.length > 0;
 		this.#cacheManager.beginMetadataBatch();
 		try {
-			await Promise.all([
-				this.#writeResultCache(),
-
-				this.#writeTaskStageCache(),
-				this.#writeTaskRequestCache(),
-
-				this.#writeSourceIndex(),
-			]);
+			if (hasContentWrites) {
+				this.#cacheManager.beginContentBatch();
+				for (const {integrity, compressedBuffer} of allCasRows) {
+					this.#cacheManager.putCompressedContent(integrity, compressedBuffer);
+				}
+				this.#cacheManager.endContentBatch();
+			}
+			if (resultPrepared) {
+				this.#cacheManager.writeResultMetadata(
+					resultPrepared.projectId, resultPrepared.buildSignature,
+					resultPrepared.stageSignature, resultPrepared.metadata);
+			}
+			for (const {stageId, stageSignature, metadata} of stagePrepared) {
+				this.#cacheManager.writeStageCache(
+					this.#project.getId(), this.#buildSignature,
+					stageId, stageSignature, metadata);
+			}
+			for (const {taskName, type, metadata} of taskRequestPrepared) {
+				this.#cacheManager.writeTaskMetadata(
+					this.#project.getId(), this.#buildSignature, taskName, type, metadata);
+			}
+			if (sourceIndexPrepared) {
+				this.#cacheManager.writeIndexCache(
+					sourceIndexPrepared.projectId, sourceIndexPrepared.buildSignature,
+					sourceIndexPrepared.kind, sourceIndexPrepared.index);
+			}
+			if (hasContentWrites) {
+				this.#cacheManager.endContentBatch();
+			}
 			this.#cacheManager.endMetadataBatch();
 		} catch (err) {
+			if (hasContentWrites) {
+				this.#cacheManager.rollbackContentBatch();
+			}
 			this.#cacheManager.rollbackMetadataBatch();
 			throw err;
 		}
+
 		if (log.isLevelEnabled("perf")) {
 			log.perf(
 				`Wrote build cache for project ${this.#project.getName()} in ` +
@@ -1528,51 +1554,65 @@ export default class ProjectBuildCache {
 	}
 
 	/**
-	 * Stores the signatures of all stages that lead to the current build result. This can be used to
-	 * recreate the build result
+	 * Builds the result-cache payload, or returns null if the result stage is unchanged.
 	 *
-	 * @returns {Promise<void>}
+	 * @returns {{projectId: string, buildSignature: string, stageSignature: string, metadata: object}|null}
 	 */
-	async #writeResultCache() {
+	#prepareResultCache() {
 		const stageSignature = this.#currentResultSignature;
 		if (stageSignature === this.#cachedResultSignature) {
 			// No changes to already cached result stage
-			return;
+			return null;
 		}
-		log.verbose(`Storing result metadata for project ${this.#project.getName()} ` +
+		log.verbose(`Preparing result metadata for project ${this.#project.getName()} ` +
 			`using result stage signature ${stageSignature}`);
 		const stageSignatures = Object.create(null);
 		for (const [stageName, stageSigs] of this.#currentStageSignatures.entries()) {
 			stageSignatures[stageName] = stageSigs.join("-");
 		}
 
-		const metadata = {
-			stageSignatures,
-			sourceStageSignature: this.#sourceIndex.getSignature(),
+		return {
+			projectId: this.#project.getId(),
+			buildSignature: this.#buildSignature,
+			stageSignature,
+			metadata: {
+				stageSignatures,
+				sourceStageSignature: this.#sourceIndex.getSignature(),
+			},
 		};
-		await this.#cacheManager.writeResultMetadata(
-			this.#project.getId(), this.#buildSignature, stageSignature, metadata);
 	}
 
 	/**
-	 * Writes all pending task stage caches to persistent storage
+	 * Prepares all pending task stage caches for persistence.
 	 *
-	 * @returns {Promise<void>}
+	 * Gathers resources, computes integrity, gzip-compresses payloads.
+	 *
+	 * Per-stage iteration is sequential so that integrities collected from one stage
+	 * are visible to the next, preserving CAS dedupe.
+	 *
+	 * @returns {Promise<Array<{
+	 *   stageId: string,
+	 *   stageSignature: string,
+	 *   metadata: object,
+	 *   casRows: Array<{integrity: string, compressedBuffer: Buffer}>
+	 * }>>}
 	 */
-	async #writeTaskStageCache() {
+	async #prepareTaskStageCache() {
 		if (!this.#stageCache.hasPendingCacheQueue()) {
-			return;
+			return [];
 		}
-		// Store stage caches
-		log.verbose(`Storing stage caches for project ${this.#project.getName()} ` +
+		log.verbose(`Preparing stage caches for project ${this.#project.getName()} ` +
 			`with build signature ${this.#buildSignature}`);
 		const stageQueue = this.#stageCache.flushCacheQueue();
-		await Promise.all(stageQueue.map(async ([stageId, stageSignature]) => {
+
+		const payloads = [];
+		for (const [stageId, stageSignature] of stageQueue) {
 			const {stage, projectTagOperations, buildTagOperations} =
 				this.#stageCache.getCacheForSignature(stageId, stageSignature);
 			const writer = stage.getWriter();
 
 			let metadata;
+			const casRowsForStage = [];
 			if (writer.getMapping) {
 				const writerMapping = writer.getMapping();
 				// Ensure unique readers are used
@@ -1584,27 +1624,31 @@ export default class ProjectBuildCache {
 					resourceMapping[virPath] = readerIdx;
 				}
 
-				const resourceMetadata = await Promise.all(readers.map(async (reader, idx) => {
+				const perReader = await Promise.all(readers.map(async (reader) => {
 					const resources = await reader.byGlob("/**/*");
-
-					return await this.#writeStageResources(
-						resources, stageId, stageSignature, this.#knownCasIntegrities);
+					return await this.#prepareStageResources(resources, stageId);
 				}));
+				const resourceMetadata = [];
+				for (const r of perReader) {
+					resourceMetadata.push(r.resourceMetadata);
+					casRowsForStage.push(...r.casRows);
+				}
 				this.#collectKnownIntegrities(resourceMetadata);
 
 				metadata = {resourceMapping, resourceMetadata};
 			} else {
 				const resources = await writer.byGlob("/**/*");
-				const resourceMetadata = await this.#writeStageResources(
-					resources, stageId, stageSignature, this.#knownCasIntegrities);
-				this.#collectKnownIntegrities(resourceMetadata);
-				metadata = {resourceMetadata};
+				const prep = await this.#prepareStageResources(resources, stageId);
+				casRowsForStage.push(...prep.casRows);
+				this.#collectKnownIntegrities(prep.resourceMetadata);
+				metadata = {resourceMetadata: prep.resourceMetadata};
 			}
 			metadata.projectTagOperations = tagOpsToObject(projectTagOperations);
 			metadata.buildTagOperations = tagOpsToObject(buildTagOperations);
-			await this.#cacheManager.writeStageCache(
-				this.#project.getId(), this.#buildSignature, stageId, stageSignature, metadata);
-		}));
+
+			payloads.push({stageId, stageSignature, metadata, casRows: casRowsForStage});
+		}
+		return payloads;
 	}
 
 	/**
@@ -1625,15 +1669,18 @@ export default class ProjectBuildCache {
 	}
 
 	/**
-	 * Writes stage resources to persistent storage and returns their metadata
+	 * Prepares stage resources for persistence: gathers metadata, dedupes against the CAS,
+	 * and gzip-compresses payloads for content writes.
 	 *
-	 * @param {@ui5/fs/Resource[]} resources Array of resources to write
-	 * @param {string} stageId Stage identifier
-	 * @param {string} stageSignature Stage signature
-	 * @param {Set<string>} [knownCasIntegrities] Set of integrity hashes known to exist in CAS
-	 * @returns {Promise<Object<string, object>>} Resource metadata indexed by path
+	 * @param {@ui5/fs/Resource[]} resources Array of resources to prepare
+	 * @param {string} stageId Stage identifier (for perf logging)
+	 * @returns {Promise<{
+	 *   resourceMetadata: Object<string, object>,
+	 *   casRows: Array<{integrity: string, compressedBuffer: Buffer}>
+	 * }>}
+	 *   Resource metadata indexed by path, plus the list of CAS rows the caller must insert.
 	 */
-	async #writeStageResources(resources, stageId, stageSignature, knownCasIntegrities) {
+	async #prepareStageResources(resources, stageId) {
 		const resourceMetadata = Object.create(null);
 		let casSkipped = 0;
 
@@ -1642,7 +1689,7 @@ export default class ProjectBuildCache {
 		await Promise.all(resources.map(async (res) => {
 			const integrity = await res.getIntegrity();
 
-			if (knownCasIntegrities?.has(integrity)) {
+			if (this.#knownCasIntegrities.has(integrity)) {
 				casSkipped++;
 			} else {
 				const buffer = await res.getBuffer();
@@ -1657,7 +1704,7 @@ export default class ProjectBuildCache {
 			};
 		}));
 
-		// Phase 1.5: Batch-check which integrities already exist in the DB
+		// Phase 2: Batch-check which integrities already exist in the DB (sync read, no batch)
 		if (toWrite.length > 0) {
 			const existingIntegrities = this.#cacheManager.findExistingContentIntegrities(
 				toWrite.map(({integrity}) => integrity)
@@ -1668,11 +1715,10 @@ export default class ProjectBuildCache {
 			}
 		}
 
-		// Phase 2: Parallel async compression (outside transaction)
+		// Phase 3: Parallel async compression
+		const casRows = [];
 		if (toWrite.length > 0) {
 			const concurrency = Math.min(os.availableParallelism(), 8);
-			const compressed = new Array(toWrite.length);
-
 			for (let i = 0; i < toWrite.length; i += concurrency) {
 				const chunk = toWrite.slice(i, i + concurrency);
 				const results = await Promise.all(chunk.map(({buffer}) => {
@@ -1684,77 +1730,68 @@ export default class ProjectBuildCache {
 					);
 				}));
 				for (let j = 0; j < results.length; j++) {
-					compressed[i + j] = results[j];
+					casRows.push({integrity: chunk[j].integrity, compressedBuffer: results[j]});
 				}
-			}
-
-			// Phase 3: Batch insert pre-compressed content in transaction
-			this.#cacheManager.beginContentBatch();
-			try {
-				for (let i = 0; i < toWrite.length; i++) {
-					this.#cacheManager.putCompressedContent(toWrite[i].integrity, compressed[i]);
-				}
-				this.#cacheManager.endContentBatch();
-			} catch (err) {
-				this.#cacheManager.rollbackContentBatch();
-				throw err;
 			}
 		}
 
 		if (log.isLevelEnabled("perf") && casSkipped > 0) {
 			log.perf(
-				`#writeStageResources for stage ${stageId}: ` +
-				`${casSkipped} CAS skipped, ${resources.length - casSkipped} CAS written`);
+				`#prepareStageResources for stage ${stageId}: ` +
+				`${casSkipped} CAS skipped, ${resources.length - casSkipped} CAS to write`);
 		}
-		return resourceMetadata;
+		return {resourceMetadata, casRows};
 	}
 
 	/**
-	 * Writes task request metadata to persistent storage
+	 * Builds task-request metadata payloads for all tasks with new or modified entries.
 	 *
-	 * @returns {Promise<void>}
+	 * @returns {Array<{taskName: string, type: string, metadata: object}>}
 	 */
-	async #writeTaskRequestCache() {
-		// Store task caches
+	#prepareTaskRequestCache() {
+		const out = [];
 		for (const [taskName, taskCache] of this.#taskCache) {
-			if (taskCache.hasNewOrModifiedCacheEntries()) {
-				const [projectRequests, dependencyRequests] = taskCache.toCacheObjects();
-				log.verbose(`Storing task cache metadata for task ${taskName} in project ${this.#project.getName()}`);
-				const writes = [];
-				if (projectRequests) {
-					writes.push(this.#cacheManager.writeTaskMetadata(
-						this.#project.getId(), this.#buildSignature, taskName, "project", projectRequests));
-				}
-				if (dependencyRequests) {
-					writes.push(this.#cacheManager.writeTaskMetadata(
-						this.#project.getId(), this.#buildSignature, taskName, "dependencies", dependencyRequests));
-				}
-				await Promise.all(writes);
+			if (!taskCache.hasNewOrModifiedCacheEntries()) {
+				continue;
+			}
+			const [projectRequests, dependencyRequests] = taskCache.toCacheObjects();
+			log.verbose(`Preparing task cache metadata for task ${taskName} in project ${this.#project.getName()}`);
+			if (projectRequests) {
+				out.push({taskName, type: "project", metadata: projectRequests});
+			}
+			if (dependencyRequests) {
+				out.push({taskName, type: "dependencies", metadata: dependencyRequests});
 			}
 		}
+		return out;
 	}
 
 	/**
-	 * Writes the source index cache to persistent storage
+	 * Builds the source-index payload, or returns null if the source index is unchanged.
 	 *
-	 * @returns {Promise<void>}
+	 * @returns {{projectId: string, buildSignature: string, kind: string, index: object}|null}
 	 */
-	async #writeSourceIndex() {
+	#prepareSourceIndex() {
 		if (this.#cachedSourceSignature === this.#sourceIndex.getSignature()) {
 			// No changes to already cached result index
-			return;
+			return null;
 		}
-		log.verbose(`Storing resource index cache for project ${this.#project.getName()} ` +
+		log.verbose(`Preparing resource index cache for project ${this.#project.getName()} ` +
 			`with build signature ${this.#buildSignature}`);
 		const sourceIndexObject = this.#sourceIndex.toCacheObject();
 		const tasks = [];
 		for (const [taskName, taskCache] of this.#taskCache) {
 			tasks.push([taskName, taskCache.getSupportsDifferentialBuilds() ? 1 : 0]);
 		}
-		await this.#cacheManager.writeIndexCache(this.#project.getId(), this.#buildSignature, "source", {
-			...sourceIndexObject,
-			tasks,
-		});
+		return {
+			projectId: this.#project.getId(),
+			buildSignature: this.#buildSignature,
+			kind: "source",
+			index: {
+				...sourceIndexObject,
+				tasks,
+			},
+		};
 	}
 
 	/**

--- a/packages/project/test/lib/build/cache/BuildCacheStorage.js
+++ b/packages/project/test/lib/build/cache/BuildCacheStorage.js
@@ -232,130 +232,130 @@ test("Read throws wrapped error after close", (t) => {
 	t.truthy(err.cause);
 });
 
-// ===== Metadata batch transactions =====
+// ===== Transactions =====
 
-test("beginMetadataBatch/endMetadataBatch: Multiple writes commit atomically", (t) => {
+test("transaction: Multiple writes commit atomically", (t) => {
 	const {storage} = t.context;
-	storage.beginMetadataBatch();
-	storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
-	storage.writeTaskMetadata("project-a", "sig-1", "minify", "project", {v: 2});
-	storage.writeResultMetadata("project-a", "sig-1", "result-sig-1", {v: 3});
-	storage.endMetadataBatch();
+	storage.transaction(() => {
+		storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+		storage.writeTaskMetadata("project-a", "sig-1", "minify", "project", {v: 2});
+		storage.writeResultMetadata("project-a", "sig-1", "result-sig-1", {v: 3});
+	});
 
 	t.deepEqual(storage.readIndexCache("project-a", "sig-1", "source"), {v: 1});
 	t.deepEqual(storage.readTaskMetadata("project-a", "sig-1", "minify", "project"), {v: 2});
 	t.deepEqual(storage.readResultMetadata("project-a", "sig-1", "result-sig-1"), {v: 3});
 });
 
-test("rollbackMetadataBatch: Discards uncommitted writes", (t) => {
+test("transaction: Throwing callback rolls back all writes", (t) => {
 	const {storage} = t.context;
-	storage.beginMetadataBatch();
-	storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
-	storage.writeTaskMetadata("project-a", "sig-1", "minify", "project", {v: 2});
-	storage.rollbackMetadataBatch();
+	t.throws(() => {
+		storage.transaction(() => {
+			storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+			storage.writeTaskMetadata("project-a", "sig-1", "minify", "project", {v: 2});
+			throw new Error("boom");
+		});
+	}, {message: "boom"});
 
 	t.is(storage.readIndexCache("project-a", "sig-1", "source"), null);
 	t.is(storage.readTaskMetadata("project-a", "sig-1", "minify", "project"), null);
 });
 
-test("close: Rolls back uncommitted metadata batch", (t) => {
+test("transaction: Combined metadata and content writes commit atomically", (t) => {
 	const {storage} = t.context;
-	storage.beginMetadataBatch();
-	storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+	storage.transaction(() => {
+		storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+		storage.putContent("sha256-tx", Buffer.from("tx content"));
+	});
+
+	t.deepEqual(storage.readIndexCache("project-a", "sig-1", "source"), {v: 1});
+	t.deepEqual(storage.readContent("sha256-tx"), Buffer.from("tx content"));
+});
+
+test("transaction: Throwing rolls back both metadata and content writes", (t) => {
+	const {storage} = t.context;
+	t.throws(() => {
+		storage.transaction(() => {
+			storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+			storage.putContent("sha256-rb", Buffer.from("will be rolled back"));
+			throw new Error("nope");
+		});
+	}, {message: "nope"});
+
+	t.is(storage.readIndexCache("project-a", "sig-1", "source"), null);
+	t.false(storage.hasContent("sha256-rb"));
+});
+
+test("transaction: Returns the callback's return value", (t) => {
+	const {storage} = t.context;
+	const result = storage.transaction(() => {
+		storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+		return 42;
+	});
+	t.is(result, 42);
+});
+
+test("transaction: Nested calls throw", (t) => {
+	const {storage} = t.context;
+	t.throws(() => {
+		storage.transaction(() => {
+			storage.transaction(() => {});
+		});
+	}, {message: /Nested transactions are not supported/});
+
+	// After the failed nested call the outer transaction was rolled back and
+	// the storage is usable again
+	storage.transaction(() => {
+		storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+	});
+	t.deepEqual(storage.readIndexCache("project-a", "sig-1", "source"), {v: 1});
+});
+
+test("transaction: Async callback throws and rolls back", (t) => {
+	const {storage} = t.context;
+	t.throws(() => {
+		storage.transaction(async () => {
+			storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+		});
+	}, {message: /Async callbacks are not supported/});
+
+	// Writes performed before the throw are rolled back
+	t.is(storage.readIndexCache("project-a", "sig-1", "source"), null);
+
+	// Storage remains usable after the rollback
+	storage.transaction(() => {
+		storage.writeIndexCache("project-a", "sig-1", "source", {v: 2});
+	});
+	t.deepEqual(storage.readIndexCache("project-a", "sig-1", "source"), {v: 2});
+});
+
+test("transaction: Callback returning a thenable throws and rolls back", (t) => {
+	const {storage} = t.context;
+	t.throws(() => {
+		storage.transaction(() => {
+			storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+			return Promise.resolve("nope");
+		});
+	}, {message: /Async callbacks are not supported/});
+
+	t.is(storage.readIndexCache("project-a", "sig-1", "source"), null);
+});
+
+test("close: Rolls back uncommitted transaction", (t) => {
+	const {storage} = t.context;
+	// Simulate an interrupted transaction by throwing inside the callback
+	// without rethrowing — close() should still leave the DB in a clean state.
+	t.throws(() => {
+		storage.transaction(() => {
+			storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
+			throw new Error("interrupted");
+		});
+	}, {message: "interrupted"});
 	storage.close();
 
 	const fresh = new BuildCacheStorage(t.context.dbDir);
 	t.is(fresh.readIndexCache("project-a", "sig-1", "source"), null);
 	fresh.close();
-});
-
-test("beginMetadataBatch: Nested calls are idempotent", (t) => {
-	const {storage} = t.context;
-	storage.beginMetadataBatch();
-	storage.beginMetadataBatch();
-	storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
-	storage.endMetadataBatch();
-
-	t.deepEqual(storage.readIndexCache("project-a", "sig-1", "source"), {v: 1});
-});
-
-// ===== Standalone content batch transactions =====
-
-test("Standalone content batch: Commit persists content", (t) => {
-	const {storage} = t.context;
-	storage.beginContentBatch();
-	storage.putContent("sha256-batch1", Buffer.from("batch item 1"));
-	storage.putContent("sha256-batch2", Buffer.from("batch item 2"));
-	storage.endContentBatch();
-
-	t.deepEqual(storage.readContent("sha256-batch1"), Buffer.from("batch item 1"));
-	t.deepEqual(storage.readContent("sha256-batch2"), Buffer.from("batch item 2"));
-});
-
-test("Standalone content batch: Rollback discards content", (t) => {
-	const {storage} = t.context;
-	storage.beginContentBatch();
-	storage.putContent("sha256-rollback", Buffer.from("should be discarded"));
-	storage.rollbackContentBatch();
-
-	t.false(storage.hasContent("sha256-rollback"));
-});
-
-test("beginContentBatch: Nested calls are idempotent", (t) => {
-	const {storage} = t.context;
-	storage.beginContentBatch();
-	storage.beginContentBatch();
-	storage.putContent("sha256-idempotent", Buffer.from("idempotent"));
-	storage.endContentBatch();
-
-	t.deepEqual(storage.readContent("sha256-idempotent"), Buffer.from("idempotent"));
-});
-
-// ===== Nested content batch inside metadata batch (SAVEPOINT) =====
-
-test("Nested content batch: Content persists when both batches commit", (t) => {
-	const {storage} = t.context;
-	storage.beginMetadataBatch();
-	storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
-
-	storage.beginContentBatch();
-	storage.putContent("sha256-nested", Buffer.from("nested content"));
-	storage.endContentBatch();
-
-	storage.endMetadataBatch();
-
-	t.deepEqual(storage.readIndexCache("project-a", "sig-1", "source"), {v: 1});
-	t.deepEqual(storage.readContent("sha256-nested"), Buffer.from("nested content"));
-});
-
-test("Nested content batch rollback: Metadata survives, content is discarded", (t) => {
-	const {storage} = t.context;
-	storage.beginMetadataBatch();
-	storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
-
-	storage.beginContentBatch();
-	storage.putContent("sha256-rolled-back", Buffer.from("will be rolled back"));
-	storage.rollbackContentBatch();
-
-	storage.endMetadataBatch();
-
-	t.deepEqual(storage.readIndexCache("project-a", "sig-1", "source"), {v: 1});
-	t.false(storage.hasContent("sha256-rolled-back"));
-});
-
-test("Metadata rollback: Both metadata and nested content are discarded", (t) => {
-	const {storage} = t.context;
-	storage.beginMetadataBatch();
-	storage.writeIndexCache("project-a", "sig-1", "source", {v: 1});
-
-	storage.beginContentBatch();
-	storage.putContent("sha256-outer-rb", Buffer.from("will be discarded"));
-	storage.endContentBatch();
-
-	storage.rollbackMetadataBatch();
-
-	t.is(storage.readIndexCache("project-a", "sig-1", "source"), null);
-	t.false(storage.hasContent("sha256-outer-rb"));
 });
 
 // ===== Validity =====

--- a/packages/project/test/lib/build/cache/CacheManager.js
+++ b/packages/project/test/lib/build/cache/CacheManager.js
@@ -166,21 +166,6 @@ test.serial("putCompressedContent stores pre-compressed data that readContent de
 	cm.close();
 });
 
-test.serial("writeStageResource writes resource by integrity", async (t) => {
-	const testDir = getUniqueTestDir();
-	const CacheManager = (await import("../../../../lib/build/cache/CacheManager.js")).default;
-	const cm = new CacheManager(path.join(testDir, "buildCache"));
-
-	const resource = {
-		getIntegrity: async () => "sha256-stage",
-		getBuffer: async () => Buffer.from("stage resource content")
-	};
-	await cm.writeStageResource(resource);
-	t.true(cm.hasContent("sha256-stage"));
-	t.deepEqual(cm.readContent("sha256-stage"), Buffer.from("stage resource content"));
-	cm.close();
-});
-
 test.serial("Batch operations: content batch begin/end", async (t) => {
 	const testDir = getUniqueTestDir();
 	const CacheManager = (await import("../../../../lib/build/cache/CacheManager.js")).default;

--- a/packages/project/test/lib/build/cache/CacheManager.js
+++ b/packages/project/test/lib/build/cache/CacheManager.js
@@ -166,58 +166,40 @@ test.serial("putCompressedContent stores pre-compressed data that readContent de
 	cm.close();
 });
 
-test.serial("Batch operations: content batch begin/end", async (t) => {
+test.serial("transaction: commits combined metadata and content writes atomically", async (t) => {
 	const testDir = getUniqueTestDir();
 	const CacheManager = (await import("../../../../lib/build/cache/CacheManager.js")).default;
 	const cm = new CacheManager(path.join(testDir, "buildCache"));
 
-	cm.beginContentBatch();
-	cm.putContent("sha256-batch1", Buffer.from("batch1"));
-	cm.putContent("sha256-batch2", Buffer.from("batch2"));
-	cm.endContentBatch();
+	const result = cm.transaction(() => {
+		cm.putContent("sha256-batch1", Buffer.from("batch1"));
+		cm.putContent("sha256-batch2", Buffer.from("batch2"));
+		cm.writeIndexCache("proj-batch", "sig", "source", {data: true});
+		return "ok";
+	});
 
+	t.is(result, "ok");
 	t.true(cm.hasContent("sha256-batch1"));
 	t.true(cm.hasContent("sha256-batch2"));
+	t.deepEqual(cm.readIndexCache("proj-batch", "sig", "source"), {data: true});
 	cm.close();
 });
 
-test.serial("Batch operations: content batch rollback", async (t) => {
+test.serial("transaction: throwing rolls back metadata and content writes", async (t) => {
 	const testDir = getUniqueTestDir();
 	const CacheManager = (await import("../../../../lib/build/cache/CacheManager.js")).default;
 	const cm = new CacheManager(path.join(testDir, "buildCache"));
 
-	cm.beginContentBatch();
-	cm.putContent("sha256-rollback", Buffer.from("rollback"));
-	cm.rollbackContentBatch();
+	t.throws(() => {
+		cm.transaction(() => {
+			cm.putContent("sha256-rollback", Buffer.from("rollback"));
+			cm.writeIndexCache("proj-rollback", "sig", "source", {data: true});
+			throw new Error("boom");
+		});
+	}, {message: "boom"});
 
 	t.false(cm.hasContent("sha256-rollback"), "Content should not exist after rollback");
-	cm.close();
-});
-
-test.serial("Batch operations: metadata batch begin/end", async (t) => {
-	const testDir = getUniqueTestDir();
-	const CacheManager = (await import("../../../../lib/build/cache/CacheManager.js")).default;
-	const cm = new CacheManager(path.join(testDir, "buildCache"));
-
-	cm.beginMetadataBatch();
-	cm.writeIndexCache("proj-batch", "sig", "source", {data: true});
-	cm.endMetadataBatch();
-
-	const result = cm.readIndexCache("proj-batch", "sig", "source");
-	t.deepEqual(result, {data: true});
-	cm.close();
-});
-
-test.serial("Batch operations: metadata batch rollback", async (t) => {
-	const testDir = getUniqueTestDir();
-	const CacheManager = (await import("../../../../lib/build/cache/CacheManager.js")).default;
-	const cm = new CacheManager(path.join(testDir, "buildCache"));
-
-	cm.beginMetadataBatch();
-	cm.writeIndexCache("proj-rollback", "sig", "source", {data: true});
-	cm.rollbackMetadataBatch();
-
-	const result = cm.readIndexCache("proj-rollback", "sig", "source");
-	t.is(result, null, "Metadata should not exist after rollback");
+	t.is(cm.readIndexCache("proj-rollback", "sig", "source"), null,
+		"Metadata should not exist after rollback");
 	cm.close();
 });

--- a/packages/project/test/lib/build/cache/CacheManager.js
+++ b/packages/project/test/lib/build/cache/CacheManager.js
@@ -29,8 +29,8 @@ test.serial("Index cache: round-trip via CacheManager", async (t) => {
 	const cm = new CacheManager(path.join(testDir, "buildCache"));
 
 	const data = {indexTimestamp: 1234, root: {name: "", hash: "abc"}};
-	await cm.writeIndexCache("project-x", "build-sig", "source", data);
-	const result = await cm.readIndexCache("project-x", "build-sig", "source");
+	cm.writeIndexCache("project-x", "build-sig", "source", data);
+	const result = cm.readIndexCache("project-x", "build-sig", "source");
 	t.deepEqual(result, data);
 	cm.close();
 });
@@ -41,8 +41,8 @@ test.serial("Stage cache: round-trip via CacheManager", async (t) => {
 	const cm = new CacheManager(path.join(testDir, "buildCache"));
 
 	const data = {resourceMetadata: {"/a.js": {integrity: "hash-a"}}};
-	await cm.writeStageCache("project-x", "build-sig", "task/minify", "stage-sig", data);
-	const result = await cm.readStageCache("project-x", "build-sig", "task/minify", "stage-sig");
+	cm.writeStageCache("project-x", "build-sig", "task/minify", "stage-sig", data);
+	const result = cm.readStageCache("project-x", "build-sig", "task/minify", "stage-sig");
 	t.deepEqual(result, data);
 	cm.close();
 });
@@ -53,8 +53,8 @@ test.serial("Task metadata: round-trip via CacheManager", async (t) => {
 	const cm = new CacheManager(path.join(testDir, "buildCache"));
 
 	const data = {requestSetGraph: {nodes: []}};
-	await cm.writeTaskMetadata("project-x", "build-sig", "minify", "project", data);
-	const result = await cm.readTaskMetadata("project-x", "build-sig", "minify", "project");
+	cm.writeTaskMetadata("project-x", "build-sig", "minify", "project", data);
+	const result = cm.readTaskMetadata("project-x", "build-sig", "minify", "project");
 	t.deepEqual(result, data);
 	cm.close();
 });
@@ -65,8 +65,8 @@ test.serial("Result metadata: round-trip via CacheManager", async (t) => {
 	const cm = new CacheManager(path.join(testDir, "buildCache"));
 
 	const data = {stageSignatures: {"task/minify": "sig-abc"}};
-	await cm.writeResultMetadata("project-x", "build-sig", "result-sig", data);
-	const result = await cm.readResultMetadata("project-x", "build-sig", "result-sig");
+	cm.writeResultMetadata("project-x", "build-sig", "result-sig", data);
+	const result = cm.readResultMetadata("project-x", "build-sig", "result-sig");
 	t.deepEqual(result, data);
 	cm.close();
 });
@@ -76,10 +76,10 @@ test.serial("Cache miss returns null for all metadata types", async (t) => {
 	const CacheManager = (await import("../../../../lib/build/cache/CacheManager.js")).default;
 	const cm = new CacheManager(path.join(testDir, "buildCache"));
 
-	t.is(await cm.readIndexCache("no-project", "no-sig", "source"), null);
-	t.is(await cm.readStageCache("no-project", "no-sig", "no-stage", "no-sig"), null);
-	t.is(await cm.readTaskMetadata("no-project", "no-sig", "no-task", "project"), null);
-	t.is(await cm.readResultMetadata("no-project", "no-sig", "no-sig"), null);
+	t.is(cm.readIndexCache("no-project", "no-sig", "source"), null);
+	t.is(cm.readStageCache("no-project", "no-sig", "no-stage", "no-sig"), null);
+	t.is(cm.readTaskMetadata("no-project", "no-sig", "no-task", "project"), null);
+	t.is(cm.readResultMetadata("no-project", "no-sig", "no-sig"), null);
 	cm.close();
 });
 
@@ -215,10 +215,10 @@ test.serial("Batch operations: metadata batch begin/end", async (t) => {
 	const cm = new CacheManager(path.join(testDir, "buildCache"));
 
 	cm.beginMetadataBatch();
-	await cm.writeIndexCache("proj-batch", "sig", "source", {data: true});
+	cm.writeIndexCache("proj-batch", "sig", "source", {data: true});
 	cm.endMetadataBatch();
 
-	const result = await cm.readIndexCache("proj-batch", "sig", "source");
+	const result = cm.readIndexCache("proj-batch", "sig", "source");
 	t.deepEqual(result, {data: true});
 	cm.close();
 });
@@ -229,10 +229,10 @@ test.serial("Batch operations: metadata batch rollback", async (t) => {
 	const cm = new CacheManager(path.join(testDir, "buildCache"));
 
 	cm.beginMetadataBatch();
-	await cm.writeIndexCache("proj-rollback", "sig", "source", {data: true});
+	cm.writeIndexCache("proj-rollback", "sig", "source", {data: true});
 	cm.rollbackMetadataBatch();
 
-	const result = await cm.readIndexCache("proj-rollback", "sig", "source");
+	const result = cm.readIndexCache("proj-rollback", "sig", "source");
 	t.is(result, null, "Metadata should not exist after rollback");
 	cm.close();
 });

--- a/packages/project/test/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/test/lib/build/cache/ProjectBuildCache.js
@@ -77,6 +77,7 @@ function createMockCacheManager() {
 		beginMetadataBatch: sinon.stub(),
 		endMetadataBatch: sinon.stub(),
 		rollbackMetadataBatch: sinon.stub(),
+		transaction: sinon.stub().callsFake((fn) => fn()),
 		findExistingStageSignatures: sinon.stub().callsFake((projectId, buildSig, stageId, sigs) => sigs),
 		findExistingResultSignatures: sinon.stub().callsFake((projectId, buildSig, sigs) => sigs),
 		findExistingContentIntegrities: sinon.stub().returns(new Set()),

--- a/packages/project/test/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/test/lib/build/cache/ProjectBuildCache.js
@@ -152,7 +152,7 @@ test("Create with existing index cache", async (t) => {
 	// Mock task metadata responses
 	cacheManager.readTaskMetadata.callsFake((projectId, buildSig, taskName, type) => {
 		if (type === "project") {
-			return Promise.resolve({
+			return {
 				requestSetGraph: {
 					nodes: [],
 					nextId: 1
@@ -160,9 +160,9 @@ test("Create with existing index cache", async (t) => {
 				rootIndices: [],
 				deltaIndices: [],
 				unusedAtLeastOnce: false
-			});
+			};
 		} else if (type === "dependencies") {
-			return Promise.resolve({
+			return {
 				requestSetGraph: {
 					nodes: [],
 					nextId: 1
@@ -170,9 +170,9 @@ test("Create with existing index cache", async (t) => {
 				rootIndices: [],
 				deltaIndices: [],
 				unusedAtLeastOnce: false
-			});
+			};
 		}
-		return Promise.resolve(null);
+		return null;
 	});
 
 	cacheManager.readIndexCache.returns(indexCache);
@@ -936,7 +936,7 @@ test("_refreshDependencyIndices: updates dependency indices", async (t) => {
 	// Mock task metadata responses
 	cacheManager.readTaskMetadata.callsFake((projectId, buildSig, taskName, type) => {
 		if (type === "project") {
-			return Promise.resolve({
+			return {
 				requestSetGraph: {
 					nodes: [],
 					nextId: 1
@@ -944,9 +944,9 @@ test("_refreshDependencyIndices: updates dependency indices", async (t) => {
 				rootIndices: [],
 				deltaIndices: [],
 				unusedAtLeastOnce: false
-			});
+			};
 		} else if (type === "dependencies") {
-			return Promise.resolve({
+			return {
 				requestSetGraph: {
 					nodes: [],
 					nextId: 1
@@ -954,9 +954,9 @@ test("_refreshDependencyIndices: updates dependency indices", async (t) => {
 				rootIndices: [],
 				deltaIndices: [],
 				unusedAtLeastOnce: false
-			});
+			};
 		}
-		return Promise.resolve(null);
+		return null;
 	});
 
 	cacheManager.readIndexCache.returns(indexCache);
@@ -1299,21 +1299,21 @@ async function buildCacheWithWarmCacheAndTaskResult({
 
 	// Mock task metadata for the cached task
 	cacheManager.readTaskMetadata.callsFake((projectId, buildSig, taskName, type) => {
-		return Promise.resolve({
+		return {
 			requestSetGraph: {nodes: [], nextId: 1},
 			rootIndices: [],
 			deltaIndices: [],
 			unusedAtLeastOnce: false
-		});
+		};
 	});
 
 	// Return previous frozen source metadata when readStageCache is called
 	// with the cached source signature during initSourceIndex
 	cacheManager.readStageCache.callsFake((projectId, buildSig, stageId, stageSignature) => {
 		if (stageId === "source" && stageSignature === cachedSourceSignature && previousFrozenMetadata) {
-			return Promise.resolve({resourceMetadata: previousFrozenMetadata});
+			return {resourceMetadata: previousFrozenMetadata};
 		}
-		return Promise.resolve(null);
+		return null;
 	});
 
 	cacheManager.readIndexCache.returns(indexCache);
@@ -1510,12 +1510,12 @@ test("restoreFrozenSources: cache miss skips gracefully", async (t) => {
 	};
 	cacheManager.readIndexCache.returns(indexCache);
 	cacheManager.readTaskMetadata.callsFake((projectId, buildSig, taskName, type) => {
-		return Promise.resolve({
+		return {
 			requestSetGraph: {nodes: [], nextId: 1},
 			rootIndices: [],
 			deltaIndices: [],
 			unusedAtLeastOnce: true
-		});
+		};
 	});
 
 	// readResultMetadata returns metadata WITH sourceStageSignature
@@ -1527,14 +1527,14 @@ test("restoreFrozenSources: cache miss skips gracefully", async (t) => {
 	// readStageCache for task stage returns valid data, but for "source" stage returns null
 	cacheManager.readStageCache.callsFake((projectId, buildSig, stageName, signature) => {
 		if (stageName === "source") {
-			return Promise.resolve(null); // Cache miss for source stage
+			return null; // Cache miss for source stage
 		}
 		// Return valid stage for task stages
-		return Promise.resolve({
+		return {
 			resourceMetadata: {"/a.js": {integrity: "hash-a", lastModified: 1000, size: 100, inode: 1}},
 			projectTagOperations: {},
 			buildTagOperations: {},
-		});
+		};
 	});
 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
@@ -1594,12 +1594,12 @@ test("restoreFrozenSources: cache hit creates CAS reader", async (t) => {
 	};
 	cacheManager.readIndexCache.returns(indexCache);
 	cacheManager.readTaskMetadata.callsFake((projectId, buildSig, taskName, type) => {
-		return Promise.resolve({
+		return {
 			requestSetGraph: {nodes: [], nextId: 1},
 			rootIndices: [],
 			deltaIndices: [],
 			unusedAtLeastOnce: true
-		});
+		};
 	});
 
 	// readResultMetadata returns metadata WITH sourceStageSignature
@@ -1611,17 +1611,17 @@ test("restoreFrozenSources: cache hit creates CAS reader", async (t) => {
 	// readStageCache returns valid data for both task and source stages
 	cacheManager.readStageCache.callsFake((projectId, buildSig, stageName, signature) => {
 		if (stageName === "source") {
-			return Promise.resolve({
+			return {
 				resourceMetadata: {
 					"/b.js": {integrity: "hash-b", lastModified: 1000, size: 100, inode: 2}
 				},
-			});
+			};
 		}
-		return Promise.resolve({
+		return {
 			resourceMetadata: {"/a.js": {integrity: "hash-a", lastModified: 1000, size: 100, inode: 1}},
 			projectTagOperations: {},
 			buildTagOperations: {},
-		});
+		};
 	});
 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
@@ -1708,12 +1708,12 @@ async function createCacheInRestoringState({
 	};
 
 	cacheManager.readTaskMetadata.callsFake((projectId, buildSig, taskName, type) => {
-		return Promise.resolve({
+		return {
 			requestSetGraph: {nodes: [], nextId: 1},
 			rootIndices: [],
 			deltaIndices: [],
 			unusedAtLeastOnce: false
-		});
+		};
 	});
 
 	cacheManager.readIndexCache.returns(indexCache);

--- a/packages/project/test/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/test/lib/build/cache/ProjectBuildCache.js
@@ -65,7 +65,6 @@ function createMockCacheManager() {
 		writeResultMetadata: sinon.stub(),
 		readTaskMetadata: sinon.stub().returns(null),
 		writeTaskMetadata: sinon.stub(),
-		writeStageResource: sinon.stub().resolves(),
 		hasContent: sinon.stub().returns(false),
 		readContent: sinon.stub().returns(Buffer.from("test")),
 		readContentRaw: sinon.stub().returns(Buffer.from("test")),
@@ -1365,8 +1364,8 @@ test("freezeUntransformedSources: fast path — reuses all entries from previous
 
 	await cache.allTasksCompleted();
 
-	// writeStageResource should NOT be called — all metadata was reused
-	t.is(cacheManager.writeStageResource.callCount, 0,
+	// CAS writes should NOT happen — all metadata was reused
+	t.is(cacheManager.putCompressedContent.callCount, 0,
 		"No CAS writes needed when all metadata is reused");
 
 	// writeStageCache SHOULD be called with the reused metadata

--- a/packages/project/test/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/test/lib/build/cache/ProjectBuildCache.js
@@ -222,7 +222,7 @@ test("setTasks initializes project stages", async (t) => {
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
 
-	await cache.setTasks(["task1", "task2", "task3"]);
+	cache.setTasks(["task1", "task2", "task3"]);
 
 	t.true(project.getProjectResources().initStages.calledOnce, "initStages called once");
 	t.deepEqual(
@@ -238,7 +238,7 @@ test("setTasks with empty task list", async (t) => {
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
 
-	await cache.setTasks([]);
+	cache.setTasks([]);
 
 	t.true(project.getProjectResources().initStages.calledWith([]), "initStages called with empty array");
 });
@@ -309,7 +309,7 @@ test("prepareTaskExecutionAndValidateCache: task needs execution when no cache e
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
 
-	await cache.setTasks(["myTask"]);
+	cache.setTasks(["myTask"]);
 	const canUseCache = await cache.prepareTaskExecutionAndValidateCache("myTask");
 
 	t.false(canUseCache, "Task cannot use cache");
@@ -322,7 +322,7 @@ test("prepareTaskExecutionAndValidateCache: switches project to correct stage", 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
 
-	await cache.setTasks(["task1", "task2"]);
+	cache.setTasks(["task1", "task2"]);
 	await cache.prepareTaskExecutionAndValidateCache("task2");
 
 	t.true(project.getProjectResources().useStage.calledWith("task/task2"), "Switched to task2 stage");
@@ -334,7 +334,7 @@ test("recordTaskResult: creates task cache", async (t) => {
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
 
-	await cache.setTasks(["newTask"]);
+	cache.setTasks(["newTask"]);
 	await cache.prepareTaskExecutionAndValidateCache("newTask");
 
 	const projectRequests = {paths: new Set(["/input.js"]), patterns: new Set()};
@@ -352,7 +352,7 @@ test("recordTaskResult with empty requests", async (t) => {
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
 
-	await cache.setTasks(["task1"]);
+	cache.setTasks(["task1"]);
 	await cache.prepareTaskExecutionAndValidateCache("task1");
 
 	const projectRequests = {paths: new Set(), patterns: new Set()};
@@ -373,7 +373,7 @@ test("recordTaskResult with cacheInfo: merges resources from previous stage, ski
 		const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 		await cache.initSourceIndex();
 
-		await cache.setTasks(["myTask"]);
+		cache.setTasks(["myTask"]);
 		await cache.prepareTaskExecutionAndValidateCache("myTask");
 
 		// Resources written by the delta execution
@@ -425,7 +425,7 @@ test("recordTaskResult with cacheInfo: calls importTagOperations with previous s
 		const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 		await cache.initSourceIndex();
 
-		await cache.setTasks(["myTask"]);
+		cache.setTasks(["myTask"]);
 		await cache.prepareTaskExecutionAndValidateCache("myTask");
 
 		const writeStub = sinon.stub().resolves();
@@ -474,7 +474,7 @@ test("recordTaskResult with cacheInfo: merges tag operations with current delta 
 		const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 		await cache.initSourceIndex();
 
-		await cache.setTasks(["myTask"]);
+		cache.setTasks(["myTask"]);
 		await cache.prepareTaskExecutionAndValidateCache("myTask");
 
 		// Delta execution's own tag operations — /a.js IsDebugVariant overrides previous value
@@ -548,7 +548,7 @@ test("recordTaskResult with cacheInfo: uses cacheInfo.newSignature as stage sign
 		const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 		await cache.initSourceIndex();
 
-		await cache.setTasks(["myTask"]);
+		cache.setTasks(["myTask"]);
 		await cache.prepareTaskExecutionAndValidateCache("myTask");
 
 		const writtenRes = createMockResource("/a.js", "hash-a", 2000, 200, 2);
@@ -597,7 +597,7 @@ test("recordTaskResult with cacheInfo: uses getCachedWriter fallback when getWri
 		const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 		await cache.initSourceIndex();
 
-		await cache.setTasks(["myTask"]);
+		cache.setTasks(["myTask"]);
 		await cache.prepareTaskExecutionAndValidateCache("myTask");
 
 		const writeStub = sinon.stub().resolves();
@@ -1062,7 +1062,7 @@ test("Empty task list doesn't fail", async (t) => {
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
 
-	await cache.setTasks([]);
+	cache.setTasks([]);
 
 	t.true(project.getProjectResources().initStages.calledWith([]), "initStages called with empty array");
 });
@@ -1090,7 +1090,7 @@ async function buildCacheWithTaskResult(resources, writtenPaths = []) {
 	await cache.initSourceIndex();
 
 	// Set up and execute a task
-	await cache.setTasks(["myTask"]);
+	cache.setTasks(["myTask"]);
 	await cache.prepareTaskExecutionAndValidateCache("myTask");
 
 	// Simulate task writing some resources
@@ -1216,7 +1216,7 @@ test("freezeUntransformedSources: throws when source file not found", async (t) 
 
 	const cache = await ProjectBuildCache.create(project, "test-sig", cacheManager);
 	await cache.initSourceIndex();
-	await cache.setTasks(["myTask"]);
+	cache.setTasks(["myTask"]);
 	await cache.prepareTaskExecutionAndValidateCache("myTask");
 
 	project.getProjectResources().getStage.returns({
@@ -1322,7 +1322,7 @@ async function buildCacheWithWarmCacheAndTaskResult({
 	await cache.initSourceIndex();
 
 	// Set up and execute a task
-	await cache.setTasks(["myTask"]);
+	cache.setTasks(["myTask"]);
 	await cache.prepareTaskExecutionAndValidateCache("myTask");
 
 	// Simulate task writing some resources

--- a/packages/project/test/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/test/lib/build/cache/ProjectBuildCache.js
@@ -57,14 +57,14 @@ function createMockProject(name = "test.project", id = "test-project-id") {
 // Helper to create mock CacheManager instances
 function createMockCacheManager() {
 	return {
-		readIndexCache: sinon.stub().resolves(null),
-		writeIndexCache: sinon.stub().resolves(),
-		readStageCache: sinon.stub().resolves(null),
-		writeStageCache: sinon.stub().resolves(),
-		readResultMetadata: sinon.stub().resolves(null),
-		writeResultMetadata: sinon.stub().resolves(),
-		readTaskMetadata: sinon.stub().resolves(null),
-		writeTaskMetadata: sinon.stub().resolves(),
+		readIndexCache: sinon.stub().returns(null),
+		writeIndexCache: sinon.stub(),
+		readStageCache: sinon.stub().returns(null),
+		writeStageCache: sinon.stub(),
+		readResultMetadata: sinon.stub().returns(null),
+		writeResultMetadata: sinon.stub(),
+		readTaskMetadata: sinon.stub().returns(null),
+		writeTaskMetadata: sinon.stub(),
 		writeStageResource: sinon.stub().resolves(),
 		hasContent: sinon.stub().returns(false),
 		readContent: sinon.stub().returns(Buffer.from("test")),
@@ -176,7 +176,7 @@ test("Create with existing index cache", async (t) => {
 		return Promise.resolve(null);
 	});
 
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 
 	const cache = await ProjectBuildCache.create(project, buildSignature, cacheManager);
 	await cache.initSourceIndex();
@@ -289,7 +289,7 @@ test("allTasksCompleted returns changed resource paths", async (t) => {
 		},
 		tasks: []
 	};
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
@@ -676,7 +676,7 @@ test("projectSourcesChanged: marks cache as requiring validation", async (t) => 
 		},
 		tasks: []
 	};
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
@@ -718,7 +718,7 @@ test("dependencyResourcesChanged: marks cache as requiring validation", async (t
 		},
 		tasks: []
 	};
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
@@ -781,7 +781,7 @@ test("projectSourcesChanged after SourceChangedDuringBuildError does not corrupt
 		},
 		tasks: []
 	};
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
@@ -857,7 +857,7 @@ test("Retry after SourceChangedDuringBuildError when prior build set NO_CACHE: "
 		},
 		tasks: []
 	};
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 	// readResultMetadata returns null by default → #findResultCache returns false → NO_CACHE.
 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
@@ -960,7 +960,7 @@ test("_refreshDependencyIndices: updates dependency indices", async (t) => {
 		return Promise.resolve(null);
 	});
 
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
@@ -1025,7 +1025,7 @@ test("writeCache: skips writing unchanged caches", async (t) => {
 		},
 		tasks: []
 	};
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 
 	const cache = await ProjectBuildCache.create(project, "sig", cacheManager);
 	await cache.initSourceIndex();
@@ -1317,7 +1317,7 @@ async function buildCacheWithWarmCacheAndTaskResult({
 		return Promise.resolve(null);
 	});
 
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 
 	const cache = await ProjectBuildCache.create(project, buildSignature, cacheManager);
 	await cache.initSourceIndex();
@@ -1509,7 +1509,7 @@ test("restoreFrozenSources: cache miss skips gracefully", async (t) => {
 		},
 		tasks: [["task1", false]]
 	};
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 	cacheManager.readTaskMetadata.callsFake((projectId, buildSig, taskName, type) => {
 		return Promise.resolve({
 			requestSetGraph: {nodes: [], nextId: 1},
@@ -1520,7 +1520,7 @@ test("restoreFrozenSources: cache miss skips gracefully", async (t) => {
 	});
 
 	// readResultMetadata returns metadata WITH sourceStageSignature
-	cacheManager.readResultMetadata.resolves({
+	cacheManager.readResultMetadata.returns({
 		stageSignatures: {"task/task1": "sig1-sig2"},
 		sourceStageSignature: "source-sig-123"
 	});
@@ -1593,7 +1593,7 @@ test("restoreFrozenSources: cache hit creates CAS reader", async (t) => {
 		},
 		tasks: [["task1", false]]
 	};
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 	cacheManager.readTaskMetadata.callsFake((projectId, buildSig, taskName, type) => {
 		return Promise.resolve({
 			requestSetGraph: {nodes: [], nextId: 1},
@@ -1604,7 +1604,7 @@ test("restoreFrozenSources: cache hit creates CAS reader", async (t) => {
 	});
 
 	// readResultMetadata returns metadata WITH sourceStageSignature
-	cacheManager.readResultMetadata.resolves({
+	cacheManager.readResultMetadata.returns({
 		stageSignatures: {"task/task1": "sig1-sig2"},
 		sourceStageSignature: "source-sig-456"
 	});
@@ -1717,7 +1717,7 @@ async function createCacheInRestoringState({
 		});
 	});
 
-	cacheManager.readIndexCache.resolves(indexCache);
+	cacheManager.readIndexCache.returns(indexCache);
 
 	const cache = await ProjectBuildCache.create(project, buildSignature, cacheManager);
 	await cache.initSourceIndex();


### PR DESCRIPTION
- Make APIs sync that do not need async behaviour
- Prevent concurrent access to DB (especially for batch transactions) by splitting async work from sync DB access

JIRA: CPOUI5FOUNDATION-1207