### PR TITLE
fix(server): Remove import of @ui5/project build cache enum

### DIFF
--- a/packages/server/lib/server.js
+++ b/packages/server/lib/server.js
@@ -8,7 +8,6 @@ import attachLiveReloadServer from "./liveReload/server.js";
 import {createReaderCollection} from "@ui5/fs/resourceFactory";
 import ReaderCollectionPrioritized from "@ui5/fs/ReaderCollectionPrioritized";
 import {getLogger} from "@ui5/logger";
-import Cache from "@ui5/project/build/cache/Cache";
 
 const log = getLogger("server");
 /**
@@ -151,7 +150,7 @@ async function _addSsl({app, key, cert}) {
 export async function serve(graph, {
 	port: requestedPort, changePortIfInUse = false, h2 = false, key, cert,
 	acceptRemoteConnections = false, sendSAPTargetCSP = false,
-	simpleIndex = false, liveReload = false, serveCSPReports = false, cache = Cache.Default,
+	simpleIndex = false, liveReload = false, serveCSPReports = false, cache = "Default",
 	ui5DataDir, includedTasks, excludedTasks,
 }, error) {
 	const rootProject = graph.getRoot();


### PR DESCRIPTION
@ui5/server imported the Cache enum from
"@ui5/project/build/cache/Cache" to default the serve() cache option,
but @ui5/project is intentionally not declared as a non-dev dependency.
Drop the import and inline the enum's "Default" value instead.
