### PR TITLE
docs: Several refactorings

### DIFF
--- a/internal/documentation/.vitepress/config.ts
+++ b/internal/documentation/.vitepress/config.ts
@@ -285,7 +285,7 @@ function guide() {
 		(() => {
 			// This function builds the tree for the api docs
 			const tree = {
-				text: "API",
+				text: "📚 API",
 				collapsed: false,
 				items: [{
 					text: "@ui5",

--- a/internal/documentation/.vitepress/config.ts
+++ b/internal/documentation/.vitepress/config.ts
@@ -285,7 +285,7 @@ function guide() {
 		(() => {
 			// This function builds the tree for the api docs
 			const tree = {
-				text: "📚 API",
+				text: "API",
 				collapsed: false,
 				items: [{
 					text: "@ui5",

--- a/internal/documentation/README.md
+++ b/internal/documentation/README.md
@@ -41,7 +41,6 @@ The development server starts at `http://localhost:5173` with hot-reload for liv
 | `download-packages` | Downloads the latest published versions of all UI5 CLI packages (`@ui5/builder`, `@ui5/cli`, etc.) via `npm pack` and extracts them to `tmp/packages/`. This enables gh-pages builds to use published npm packages instead of local workspace code. |
 | `jsdoc-generate` | Generates API documentation from local workspace package sources (`../../packages/*/lib/**/*.js`). Uses the workspace JSDoc config targeting the current development version (v5). |
 | `jsdoc-generate-gh-pages` | Generates API documentation from downloaded packages in `tmp/packages/`. Uses the gh-pages JSDoc config targeting the published version (v4). Requires `download-packages` to run first. |
-| `jsdoc` | Generates JSDoc API documentation from the local workspace and opens the result in the browser. Convenience wrapper for local development. |
 
 
 ## Dual-Version Documentation

--- a/internal/documentation/docs/index.md
+++ b/internal/documentation/docs/index.md
@@ -107,7 +107,7 @@ info ProjectBuilder Executing cleanup tasks...
 Most UI5 CLI modules provide JavaScript APIs for direct consumption in other Node.js projects.
 This allows you to rely on UI5 CLI for UI5-specific build functionality and project handling, while creating your own tools to perfectly match the needs of your project.
 
-All available APIs are documented in the [UI5 CLI API Reference](https://ui5.github.io/cli/v5/api/index.html).
+All available APIs are documented directly within this documentation. Use the sidebar menu and navigate to **📚 API** to browse the API reference for each package.
 
 ::: code-group
 ```js [ESM]

--- a/internal/documentation/docs/index.md
+++ b/internal/documentation/docs/index.md
@@ -107,7 +107,7 @@ info ProjectBuilder Executing cleanup tasks...
 Most UI5 CLI modules provide JavaScript APIs for direct consumption in other Node.js projects.
 This allows you to rely on UI5 CLI for UI5-specific build functionality and project handling, while creating your own tools to perfectly match the needs of your project.
 
-All available APIs are documented directly within this documentation. Use the sidebar menu and navigate to **📚 API** to browse the API reference for each package.
+All available APIs are documented directly within this documentation. Use the sidebar menu and navigate to **API** to browse the API reference for each package.
 
 ::: code-group
 ```js [ESM]

--- a/internal/documentation/docs/pages/Builder.md
+++ b/internal/documentation/docs/pages/Builder.md
@@ -10,9 +10,9 @@ Based on a project's type, the UI5 Builder defines a series of build steps to ex
 
 For every type there is a set of default tasks. You can disable single tasks using the `--exclude-task` [CLI parameter](./CLI.md#ui5-build), and you can include tasks using the `--include-task` parameter.
 
-<div style="margin: 1rem 0;">
-  <VPButton class="no-decoration" text="📚 API Reference" href="https://ui5.github.io/cli/v5/api/index.html"/>
-</div>
+::: tip
+Browse the API reference for each Builder API by navigating in the sidebar menu to **📚 API -> @ui5/builder**.
+:::
 
 ## Tasks
 Tasks are specific build steps to be executed during build phase.
@@ -23,31 +23,31 @@ A project can add custom tasks to the build by using the [Custom Tasks Extensibi
 
 ### Standard Tasks
 
-All available standard tasks are documented [in the API reference](https://ui5.github.io/cli/v5/api/index.html). Search for `@ui5/builder/tasks/` to filter the API reference for all available tasks. The list below offers the actual order of their execution:
+All available standard tasks are documented under **📚 API -> @ui5/builder -> tasks**. Use the sidebar menu to access the respective pages. The list below offers the actual order of their execution:
 
-| Task                           |   Type `application`    |    Type `component`     |     Type `library`      |  Type `theme-library`   |
-|--------------------------------|:-----------------------:|:-----------------------:|:-----------------------:|:-----------------------:|
-| escapeNonAsciiCharacters       |         enabled         |         enabled         |         enabled         |                         |
-| replaceCopyright               |         enabled         |         enabled         |         enabled         |         enabled         |
-| replaceVersion                 |         enabled         |         enabled         |         enabled         |         enabled         |
-| replaceBuildtime               |                         |                         |         enabled         |                         |
-| generateJsdoc                  |                         |                         | *disabled* <sup>1</sup> |                         |
-| executeJsdocSdkTransformation  |                         |                         | *disabled* <sup>1</sup> |                         |
-| minify                         |         enabled         |         enabled         |         enabled         |                         |
-| generateFlexChangesBundle      |         enabled         |         enabled         |         enabled         |                         |
-| generateLibraryManifest        |                         |                         |         enabled         |                         |
-| enhanceManifest                |         enabled         |         enabled         |         enabled         |                         |
-| generateComponentPreload       |         enabled         |         enabled         | *disabled* <sup>2</sup> |                         |
-| generateLibraryPreload         |                         |                         |         enabled         |                         |
-| generateStandaloneAppBundle    | *disabled* <sup>3</sup> |                         |                         |                         |
-| transformBootstrapHtml         | *disabled* <sup>3</sup> |                         |                         |                         |
-| generateBundle                 | *disabled* <sup>4</sup> | *disabled* <sup>4</sup> | *disabled* <sup>4</sup> |                         |
-| buildThemes                    |                         |                         |         enabled         |         enabled         |
-| generateThemeDesignerResources |                         |                         | *disabled* <sup>5</sup> | *disabled* <sup>5</sup> |
-| generateVersionInfo            |  enabled <sup>6</sup>   |                         |                         |                         |
-| generateCachebusterInfo        |       *disabled*        |       *disabled*        |                         |                         |
-| generateApiIndex               | *disabled* <sup>1</sup> |                         |                         |                         |
-| generateResourcesJson          |       *disabled*        |       *disabled*        |       *disabled*        |       *disabled*        |
+| Task                                                                                                  |   Type `application`    |    Type `component`     |     Type `library`      |  Type `theme-library`   |
+|-------------------------------------------------------------------------------------------------------|:-----------------------:|:-----------------------:|:-----------------------:|:-----------------------:|
+| [escapeNonAsciiCharacters](../api/module-@ui5_builder_tasks_escapeNonAsciiCharacters)                 |         enabled         |         enabled         |         enabled         |                         |
+| [replaceCopyright](../api/module-@ui5_builder_tasks_replaceCopyright)                                 |         enabled         |         enabled         |         enabled         |         enabled         |
+| [replaceVersion](../api/module-@ui5_builder_tasks_replaceVersion)                                     |         enabled         |         enabled         |         enabled         |         enabled         |
+| [replaceBuildtime](../api/module-@ui5_builder_tasks_replaceBuildtime)                                 |                         |                         |         enabled         |                         |
+| [generateJsdoc](../api/module-@ui5_builder_tasks_jsdoc_generateJsdoc)                                 |                         |                         | *disabled* <sup>1</sup> |                         |
+| [executeJsdocSdkTransformation](../api/module-@ui5_builder_tasks_jsdoc_executeJsdocSdkTransformation) |                         |                         | *disabled* <sup>1</sup> |                         |
+| [minify](../api/module-@ui5_builder_tasks_minify)                                                     |         enabled         |         enabled         |         enabled         |                         |
+| [generateFlexChangesBundle](../api/module-@ui5_builder_tasks_bundlers_generateFlexChangesBundle)      |         enabled         |         enabled         |         enabled         |                         |
+| [generateLibraryManifest](../api/module-@ui5_builder_tasks_generateLibraryManifest)                   |                         |                         |         enabled         |                         |
+| [enhanceManifest](../api/module-@ui5_builder_tasks_enhanceManifest)                                   |         enabled         |         enabled         |         enabled         |                         |
+| [generateComponentPreload](../api/module-@ui5_builder_tasks_bundlers_generateComponentPreload)        |         enabled         |         enabled         | *disabled* <sup>2</sup> |                         |
+| [generateLibraryPreload](../api/module-@ui5_builder_tasks_bundlers_generateLibraryPreload)            |                         |                         |         enabled         |                         |
+| [generateStandaloneAppBundle](../api/module-@ui5_builder_tasks_bundlers_generateStandaloneAppBundle)  | *disabled* <sup>3</sup> |                         |                         |                         |
+| transformBootstrapHtml                                                                                | *disabled* <sup>3</sup> |                         |                         |                         |
+| [generateBundle](../api/module-@ui5_builder_tasks_bundlers_generateBundle)                            | *disabled* <sup>4</sup> | *disabled* <sup>4</sup> | *disabled* <sup>4</sup> |                         |
+| [buildThemes](../api/module-@ui5_builder_tasks_buildThemes)                                           |                         |                         |         enabled         |         enabled         |
+| [generateThemeDesignerResources](../api/module-@ui5_builder_tasks_generateThemeDesignerResources)     |                         |                         | *disabled* <sup>5</sup> | *disabled* <sup>5</sup> |
+| [generateVersionInfo](../api/module-@ui5_builder_tasks_generateVersionInfo)                           |  enabled <sup>6</sup>   |                         |                         |                         |
+| [generateCachebusterInfo](../api/module-@ui5_builder_tasks_generateCachebusterInfo)                   |       *disabled*        |       *disabled*        |                         |                         |
+| [generateApiIndex](../api/module-@ui5_builder_tasks_jsdoc_generateApiIndex)                           | *disabled* <sup>1</sup> |                         |                         |                         |
+| [generateResourcesJson](../api/module-@ui5_builder_tasks_generateResourcesJson)                       |       *disabled*        |       *disabled*        |       *disabled*        |       *disabled*        |
 
 *Disabled tasks can be activated by certain build modes, the project configuration, or by using the `--include-task` [CLI parameter](./CLI.md#ui5-build). See footnotes where given*
 
@@ -158,7 +158,7 @@ Processors work with provided resources. They contain the actual build step logi
 Processors can be implemented generically. The string replacer is an example for that.
 Since string replacement is a common build step, it can be useful in different contexts, e.g. code, version, date, and copyright replacement. A concrete replacement operation could be achieved by passing a custom configuration to the processor. This way, multiple tasks can make use of the same processor to achieve their build step.
 
-To get a list of all available processors, please visit [the API reference](https://ui5.github.io/cli/v5/api/index.html) and search for `@ui5/builder/processors/`.
+To get a list of all available processors, use the sidebar menu and navigate to **📚 API -> @ui5/builder -> processors**.
 
 ## Legacy Bundle Tooling (lbt)
 JavaScript port of the "legacy" Maven/Java based bundle tooling.

--- a/internal/documentation/docs/pages/Builder.md
+++ b/internal/documentation/docs/pages/Builder.md
@@ -11,7 +11,7 @@ Based on a project's type, the UI5 Builder defines a series of build steps to ex
 For every type there is a set of default tasks. You can disable single tasks using the `--exclude-task` [CLI parameter](./CLI.md#ui5-build), and you can include tasks using the `--include-task` parameter.
 
 ::: tip
-Browse the API reference for each Builder API by navigating in the sidebar menu to **📚 API -> @ui5/builder**.
+Browse the API reference for each Builder API by navigating in the sidebar menu to **API -> @ui5/builder**.
 :::
 
 ## Tasks
@@ -23,7 +23,7 @@ A project can add custom tasks to the build by using the [Custom Tasks Extensibi
 
 ### Standard Tasks
 
-All available standard tasks are documented under **📚 API -> @ui5/builder -> tasks**. Use the sidebar menu to access the respective pages. The list below offers the actual order of their execution:
+All available standard tasks are documented under **API -> @ui5/builder -> tasks**. Use the sidebar menu to access the respective pages. The list below offers the actual order of their execution:
 
 | Task                                                                                                  |   Type `application`    |    Type `component`     |     Type `library`      |  Type `theme-library`   |
 |-------------------------------------------------------------------------------------------------------|:-----------------------:|:-----------------------:|:-----------------------:|:-----------------------:|
@@ -158,7 +158,7 @@ Processors work with provided resources. They contain the actual build step logi
 Processors can be implemented generically. The string replacer is an example for that.
 Since string replacement is a common build step, it can be useful in different contexts, e.g. code, version, date, and copyright replacement. A concrete replacement operation could be achieved by passing a custom configuration to the processor. This way, multiple tasks can make use of the same processor to achieve their build step.
 
-To get a list of all available processors, use the sidebar menu and navigate to **📚 API -> @ui5/builder -> processors**.
+To get a list of all available processors, use the sidebar menu and navigate to **API -> @ui5/builder -> processors**.
 
 ## Legacy Bundle Tooling (lbt)
 JavaScript port of the "legacy" Maven/Java based bundle tooling.

--- a/internal/documentation/docs/pages/Configuration.md
+++ b/internal/documentation/docs/pages/Configuration.md
@@ -749,7 +749,7 @@ A list of bundle definitions. A `bundleDefinition` contains of the following opt
 
 - `name`: The module bundle name
 - `defaultFileTypes`: List of default file types which should be included in the bundle. Defaults to: `.js`, `.control.xml`, `.fragment.html`, `.fragment.json`, `.fragment.xml`, `.view.html`, `.view.json` and `.view.xml`
-- `sections`: A list of module bundle definition sections. Each section specifies an embedding technology (see [API-Reference](https://ui5.github.io/cli/v5/api/module-@ui5_builder_processors_bundlers_moduleBundler.html#~ModuleBundleDefinition)) and lists the resources that should be in- or excluded from the section.
+- `sections`: A list of module bundle definition sections. Each section specifies an embedding technology (see [📚 API-Reference](../api/module-@ui5_builder_processors_bundlers_moduleBundler.html#~ModuleBundleDefinition)) and lists the resources that should be in- or excluded from the section.
     - `mode`:  The embedding technology (e.g. provided, raw, preload, bundleInfo, depCache, require)
     - `filters`: List of modules declared as glob patterns (resource name patterns) that are in- or excluded. Similarly to the use of a single `*` or double `**` asterisk, a pattern ending with a slash `/` denotes an arbitrary number of characters or folder names. Excludes have to be marked with a leading exclamation mark `!`. The order of filters is relevant; a later inclusion overrides an earlier exclusion, and vice versa.
     - `resolve`: Setting resolve to `true` will also include all (transitive) dependencies of the files

--- a/internal/documentation/docs/pages/Configuration.md
+++ b/internal/documentation/docs/pages/Configuration.md
@@ -749,7 +749,7 @@ A list of bundle definitions. A `bundleDefinition` contains of the following opt
 
 - `name`: The module bundle name
 - `defaultFileTypes`: List of default file types which should be included in the bundle. Defaults to: `.js`, `.control.xml`, `.fragment.html`, `.fragment.json`, `.fragment.xml`, `.view.html`, `.view.json` and `.view.xml`
-- `sections`: A list of module bundle definition sections. Each section specifies an embedding technology (see [📚 API-Reference](../api/module-@ui5_builder_processors_bundlers_moduleBundler.html#~ModuleBundleDefinition)) and lists the resources that should be in- or excluded from the section.
+- `sections`: A list of module bundle definition sections. Each section specifies an embedding technology (see [API-Reference](../api/module-@ui5_builder_processors_bundlers_moduleBundler.html#~ModuleBundleDefinition)) and lists the resources that should be in- or excluded from the section.
     - `mode`:  The embedding technology (e.g. provided, raw, preload, bundleInfo, depCache, require)
     - `filters`: List of modules declared as glob patterns (resource name patterns) that are in- or excluded. Similarly to the use of a single `*` or double `**` asterisk, a pattern ending with a slash `/` denotes an arbitrary number of characters or folder names. Excludes have to be marked with a leading exclamation mark `!`. The order of filters is relevant; a later inclusion overrides an earlier exclusion, and vice versa.
     - `resolve`: Setting resolve to `true` will also include all (transitive) dependencies of the files

--- a/internal/documentation/docs/pages/FileSystem.md
+++ b/internal/documentation/docs/pages/FileSystem.md
@@ -6,9 +6,9 @@ The [UI5 FS](https://github.com/SAP/ui5-fs) provides a UI5-specific file system 
 import VPButton from "vitepress/dist/client/theme-default/components/VPButton.vue"
 </script>
 
-<div style="margin: 1rem 0;">
-  <VPButton class="no-decoration" text="📚 API Reference" href="https://ui5.github.io/cli/v5/api/"/>
-</div>
+::: tip
+Browse the API reference for each FS API by navigating in the sidebar menu to **📚 API -> @ui5/fs**.
+:::
 
 ## Overview
 
@@ -16,7 +16,7 @@ The virtual file system "UI5 FS" offers an abstraction layer from the physical f
 
 ### Resource
 
-A [Resource](https://ui5.github.io/cli/v5/api/@ui5_fs_Resource.html) basically represents a file. Besides providing access to the file content, it also carries metadata like the **virtual path** of the Resource.
+A [Resource](../api/@ui5_fs_Resource.html) basically represents a file. Besides providing access to the file content, it also carries metadata like the **virtual path** of the Resource.
 
 Resources are typically created and stored in [Adapters](#adapters). Once read from a physical file system, they are typically kept in memory for further processing in other modules.
 
@@ -26,9 +26,9 @@ This ensures a high build performance, as physical read and write access for a h
 
 Adapters abstract access to different resource locations.
 
-The [Memory Adapter](https://ui5.github.io/cli/v5/api/@ui5_fs_adapters_Memory.html) represents a virtual file system which maintains respective [Resources](#resource) inside a virtual data structure.
+The [Memory Adapter](../api/@ui5_fs_adapters_Memory.html) represents a virtual file system which maintains respective [Resources](#resource) inside a virtual data structure.
 
-The [File System Adapter](https://ui5.github.io/cli/v5/api/@ui5_fs_adapters_FileSystem.html), on the other hand, has direct access to the physical file system. It maps a "virtual base path" to a given physical path.
+The [File System Adapter](../api/@ui5_fs_adapters_FileSystem.html), on the other hand, has direct access to the physical file system. It maps a "virtual base path" to a given physical path.
 
 Both adapters provide APIs to retrieve and persist [Resources](#resource), namely 
 
@@ -43,10 +43,10 @@ Reader collections allow grouped access to multiple adapters, which might even b
 
 They implement the same API for **retrieving** resources as adapters (`byPath` and `byGlob`). Multiple flavors exist:
 
-* [ReaderCollection](https://ui5.github.io/cli/v5/api/@ui5_fs_ReaderCollection.html): The most basic collection. Allows parallel read access to multiple readers (i.e. adapters or collections)
-* [ReaderCollectionPrioritized](https://ui5.github.io/cli/v5/api/@ui5_fs_ReaderCollectionPrioritized.html): Contains a list of readers which are searched in-order. This allows one reader to "overlay" resources of another
-* [DuplexCollection](https://ui5.github.io/cli/v5/api/@ui5_fs_DuplexCollection.html): Contains a single reader and a single "writer". It therefore also implements the Adapter API for **persisting** resources (`write()`). When retrieving resources, the writer is prioritized over the reader
-* [WriterCollection](https://ui5.github.io/cli/v5/api/@ui5_fs_WriterCollection.html): Contains a set of writers and a mapping for each of them. When writing a resource, the writer is chosen based on the resource's virtual path.
+* [ReaderCollection](../api/@ui5_fs_ReaderCollection.html): The most basic collection. Allows parallel read access to multiple readers (i.e. adapters or collections)
+* [ReaderCollectionPrioritized](../api/@ui5_fs_ReaderCollectionPrioritized.html): Contains a list of readers which are searched in-order. This allows one reader to "overlay" resources of another
+* [DuplexCollection](../api/@ui5_fs_DuplexCollection.html): Contains a single reader and a single "writer". It therefore also implements the Adapter API for **persisting** resources (`write()`). When retrieving resources, the writer is prioritized over the reader
+* [WriterCollection](../api/@ui5_fs_WriterCollection.html): Contains a set of writers and a mapping for each of them. When writing a resource, the writer is chosen based on the resource's virtual path.
 
 <style>
 .no-decoration {

--- a/internal/documentation/docs/pages/FileSystem.md
+++ b/internal/documentation/docs/pages/FileSystem.md
@@ -7,7 +7,7 @@ import VPButton from "vitepress/dist/client/theme-default/components/VPButton.vu
 </script>
 
 ::: tip
-Browse the API reference for each FS API by navigating in the sidebar menu to **📚 API -> @ui5/fs**.
+Browse the API reference for each file system API by navigating in the sidebar menu to **📚 API -> @ui5/fs**.
 :::
 
 ## Overview

--- a/internal/documentation/docs/pages/FileSystem.md
+++ b/internal/documentation/docs/pages/FileSystem.md
@@ -7,7 +7,7 @@ import VPButton from "vitepress/dist/client/theme-default/components/VPButton.vu
 </script>
 
 ::: tip
-Browse the API reference for each file system API by navigating in the sidebar menu to **📚 API -> @ui5/fs**.
+Browse the API reference for each file system API by navigating in the sidebar menu to **API -> @ui5/fs**.
 :::
 
 ## Overview

--- a/internal/documentation/docs/pages/Overview.md
+++ b/internal/documentation/docs/pages/Overview.md
@@ -110,7 +110,7 @@ dependencies:
 
 By placing this file in the root directory of the `my.app` application project, you can start a server with a local copy of the `my.lib` dependency, located in the same parent directory, using the command `ui5 serve --dependency-definition ./projectDependencies.yaml`.
 
-The structure of the dependency definition file follows that of the [`@ui5/project/graph/providers/DependencyTree~TreeNode`](https://ui5.github.io/cli/v5/api/@ui5_project_graph_providers_DependencyTree.html#~TreeNode) type.
+The structure of the dependency definition file follows that of the [`@ui5/project/graph/providers/DependencyTree~TreeNode`](../api/@ui5_project_graph_providers_DependencyTree.html#~TreeNode) type.
 
 ## HTTP/2 Development Webserver
 The UI5 CLI contains a web server to serve the project via HTTP/2 protocol.
@@ -124,4 +124,4 @@ This requires an SSL certificate. You are guided through the automatic generatio
 ## Integration in Other Tools
 One of the key features of the UI5 CLI is its modularization. Single parts of UI5 CLI can easily be integrated in other `Node.js`-based tools and frameworks like [Grunt](https://gruntjs.com/) or [Gulp](https://gulpjs.com/).
 
-All JavaScript APIs available for direct consumption are listed [here](https://ui5.github.io/cli/v5/api/index.html). However, for standard UI5 development, the [UI5 CLI](./CLI.md) should always be the first choice.
+All JavaScript APIs available for direct consumption are listed in the sidebar menu under **📚 API**. However, for standard UI5 development, the [UI5 CLI](./CLI.md) should always be the first choice.

--- a/internal/documentation/docs/pages/Overview.md
+++ b/internal/documentation/docs/pages/Overview.md
@@ -124,4 +124,4 @@ This requires an SSL certificate. You are guided through the automatic generatio
 ## Integration in Other Tools
 One of the key features of the UI5 CLI is its modularization. Single parts of UI5 CLI can easily be integrated in other `Node.js`-based tools and frameworks like [Grunt](https://gruntjs.com/) or [Gulp](https://gulpjs.com/).
 
-All JavaScript APIs available for direct consumption are listed in the sidebar menu under **📚 API**. However, for standard UI5 development, the [UI5 CLI](./CLI.md) should always be the first choice.
+All JavaScript APIs available for direct consumption are listed in the sidebar menu under **API**. However, for standard UI5 development, the [UI5 CLI](./CLI.md) should always be the first choice.

--- a/internal/documentation/docs/pages/Project.md
+++ b/internal/documentation/docs/pages/Project.md
@@ -91,10 +91,9 @@ In the table below you can find the available combinations of project type & out
 ² Theme libraries in most cases have more than one namespace.  
 ³ Modules have explicit path mappings configured and no namespace concept.  
 
-
-<div style="margin: 1rem 0;">
-  <VPButton class="no-decoration" text="📚 API Reference" href="https://ui5.github.io/cli/v5/api/@ui5_project_build_ProjectBuilder.html"/>
-</div>
+::: tip
+Browse the API reference for each Project API by navigating in the sidebar menu to **📚 API -> @ui5/project**.
+:::
 
 <style>
 .no-decoration {

--- a/internal/documentation/docs/pages/Project.md
+++ b/internal/documentation/docs/pages/Project.md
@@ -92,7 +92,7 @@ In the table below you can find the available combinations of project type & out
 ³ Modules have explicit path mappings configured and no namespace concept.  
 
 ::: tip
-Browse the API reference for each Project API by navigating in the sidebar menu to **📚 API -> @ui5/project**.
+Browse the API reference for each Project API by navigating in the sidebar menu to **API -> @ui5/project**.
 :::
 
 <style>

--- a/internal/documentation/docs/pages/Server.md
+++ b/internal/documentation/docs/pages/Server.md
@@ -6,9 +6,9 @@ The [UI5 Server](https://github.com/SAP/ui5-server) module provides server capab
 import VPButton from "vitepress/dist/client/theme-default/components/VPButton.vue"
 </script>
 
-<div style="margin: 1rem 0;">
-  <VPButton class="no-decoration" text="📚 API Reference" href="https://ui5.github.io/cli/v5/api/module-@ui5_server.html"/>
-</div>
+::: tip
+Browse the API reference for each Server API by navigating in the sidebar menu to **📚 API -> @ui5/server**.
+:::
 
 ::: warning Development Use Only
 The UI5 Server is intended for **local development purposes only**. It must not be exposed to untrusted parties or used as a public-facing web server.

--- a/internal/documentation/docs/pages/Server.md
+++ b/internal/documentation/docs/pages/Server.md
@@ -7,7 +7,7 @@ import VPButton from "vitepress/dist/client/theme-default/components/VPButton.vu
 </script>
 
 ::: tip
-Browse the API reference for each Server API by navigating in the sidebar menu to **📚 API -> @ui5/server**.
+Browse the API reference for each Server API by navigating in the sidebar menu to **API -> @ui5/server**.
 :::
 
 ::: warning Development Use Only

--- a/internal/documentation/docs/pages/extensibility/CustomServerMiddleware.md
+++ b/internal/documentation/docs/pages/extensibility/CustomServerMiddleware.md
@@ -255,7 +255,7 @@ Live demo of the above example: [openui5-sample-app with custom middleware](http
 
 Custom middleware defining [Specification Version](../Configuration.md#specification-versions) 2.0 or higher have access to an interface of a [MiddlewareUtil](https://ui5.github.io/cli/v5/api/@ui5_server_middleware_MiddlewareUtil.html) instance.
 
-In this case, a `middlewareUtil` object is provided as a part of the custom middleware's [parameters](#custom-middleware-implementation). Depending on the specification version of the custom middleware, a set of helper functions is available to the implementation. The lowest required specification version for every function is listed in the [MiddlewareUtil API reference](https://ui5.github.io/cli/v5/api/@ui5_server_middleware_MiddlewareUtil.html).
+In this case, a `middlewareUtil` object is provided as a part of the custom middleware's [parameters](#custom-middleware-implementation). Depending on the specification version of the custom middleware, a set of helper functions is available to the implementation. The lowest required specification version for every function is listed in the [MiddlewareUtil API reference](../../api/@ui5_server_middleware_MiddlewareUtil.html).
 
 ## Integration with `karma-ui5`
 

--- a/internal/documentation/docs/pages/extensibility/CustomTasks.md
+++ b/internal/documentation/docs/pages/extensibility/CustomTasks.md
@@ -352,7 +352,7 @@ The following code snippets show examples for custom task implementations.
 
 #### Example: lib/tasks/renderMarkdownFiles.js
 
-This example is making use of the `resourceFactory` [TaskUtil](https://ui5.github.io/cli/v5/api/@ui5_project_build_helpers_TaskUtil.html)
+This example is making use of the `resourceFactory` [TaskUtil](../../api/@ui5_project_build_helpers_TaskUtil.html)
 API to create new resources based on the output of a third-party module for rendering Markdown files. The created resources are added to the build
 result by writing them into the provided `workspace`.
 In addition, this task supports differential builds, which re-process only changed resources.
@@ -449,7 +449,7 @@ Tasks should ideally use the reader/writer APIs provided by UI5 CLI for working 
 
 #### Example: lib/tasks/compileLicenseSummary.js
 
-This example is making use of multiple [TaskUtil](https://ui5.github.io/cli/v5/api/@ui5_project_build_helpers_TaskUtil.html)
+This example is making use of multiple [TaskUtil](../../api/@ui5_project_build_helpers_TaskUtil.html)
 APIs to retrieve additional information about the project currently being built (`taskUtil.getProject()`) and its direct dependencies
 (`taskUtil.getDependencies()`). Project configuration files like `package.json` can be accessed directly using `project.getRootReader()`.
 
@@ -554,6 +554,6 @@ module.exports = async function({dependencies, log, options, taskUtil, workspace
 
 ## Helper Class `TaskUtil`
 
-Custom tasks defining [Specification Version](../Configuration.md#specification-versions) 2.2 or higher have access to an interface of a [TaskUtil](https://ui5.github.io/cli/v5/api/@ui5_project_build_helpers_TaskUtil.html) instance.
+Custom tasks defining [Specification Version](../Configuration.md#specification-versions) 2.2 or higher have access to an interface of a [TaskUtil](../../api/@ui5_project_build_helpers_TaskUtil.html) instance.
 
-In this case, a `taskUtil` object is provided as a part of the custom task's [parameters](#task-implementation). Depending on the specification version of the custom task, a set of helper functions is available to the implementation. The lowest required specification version for every function is listed in the [TaskUtil API reference](https://ui5.github.io/cli/v5/api/@ui5_project_build_helpers_TaskUtil.html).
+In this case, a `taskUtil` object is provided as a part of the custom task's [parameters](#task-implementation). Depending on the specification version of the custom task, a set of helper functions is available to the implementation. The lowest required specification version for every function is listed in the [TaskUtil API reference](../../api/@ui5_project_build_helpers_TaskUtil.html).

--- a/internal/documentation/package.json
+++ b/internal/documentation/package.json
@@ -28,7 +28,6 @@
 		"build:vitepress": "vitepress build",
 		"build:assets": "sh -c 'DEST_DIR=${1:-./dist}; cp -r ./docs/images \"$DEST_DIR/images\"' --",
 		"preview": "vitepress preview --port 8080",
-		"jsdoc": "npm run jsdoc-generate && open-cli dist/api/index.html",
 		"jsdoc-generate": "jsdoc -c jsdoc/jsdoc-workspace.json -t jsdoc/docdash ./ || (echo 'Error during JSDoc generation! Check log.' && exit 1)",
 		"jsdoc-generate-gh-pages": "jsdoc -c jsdoc/jsdoc.json -t jsdoc/docdash ./ || (echo 'Error during JSDoc generation! Check log.' && exit 1)",
 		"generate-cli-doc": "node ./scripts/generateCliDoc.js",
@@ -51,7 +50,6 @@
 		"@apidevtools/json-schema-ref-parser": "^14.2.1",
 		"handlebars": "^4.7.9",
 		"jsdoc": "^4.0.5",
-		"open-cli": "^9.0.0",
 		"traverse": "^0.6.11"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
 				"@apidevtools/json-schema-ref-parser": "^14.2.1",
 				"handlebars": "^4.7.9",
 				"jsdoc": "^4.0.5",
-				"open-cli": "^9.0.0",
 				"traverse": "^0.6.11"
 			},
 			"engines": {
@@ -862,17 +861,6 @@
 			"integrity": "sha512-xW5Xb9Fr3WtYAOwavxxWL0CaJK/ReT+HKb5/R6dR1p9RVJ55MTdaxPdeTKY2ukhFchv2YHPMM8YuZyfyLqxedg==",
 			"dev": true,
 			"license": "CC0-1.0"
-		},
-		"node_modules/@borewit/text-codec": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
-			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
 		},
 		"node_modules/@colordx/core": {
 			"version": "5.5.0",
@@ -4532,31 +4520,6 @@
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
-		"node_modules/@tokenizer/inflate": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
-			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.3",
-				"token-types": "^6.1.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
-		"node_modules/@tokenizer/token": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@tufjs/canonical-json": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -7537,35 +7500,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/crypto-random-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-			"integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/crypto-random-string/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/css-declaration-sorter": {
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
@@ -9425,25 +9359,6 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/file-type": {
-			"version": "21.3.4",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
-			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tokenizer/inflate": "^0.4.1",
-				"strtok3": "^10.3.4",
-				"token-types": "^6.1.1",
-				"uint8array-extras": "^1.4.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
 		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -10513,27 +10428,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
 			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -13880,41 +13774,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/open-cli": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/open-cli/-/open-cli-9.0.0.tgz",
-			"integrity": "sha512-4UHkLVm4tUM/ardg66uY3x1icgfCnunks5eFVFBzASO3b13Ow2Md3xs9YT7yXWFjXOBpauIeh/N9fvbziU1wkg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"file-type": "^21.3.4",
-				"meow": "^14.1.0",
-				"open": "^11.0.0",
-				"tempy": "^3.2.0"
-			},
-			"bin": {
-				"open-cli": "cli.js"
-			},
-			"engines": {
-				"node": ">=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/open-cli/node_modules/meow": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
-			"integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -16850,23 +16709,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/strtok3": {
-			"version": "10.3.5",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
-			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/stubborn-fs": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
@@ -17140,51 +16982,6 @@
 				"node": ">=14.16"
 			}
 		},
-		"node_modules/tempy": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
-			"integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-stream": "^3.0.0",
-				"temp-dir": "^3.0.0",
-				"type-fest": "^2.12.2",
-				"unique-string": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/tempy/node_modules/is-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/tempy/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/terser": {
 			"version": "5.49.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
@@ -17389,25 +17186,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.6"
-			}
-		},
-		"node_modules/token-types": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
-			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@borewit/text-codec": "^0.2.1",
-				"@tokenizer/token": "^0.3.0",
-				"ieee754": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/tr46": {
@@ -17708,19 +17486,6 @@
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/uint8array-extras": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/unbash": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.3.tgz",
@@ -17778,22 +17543,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/unique-string": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-			"integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"crypto-random-string": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"


### PR DESCRIPTION
This PR includes the outsourced "Side tasks done" from original PR #1453.
Following changes have been made:

* docs: Replace hardcoded URLs (ui5.github.io/..) with dynamic links
* docs: Replace dead "API Reference" links
    * Guide the reader to use the new sidebar menu
* docs: Add links to all Builder tasks in Standard Tasks table
* refactor(internal/documentation): Remove of npm script `jsdoc` (deprecated & not used in CI)
    * Remove now unused dep `open-cli`