### PR TITLE
refactor(builder): Include component path in versionInfoGenerator logs

### DIFF
--- a/packages/builder/lib/processors/versionInfoGenerator.js
+++ b/packages/builder/lib/processors/versionInfoGenerator.js
@@ -101,7 +101,7 @@ const processManifest = async (manifestResource) => {
  */
 const isBundledWithLibrary = (embeddedBy, componentPath, libraryPathPrefix) => {
 	if (typeof embeddedBy === "undefined") {
-		log.verbose("  Component doesn't declare 'sap.app/embeddedBy', don't list it as 'embedded'");
+		log.verbose(`  Component '${componentPath}' doesn't declare 'sap.app/embeddedBy', don't list it as 'embedded'`);
 		return false;
 	}
 	if (typeof embeddedBy !== "string") {
@@ -122,11 +122,13 @@ const isBundledWithLibrary = (embeddedBy, componentPath, libraryPathPrefix) => {
 		resolvedEmbeddedBy = resolvedEmbeddedBy + "/";
 	}
 	if ( libraryPathPrefix === resolvedEmbeddedBy ) {
-		log.verbose("  Component's 'sap.app/embeddedBy' property points to library, list it as 'embedded'");
+		log.verbose(
+			`  Component '${componentPath}': property 'sap.app/embeddedBy' points to library, list it as 'embedded'`);
 		return true;
 	} else {
 		log.verbose(
-			`  Component's 'sap.app/embeddedBy' points to '${resolvedEmbeddedBy}', don't list it as 'embedded'`);
+			`  Component '${componentPath}': property 'sap.app/embeddedBy' points to '${resolvedEmbeddedBy}', ` +
+			`don't list it as 'embedded'`);
 		return false;
 	}
 };

--- a/packages/builder/test/lib/processors/versionInfoGenerator.js
+++ b/packages/builder/test/lib/processors/versionInfoGenerator.js
@@ -355,6 +355,10 @@ test.serial("versionInfoGenerator library infos with embeds", async (t) => {
 	assertVersionInfoContent(t, oExpected, result);
 	t.is(t.context.infoLogStub.callCount, 0);
 	t.is(t.context.warnLogStub.callCount, 0);
+	t.is(t.context.verboseLogStub.callCount, 1);
+	t.is(t.context.verboseLogStub.getCall(0).args[0],
+		"  Component '/resources/lib/a/sub' doesn't declare 'sap.app/embeddedBy', " +
+		"don't list it as 'embedded'");
 });
 
 test.serial("versionInfoGenerator library infos with no embeds", async (t) => {
@@ -512,4 +516,8 @@ test.serial("versionInfoGenerator library infos with embeds and embeddedBy (hasO
 	assertVersionInfoContent(t, oExpected, result);
 	t.is(t.context.infoLogStub.callCount, 0);
 	t.is(t.context.warnLogStub.callCount, 0);
+	t.is(t.context.verboseLogStub.callCount, 1);
+	t.is(t.context.verboseLogStub.getCall(0).args[0],
+		"  Component '/resources/lib/a/sub': property 'sap.app/embeddedBy' points to library, " +
+		"list it as 'embedded'");
 });

--- a/packages/builder/test/lib/tasks/generateVersionInfo.js
+++ b/packages/builder/test/lib/tasks/generateVersionInfo.js
@@ -955,7 +955,8 @@ test.serial("integration: Library without dependencies and embeddedBy undefined"
 
 	t.is(verboseLogStub.callCount, 1);
 	t.is(verboseLogStub.firstCall.args[0],
-		"  Component doesn't declare 'sap.app/embeddedBy', don't list it as 'embedded'");
+		"  Component '/resources/lib/a/sub/fold' doesn't declare 'sap.app/embeddedBy', " +
+		"don't list it as 'embedded'");
 });
 
 test.serial("integration: Library without dependencies and embeddedBy not a string", async (t) => {
@@ -1098,7 +1099,8 @@ test.serial("integration: Library without dependencies and embeddedBy path not c
 
 	t.is(verboseLogStub.callCount, 1);
 	t.is(verboseLogStub.firstCall.args[0],
-		"  Component's 'sap.app/embeddedBy' points to '/resources/lib/a/sub/', don't list it as 'embedded'");
+		"  Component '/resources/lib/a/sub/fold': property 'sap.app/embeddedBy' points to " +
+		"'/resources/lib/a/sub/', don't list it as 'embedded'");
 });
 
 test.serial("integration: Library with manifest with invalid dependency", async (t) => {


### PR DESCRIPTION
Several verbose and error logs in `isBundledWithLibrary` (versionInfoGenerator) reported that a component didn't declare `sap.app/embeddedBy`, or that its reference didn't point to the library, **without naming which component**. When a build lists multiple embedded components, the message alone doesn't say which one.

Add the component path to the remaining log messages, matching the format already used by the error branches (`Component '${componentPath}': ...`). Tests in the processor and the `generateVersionInfo` task now assert the component path.