### PR TITLE
test(project): Fix flaky build server Force-mode cache-miss race

### DIFF
--- a/packages/project/lib/build/helpers/BuildContext.js
+++ b/packages/project/lib/build/helpers/BuildContext.js
@@ -143,11 +143,19 @@ class BuildContext {
 			}
 		}
 
-		// Phase 2: Initialize all source indices in parallel
+		// Phase 2: Initialize all source indices in parallel. allSettled (not all) so the
+		// reported error is chosen by iteration order, not init timing: under cache=Force
+		// every uncached project rejects with an equivalent "no cache found" message, and
+		// projectBuildContexts lists the requested projects first (Phase 1), so the first
+		// rejection names what the caller asked to build, not a transitive dependency.
 		const initStart = performance.now();
-		await Promise.all(
+		const initResults = await Promise.allSettled(
 			Array.from(projectBuildContexts.values()).map((ctx) => ctx.initSourceIndex())
 		);
+		const firstError = initResults.find((result) => result.status === "rejected");
+		if (firstError) {
+			throw firstError.reason;
+		}
 		if (log.isLevelEnabled("perf")) {
 			log.perf(
 				`Parallel source index initialization completed in ` +

--- a/packages/project/test/lib/build/helpers/BuildContext.js
+++ b/packages/project/test/lib/build/helpers/BuildContext.js
@@ -324,6 +324,89 @@ test("getProjectContext", async (t) => {
 	t.is(projectBuildContext, projectBuildContext2);
 });
 
+test("getRequiredProjectContexts: initializes all required contexts in parallel", async (t) => {
+	const {BuildContext} = t.context;
+
+	const contexts = {
+		app: {
+			getRequiredDependencies: async () => ["lib"],
+			initSourceIndex: sinon.stub().resolves(),
+		},
+		lib: {
+			getRequiredDependencies: async () => [],
+			initSourceIndex: sinon.stub().resolves(),
+		},
+	};
+	t.context.ProjectBuildContextCreateStub.callsFake(async (buildContext, project) => contexts[project.name]);
+	const graph = {
+		getRoot: () => ({getType: () => "application", getRootPath: () => ""}),
+		getProject: (name) => ({name}),
+	};
+
+	const buildContext = new BuildContext(graph, "taskRepository");
+	const result = await buildContext.getRequiredProjectContexts(["app"]);
+
+	t.deepEqual(Array.from(result.keys()), ["app", "lib"],
+		"Discovers the requested project and its transitive dependency");
+	t.is(contexts.app.initSourceIndex.callCount, 1);
+	t.is(contexts.lib.initSourceIndex.callCount, 1);
+});
+
+test("getRequiredProjectContexts: deterministically reports the requested project's init error",
+	async (t) => {
+		const {BuildContext} = t.context;
+
+		// The dependency rejects immediately, the requested project only after a timer; the
+		// requested project's error must still be the one surfaced.
+		const contexts = {
+			app: {
+				getRequiredDependencies: async () => ["lib"],
+				initSourceIndex: () => new Promise((resolve, reject) =>
+					setTimeout(() => reject(new Error("no cache found for project app")), 20)),
+			},
+			lib: {
+				getRequiredDependencies: async () => [],
+				initSourceIndex: () => Promise.reject(new Error("no cache found for project lib")),
+			},
+		};
+		t.context.ProjectBuildContextCreateStub.callsFake(async (buildContext, project) => contexts[project.name]);
+		const graph = {
+			getRoot: () => ({getType: () => "application", getRootPath: () => ""}),
+			getProject: (name) => ({name}),
+		};
+
+		const buildContext = new BuildContext(graph, "taskRepository");
+		const err = await t.throwsAsync(buildContext.getRequiredProjectContexts(["app"]));
+		t.is(err.message, "no cache found for project app",
+			"Surfaces the requested project's error even though the dependency rejected first");
+	});
+
+test("getRequiredProjectContexts: surfaces a dependency error when the requested project succeeds",
+	async (t) => {
+		const {BuildContext} = t.context;
+
+		const contexts = {
+			app: {
+				getRequiredDependencies: async () => ["lib"],
+				initSourceIndex: () => Promise.resolve(),
+			},
+			lib: {
+				getRequiredDependencies: async () => [],
+				initSourceIndex: () => Promise.reject(new Error("no cache found for project lib")),
+			},
+		};
+		t.context.ProjectBuildContextCreateStub.callsFake(async (buildContext, project) => contexts[project.name]);
+		const graph = {
+			getRoot: () => ({getType: () => "application", getRootPath: () => ""}),
+			getProject: (name) => ({name}),
+		};
+
+		const buildContext = new BuildContext(graph, "taskRepository");
+		const err = await t.throwsAsync(buildContext.getRequiredProjectContexts(["app"]));
+		t.is(err.message, "no cache found for project lib",
+			"Falls back to the dependency's error when the requested project initializes cleanly");
+	});
+
 test("getCacheManager: Returns null when cache mode is 'Off'", async (t) => {
 	const {BuildContext} = t.context;
 


### PR DESCRIPTION
## Issue

`BuildServer.integration › Build server recovers from non-abort build error (no deadlock)` was flaky on CI.

`getRequiredProjectContexts` initialized all required project source indices in parallel via `Promise.all`. Under `cache=Force` with an empty cache, every uncached project throws an equivalent `no cache found for project <name>` error, so `Promise.all` rejected with whichever lost the race — a timing-dependent project name.

The root cause is that this surfaced error misidentifies the failure: the caller requests a build for `application.a`, but the error that propagates can name any transitive dependency that happened to reject first, so the message points at the wrong project. The test's hard-coded `application.a` assertion made this nondeterminism visible as flakiness, but the same race produces misleading error messages for real builds.

## Solution

Use `Promise.allSettled` and select the reported error deterministically, preferring a *requested* project's error over a transitive dependency's. Added regression tests.