### PR TITLE
ci: Add aggregator job for unit test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,18 @@ jobs:
 
     - name: Run unit tests
       run: npm run unit --workspace=${{ matrix.workspace }}
+
+  # Aggregator so branch protection can require a single "Tests" check
+  # instead of every matrix combination.
+  tests:
+    name: Tests
+    needs: unit
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check matrix result
+      run: |
+        if [ "${{ needs.unit.result }}" != "success" ]; then
+          echo "Unit test matrix result: ${{ needs.unit.result }}"
+          exit 1
+        fi


### PR DESCRIPTION
Add a 'Tests' job that depends on the full unit test matrix so branch
protection can require a single check instead of every workspace/Node/OS
combination. The 36 matrix rows remain visible in the PR checks list;
only the required-check surface collapses.

'if: always()' ensures the aggregator still runs when matrix cells fail,
so a failure surfaces as 'failed' rather than 'skipped'.
