### PR TITLE
fix(cli): Log error during initialization of UI5 CLI

### DIFF
--- a/packages/cli/bin/ui5.cjs
+++ b/packages/cli/bin/ui5.cjs
@@ -128,7 +128,7 @@ if (process.env.NODE_ENV !== "test" || process.env.UI5_CLI_TEST_BIN_RUN_MAIN !==
 	ui5.main().catch((err) => {
 		process.stderr.write("Fatal Error: Unable to initialize UI5 CLI");
 		process.stderr.write("\n");
-		process.stderr.write(err);
+		process.stderr.write(String(err));
 		process.exit(1);
 	});
 }

--- a/packages/cli/test/bin/ui5.js
+++ b/packages/cli/test/bin/ui5.js
@@ -374,6 +374,5 @@ test.serial("integration: Executing main when required as main module (catch ini
 
 	t.deepEqual(processStderrWriteStub.getCall(0).args, ["Fatal Error: Unable to initialize UI5 CLI"]);
 	t.is(processStderrWriteStub.getCall(2).args.length, 1);
-	t.true(processStderrWriteStub.getCall(2).args[0] instanceof Error);
-	t.is(processStderrWriteStub.getCall(2).args[0].message, "TEST: Unable to invoke CLI");
+	t.is(processStderrWriteStub.getCall(2).args[0], "Error: TEST: Unable to invoke CLI");
 });


### PR DESCRIPTION
Unexpected errors during initialization of the UI5 CLI are now properly logged to the console. Previously, such errors appeared as 'TypeError [ERR_INVALID_ARG_TYPE]' error because 'process.stderr.write' was called with the error object, not a string.

Up-port of https://github.com/SAP/ui5-cli/pull/818
