### PR TITLE
refactor(logger): Upgrade log-update to v8 and drop workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12033,19 +12033,20 @@
 			"license": "MIT"
 		},
 		"node_modules/log-update": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/log-update/-/log-update-7.2.0.tgz",
-			"integrity": "sha512-iLs7dGSyjZiUgvrUvuD3FndAxVJk+TywBkkkwUSm9HdYoskJalWg5qVsEiXeufPvRVPbCUmNQewg798rx+sPXg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-8.0.0.tgz",
+			"integrity": "sha512-lddSgOt3bPASrylL54ZSpy8nBHns+vBVSoILlVOx+dei300pnLRN958rj/EdlVLKuWlSESU3qdnDZdAI7FXYGg==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-escapes": "^7.3.0",
 				"cli-cursor": "^5.0.0",
-				"slice-ansi": "^8.0.0",
+				"slice-ansi": "^9.0.0",
+				"string-width": "^8.2.0",
 				"strip-ansi": "^7.2.0",
 				"wrap-ansi": "^10.0.0"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -12067,16 +12068,16 @@
 			}
 		},
 		"node_modules/log-update/node_modules/slice-ansi": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
-			"integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
+			"integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^6.2.3",
 				"is-fullwidth-code-point": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -18473,7 +18474,7 @@
 				"chalk": "^5.6.2",
 				"cli-progress": "^3.12.0",
 				"figures": "^6.1.0",
-				"log-update": "^7.2.0",
+				"log-update": "^8.0.0",
 				"pretty-hrtime": "^1.0.3",
 				"slice-ansi": "^5.0.0"
 			},

--- a/packages/logger/lib/writers/InteractiveConsole.js
+++ b/packages/logger/lib/writers/InteractiveConsole.js
@@ -63,10 +63,6 @@ class InteractiveConsole {
 	// `#render()` call hands it the full multi-line frame and it diffs against
 	// the previous one, erasing wrap-correctly.
 	#logUpdate;
-	// Line count of the most recently composed frame — used to detect
-	// growing/shrinking frames and force `log-update` off its diff path in
-	// that case. See `#render()`.
-	#lastFrameLineCount;
 
 	// True while a live-region render (or explicit persist/done) is in flight,
 	// so #interceptWrite lets log-update's own bytes through to the real
@@ -150,10 +146,9 @@ class InteractiveConsole {
 		this.#stderr.write("\n");
 	}
 
-	// Compose the full live region as a single string plus its line count.
-	// One block per region, separated by their own leading blank line.
-	// `log-update` handles wrapping and erase of the previous frame, so we
-	// just hand it the full text.
+	// Compose the full live region as a single string. One block per region,
+	// separated by their own leading blank line. `log-update` handles wrapping
+	// and erase of the previous frame, so we just hand it the full text.
 	#composeLiveRegion() {
 		const lines = [
 			...renderHeaderRegion(this.#headerState),
@@ -162,7 +157,7 @@ class InteractiveConsole {
 			...renderBuildRegion(this.#buildState),
 		];
 		if (lines.length === 0) {
-			return {frame: "", lineCount: 0};
+			return "";
 		}
 		// `log-update` wraps long lines onto additional rows; the last line is
 		// designed to fit on a single row when it's a status line, so clip it
@@ -171,7 +166,7 @@ class InteractiveConsole {
 		if (this.#buildState.state !== STATES.INITIAL) {
 			lines[lines.length - 1] = sliceAnsi(lines[lines.length - 1], 0, this.#columns);
 		}
-		return {frame: lines.join("\n"), lineCount: lines.length};
+		return lines.join("\n");
 	}
 
 	#render() {
@@ -182,23 +177,7 @@ class InteractiveConsole {
 			return;
 		}
 		this.#withRenderingGuard(() => {
-			const {frame, lineCount} = this.#composeLiveRegion();
-			// Work around a `log-update` bug (v7.2.0): when a frame grows past
-			// the previous one, its `buildPatch` clamps the pre-write cursor
-			// move at 0 instead of moving DOWN to the new start row, so the
-			// cursor ends up above where the library thinks it is. The next
-			// `persist()`/`clear()` then calls `eraseLines()` with a count
-			// based on the new frame — erasing rows that overlap the scrollback
-			// above the live region (e.g. the shell prompt line). Forcing the
-			// first-frame code path by calling `clear()` whenever the row
-			// count changes sidesteps the diff logic entirely for the cases
-			// where it's buggy; steady-state renders (spinner tick, in-place
-			// updates with unchanged row count) still take the fast diff path.
-			if (this.#lastFrameLineCount !== undefined && lineCount !== this.#lastFrameLineCount) {
-				this.#logUpdate.clear();
-			}
-			this.#lastFrameLineCount = lineCount;
-			this.#logUpdate(frame);
+			this.#logUpdate(this.#composeLiveRegion());
 		});
 	}
 
@@ -219,14 +198,7 @@ class InteractiveConsole {
 		}
 		this.#withRenderingGuard(() => {
 			this.#logUpdate.persist(line);
-			// `persist()` resets log-update's internal state, so the follow-up
-			// render is a fresh first-frame write. Reset our own line-count
-			// tracker to match — otherwise the next `#render()` would
-			// mistakenly compare against the pre-persist count.
-			this.#lastFrameLineCount = undefined;
-			const {frame, lineCount} = this.#composeLiveRegion();
-			this.#lastFrameLineCount = lineCount;
-			this.#logUpdate(frame);
+			this.#logUpdate(this.#composeLiveRegion());
 		});
 	}
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -51,7 +51,7 @@
 		"chalk": "^5.6.2",
 		"cli-progress": "^3.12.0",
 		"figures": "^6.1.0",
