### PR TITLE
refactor(project): Custom Tasks: Allow empty arrays for `changedProjectResourcePaths`

### DIFF
--- a/packages/project/lib/build/TaskRunner.js
+++ b/packages/project/lib/build/TaskRunner.js
@@ -461,9 +461,11 @@ class TaskRunner {
 				}
 			};
 			if (usingCache) {
-				params.changedProjectResourcePaths = cacheInfo.changedProjectResourcePaths;
+				params.changedProjectResourcePaths = [];
+				params.changedProjectResourcePaths.push(...cacheInfo.changedProjectResourcePaths);
 				if (provideDependenciesReader) {
-					params.changedDependencyResourcePaths = cacheInfo.changedDependencyResourcePaths;
+					params.changedDependencyResourcePaths = [];
+					params.changedDependencyResourcePaths.push(...cacheInfo.changedDependencyResourcePaths);
 				}
 			}
 			const specVersion = task.getSpecVersion();


### PR DESCRIPTION
Before this change, `changedProjectResourcePaths` was always `undefined` if the task supported as well as NOT supported differential builds if no resources changed.

Now this parameter is an empty array, if the task supports it and no resources changed. And it still returns `undefined` if the task does not support it.
