### PR TITLE
ci: Resolve audit findings via dependency updates

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -11,10 +11,6 @@
         // Fix is available in VitePress 2.x with esbuild v0.25.x, but no stable release yet (only alpha).
         "GHSA-67mh-4wv8-2f99|vitepress>vite>esbuild",
 
-        // esbuild: Missing binary integrity verification in Deno module enables remote code execution via NPM_CONFIG_REGISTRY
-        // Not applicable as we don't use Deno.
-        "GHSA-gv7w-rqvm-qjhr|vitepress>vite>esbuild",
-
         // GHSA-4w7w-66w2-5vf9 is a path traversal in Vite's dev server allowing .map file reads outside
         // the project root when the server is network-exposed (--host).
         // Not a risk here: the dev server is only used locally (never exposed to the network) and all
@@ -34,12 +30,6 @@
 
         // GHSA-v6wh-96g9-6wx3: launch-editor: NTLMv2 hash disclosure via UNC path handling on Windows
         // Not applicable as we don't use launch-editor.
-        "GHSA-v6wh-96g9-6wx3|vitepress>vite",
-
-        // JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases
-        // This only affects js-yaml within our test dependencies where every YAML file is under our control
-        // so it is not applicable to our use case.
-        "GHSA-h67p-54hq-rp68|*>@istanbuljs/load-nyc-config>js-yaml",
-        "GHSA-h67p-54hq-rp68|ava>*>js-yaml"
+        "GHSA-v6wh-96g9-6wx3|vitepress>vite"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2020,9 +2020,9 @@
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11270,9 +11270,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -16393,9 +16393,9 @@
 			}
 		},
 		"node_modules/supertap/node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
- Drop esbuild GHSA-gv7w-rqvm-qjhr allowlist entry; advisory was withdrawn on GitHub (wrong ecosystem)
- Drop js-yaml GHSA-h67p-54hq-rp68 allowlist entries; fixed via js-yaml update
- Update package-lock.json accordingly