-		"log-update": "^7.2.0",
+		"log-update": "^8.0.0",
 		"pretty-hrtime": "^1.0.3",
 		"slice-ansi": "^5.0.0"
 	},

--- a/packages/logger/test/lib/writers/InteractiveConsole.js
+++ b/packages/logger/test/lib/writers/InteractiveConsole.js
@@ -634,24 +634,6 @@ test.serial("spinner tick advances spinFrame while BUILDING", (t) => {
 	writer.disable();
 });
 
-test.serial("frame growth forces log-update off the diff path", (t) => {
-	// The InteractiveConsole works around a `log-update` bug where a growing
-	// frame miscomputes the erase range and eats scrollback above the live
-	// region. Whenever the frame's row count changes, the writer calls
-	// `logUpdate.clear()` to force the first-frame code path.
-	const {writer, stderr} = createWriter();
-	// First frame: header only.
-	process.emit("ui5.tool-info", {name: "UI5 CLI", version: "1.2.3"});
-	const framesAfterHeader = stderr.writes.length;
-	// Second frame: header + project. Different row count.
-	process.emit("ui5.project-resolved", {
-		name: "my.app", type: "application", version: "1.0.0", framework: null,
-	});
-	t.true(stderr.writes.length > framesAfterHeader,
-		"project-resolved triggers additional writes when the frame grows");
-	writer.disable();
-});
-
 // ---- process.stdout / process.stderr interception ---------------------------
 // InteractiveConsole replaces process.stdout.write / process.stderr.write while
 // active so writes that bypass @ui5/logger (custom tasks, third-party libs) get

--- a/packages/logger/test/lib/writers/interactiveConsole/render.js
+++ b/packages/logger/test/lib/writers/interactiveConsole/render.js
@@ -106,8 +106,7 @@ test("renderProjectRegion: omits the framework row when project has no framework
 	// For a UI5 app without a declared framework (a common shape when
 	// something like fiori-tools-proxy supplies it at runtime) the writer
 	// omits the row entirely rather than rendering a misleading "(none)"
-	// label. The frame grows by exactly one row later if a framework
-	// resolves; log-update's clear() workaround handles that transition.
+	// label.
 	const state = createProjectState();
 	setProject(state, {
 		name: "my.app",


### PR DESCRIPTION
log-update v8 fixes the cursor-alignment bug in its diff path where a growing frame would clamp the pre-write cursor move at 0 instead of moving down to the new start row, causing the next erase to eat scrollback above the live region. The InteractiveConsole worked around this by calling logUpdate.clear() whenever the row count changed.

With the fix upstream, drop the workaround: remove the lastFrameLineCount bookkeeping, simplify composeLiveRegion() to return just the frame string, and let render() and logAbove() hand that string straight to log-update. Also remove the test that pinned the workaround behaviour and the stale reference in render.js.

v8 requires Node >= 22, which this repo already requires.
