### PR TITLE
docs: Add missing info about 'component' type

### DIFF
--- a/internal/documentation/docs/pages/Builder.md
+++ b/internal/documentation/docs/pages/Builder.md
@@ -25,29 +25,29 @@ A project can add custom tasks to the build by using the [Custom Tasks Extensibi
 
 All available standard tasks are documented [in the API reference](https://ui5.github.io/cli/v5/api/index.html). Search for `@ui5/builder/tasks/` to filter the API reference for all available tasks. The list below offers the actual order of their execution:
 
-| Task                           |   Type `application`    |     Type `library`      |  Type `theme-library`   |
-|--------------------------------|:-----------------------:|:-----------------------:|:-----------------------:|
-| escapeNonAsciiCharacters       |         enabled         |         enabled         |                         |
-| replaceCopyright               |         enabled         |         enabled         |         enabled         |
-| replaceVersion                 |         enabled         |         enabled         |         enabled         |
-| replaceBuildtime               |                         |         enabled         |                         |
-| generateJsdoc                  |                         | *disabled* <sup>1</sup> |                         |
-| executeJsdocSdkTransformation  |                         | *disabled* <sup>1</sup> |                         |
-| minify                         |         enabled         |         enabled         |                         |
-| generateFlexChangesBundle      |         enabled         |         enabled         |                         |
-| generateLibraryManifest        |                         |         enabled         |                         |
-| enhanceManifest                |         enabled         |         enabled         |                         |
-| generateComponentPreload       |         enabled         | *disabled* <sup>2</sup> |                         |
-| generateLibraryPreload         |                         |         enabled         |                         |
-| generateStandaloneAppBundle    | *disabled* <sup>3</sup> |                         |                         |
-| transformBootstrapHtml         | *disabled* <sup>3</sup> |                         |                         |
-| generateBundle                 | *disabled* <sup>4</sup> | *disabled* <sup>4</sup> |                         |
-| buildThemes                    |                         |         enabled         |         enabled         |
-| generateThemeDesignerResources |                         | *disabled* <sup>5</sup> | *disabled* <sup>5</sup> |
-| generateVersionInfo            | *disabled* <sup>1</sup> |                         |                         |
-| generateCachebusterInfo        |       *disabled*        |                         |                         |
-| generateApiIndex               | *disabled* <sup>1</sup> |                         |                         |
-| generateResourcesJson          |       *disabled*        |       *disabled*        |       *disabled*        |
+| Task                           |   Type `application`    |    Type `component`     |     Type `library`      |  Type `theme-library`   |
+|--------------------------------|:-----------------------:|:-----------------------:|:-----------------------:|:-----------------------:|
+| escapeNonAsciiCharacters       |         enabled         |         enabled         |         enabled         |                         |
+| replaceCopyright               |         enabled         |         enabled         |         enabled         |         enabled         |
+| replaceVersion                 |         enabled         |         enabled         |         enabled         |         enabled         |
+| replaceBuildtime               |                         |                         |         enabled         |                         |
+| generateJsdoc                  |                         |                         | *disabled* <sup>1</sup> |                         |
+| executeJsdocSdkTransformation  |                         |                         | *disabled* <sup>1</sup> |                         |
+| minify                         |         enabled         |         enabled         |         enabled         |                         |
+| generateFlexChangesBundle      |         enabled         |         enabled         |         enabled         |                         |
+| generateLibraryManifest        |                         |                         |         enabled         |                         |
+| enhanceManifest                |         enabled         |         enabled         |         enabled         |                         |
+| generateComponentPreload       |         enabled         |         enabled         | *disabled* <sup>2</sup> |                         |
+| generateLibraryPreload         |                         |                         |         enabled         |                         |
+| generateStandaloneAppBundle    | *disabled* <sup>3</sup> |                         |                         |                         |
+| transformBootstrapHtml         | *disabled* <sup>3</sup> |                         |                         |                         |
+| generateBundle                 | *disabled* <sup>4</sup> | *disabled* <sup>4</sup> | *disabled* <sup>4</sup> |                         |
+| buildThemes                    |                         |                         |         enabled         |         enabled         |
+| generateThemeDesignerResources |                         |                         | *disabled* <sup>5</sup> | *disabled* <sup>5</sup> |
+| generateVersionInfo            | *disabled* <sup>1</sup> |                         |                         |                         |
+| generateCachebusterInfo        |       *disabled*        |       *disabled*        |                         |                         |
+| generateApiIndex               | *disabled* <sup>1</sup> |                         |                         |                         |
+| generateResourcesJson          |       *disabled*        |       *disabled*        |       *disabled*        |       *disabled*        |
 
 *Disabled tasks can be activated by certain build modes, the project configuration, or by using the `--include-task` [CLI parameter](./CLI.md#ui5-build). See footnotes where given*
 

--- a/internal/documentation/docs/pages/Configuration.md
+++ b/internal/documentation/docs/pages/Configuration.md
@@ -31,7 +31,7 @@ A project must define a specification version (`specVersion`), to which its conf
 
 In addition, a project must define a `type`. This can be either `component`, `application`, `library`, `theme-library` (since Specification Version 1.1), or `module`.
 
-The type defines the default path mappings and build tasks. See [UI5 Builder: Types](./Builder.md#types) for details.
+The type defines the default path mappings and build tasks. See [UI5 Project: Types](./Project.md#types) for details.
 
 :::code-group Example
 
@@ -814,6 +814,7 @@ Version | UI5 CLI Release
 
 **Features:**
 
+- Adds support for the new [`component`](./Project.md#component) project type for developing UI5 components — including application, reusable UI, and faceless components — which, unlike `application`-type projects, are served under their own namespace so multiple can coexist in one environment
 - Adds new server setting [`server.settings.liveReload`](#server-configuration) to control automatic browser reload on source changes
 
 Specification Version 5.0 projects are supported by [UI5 CLI](https://github.com/UI5/cli) v5.0.0 and above.

--- a/internal/documentation/docs/pages/GettingStarted.md
+++ b/internal/documentation/docs/pages/GettingStarted.md
@@ -33,7 +33,7 @@ When working with SAP Business Application Studio, there are several templates a
 You can find many guides on UI5 development with SAP Business Application Studio in the [Tutorial Navigator](https://developers.sap.com/tutorial-navigator.html?tag=topic:sapui5&tag=products:technology-platform/sap-business-application-studio).
 
 ## Enabling an Existing Project
-You can easily check whether or not a project (application or library) can already be used with the UI5 CLI by looking for a `ui5.yaml` file in the project's root directory.  
+You can easily check whether or not a project (application, component, or library) can already be used with the UI5 CLI by looking for a `ui5.yaml` file in the project's root directory.  
 This file (with some exceptions) is required for all projects and their dependencies (e.g. reuse libraries) to use them in the UI5 CLI.
 
 ### Setup

--- a/packages/project/lib/build/definitions/component.js
+++ b/packages/project/lib/build/definitions/component.js
@@ -111,14 +111,6 @@ export default function({project, taskUtil, getTask}) {
 		});
 	}
 
-	tasks.set("generateVersionInfo", {
-		requiresDependencies: true,
-		options: {
-			rootProject: project,
-			pattern: "/resources/**/.library"
-		}
-	});
-
 	tasks.set("generateCachebusterInfo", {
 		options: {
 			signatureType: project.getCachebusterSignatureType(),

--- a/packages/project/test/lib/build/definitions/component.js
+++ b/packages/project/test/lib/build/definitions/component.js
@@ -86,13 +86,6 @@ test("Standard build", (t) => {
 		generateBundle: {
 			taskFunction: null
 		},
-		generateVersionInfo: {
-			requiresDependencies: true,
-			options: {
-				rootProject: project,
-				pattern: "/resources/**/.library"
-			}
-		},
 		generateCachebusterInfo: {
 			options: {
 				signatureType: "PONY"
@@ -198,13 +191,6 @@ test("Custom bundles", async (t) => {
 		generateBundle: {
 			requiresDependencies: true,
 			taskFunction: generateBundleTaskDefinition.taskFunction
-		},
-		generateVersionInfo: {
-			requiresDependencies: true,
-			options: {
-				rootProject: project,
-				pattern: "/resources/**/.library"
-			}
 		},
 		generateCachebusterInfo: {
 			options: {


### PR DESCRIPTION
Also removes the `generateVersionInfo` task from the `component` type, which was accidentally taken over from the application type.