### PR TITLE
feat(project): Diagnose build cache misses via signature manifests

### DIFF
--- a/packages/project/lib/build/cache/BuildCacheStorage.js
+++ b/packages/project/lib/build/cache/BuildCacheStorage.js
@@ -10,7 +10,9 @@ const METADATA_COMPRESSION_THRESHOLD = 4096;
 const CONTENT_COMPRESSION_THRESHOLD = 128;
 
 /** All live data table names */
-const DATA_TABLES = ["content", "index_cache", "stage_metadata", "task_metadata", "result_metadata"];
+const DATA_TABLES = [
+	"content", "index_cache", "stage_metadata", "task_metadata", "result_metadata", "signature_manifest"
+];
 
 /**
  * Unified SQLite-backed storage for the build cache
@@ -87,6 +89,13 @@ export default class BuildCacheStorage {
 				PRIMARY KEY (project_id, build_signature, stage_signature)
 			) WITHOUT ROWID;
 
+			CREATE TABLE IF NOT EXISTS signature_manifest (
+				project_id TEXT NOT NULL,
+				build_signature TEXT NOT NULL,
+				data BLOB NOT NULL,
+				PRIMARY KEY (project_id, build_signature)
+			) WITHOUT ROWID;
+
 			CREATE TABLE IF NOT EXISTS _vacuum_pending (
 				pending INTEGER NOT NULL DEFAULT 0
 			);
@@ -144,6 +153,15 @@ export default class BuildCacheStorage {
 			writeResultMetadata: this.#db.prepare(
 				`INSERT OR REPLACE INTO result_metadata
 				(project_id, build_signature, stage_signature, data) VALUES (?, ?, ?, ?)`
+			),
+
+			// Signature manifest (diagnostic side-channel: named inputs behind each build signature)
+			writeSignatureManifest: this.#db.prepare(
+				`INSERT OR REPLACE INTO signature_manifest (project_id, build_signature, data)
+				VALUES (?, ?, ?)`
+			),
+			listSignatureManifests: this.#db.prepare(
+				"SELECT build_signature, data FROM signature_manifest WHERE project_id = ?"
 			),
 		};
 	}
@@ -400,6 +418,41 @@ export default class BuildCacheStorage {
 		this.#stmts.writeResultMetadata.run(
 			projectId, buildSignature, stageSignature, this.#serializeMetadata(metadata)
 		);
+	}
+
+	/**
+	 * Writes the diagnostic signature manifest for a build signature
+	 *
+	 * @param {string} projectId Project identifier
+	 * @param {string} buildSignature Build signature hash
+	 * @param {object} manifest Structured manifest of the signature's named inputs
+	 */
+	writeSignatureManifest(projectId, buildSignature, manifest) {
+		this.#stmts.writeSignatureManifest.run(
+			projectId, buildSignature, this.#serializeMetadata(manifest)
+		);
+	}
+
+	/**
+	 * Lists all stored signature manifests for a project across all its build signatures. Used to
+	 * diagnose a cache miss by diffing the current build's inputs against previously stored ones.
+	 *
+	 * @param {string} projectId Project identifier
+	 * @returns {Array<{buildSignature: string, manifest: object}>} Stored manifests (may be empty)
+	 */
+	listSignatureManifests(projectId) {
+		try {
+			const rows = this.#stmts.listSignatureManifests.all(projectId);
+			return rows.map((row) => ({
+				buildSignature: row.build_signature,
+				manifest: this.#deserializeMetadata(row.data),
+			}));
+		} catch (err) {
+			throw new Error(
+				`Failed to list signature manifests for ${projectId}: ${err.message}`,
+				{cause: err}
+			);
+		}
 	}
 
 	// ===== Transactions =====

--- a/packages/project/lib/build/cache/CacheManager.js
+++ b/packages/project/lib/build/cache/CacheManager.js
@@ -208,6 +208,29 @@ export default class CacheManager {
 	}
 
 	/**
+	 * Writes the diagnostic signature manifest for a build signature
+	 *
+	 * @public
+	 * @param {string} projectId Project identifier
+	 * @param {string} buildSignature Build signature hash
+	 * @param {object} manifest Structured manifest of the signature's named inputs
+	 */
+	writeSignatureManifest(projectId, buildSignature, manifest) {
+		this.#storage.writeSignatureManifest(projectId, buildSignature, manifest);
+	}
+
+	/**
+	 * Lists all stored signature manifests for a project across its build signatures
+	 *
+	 * @public
+	 * @param {string} projectId Project identifier
+	 * @returns {Array<{buildSignature: string, manifest: object}>} Stored manifests (may be empty)
+	 */
+	listSignatureManifests(projectId) {
+		return this.#storage.listSignatureManifests(projectId);
+	}
+
+	/**
 	 * Batch-checks which stage signatures exist in the database
 	 *
 	 * @public

--- a/packages/project/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/lib/build/cache/ProjectBuildCache.js
@@ -36,6 +36,85 @@ export const RESULT_CACHE_STATES = Object.freeze({
 });
 
 /**
+ * Sentinel marking a key that is present on only one side of a diff, so an added/removed key is
+ * distinguishable from a key whose value is an explicit `undefined` or `null`.
+ *
+ * @private
+ */
+const ABSENT = Symbol("absent");
+
+/**
+ * Recursively collects the leaf-level differences between two values into `differences`, keyed by a
+ * dotted/bracketed path (e.g. `server.customMiddleware[1].configuration.prependPath`). Objects and
+ * arrays are descended into; any other value (or a type mismatch between the two sides) is reported
+ * as a single leaf. This keeps a diagnosis actionable: instead of dumping two large config blobs, it
+ * pinpoints the exact field that changed.
+ *
+ * @private
+ * @param {string} path Dotted path to the current position (empty at the root)
+ * @param {*} cached Value from the previously stored manifest (or {@link ABSENT})
+ * @param {*} current Value from the current manifest (or {@link ABSENT})
+ * @param {Array<{field: string, cached: *, current: *}>} differences Accumulator, mutated in place
+ */
+function collectLeafDifferences(path, cached, current, differences) {
+	if (JSON.stringify(cached) === JSON.stringify(current)) {
+		return;
+	}
+	const bothPlainObjects =
+		cached && current && typeof cached === "object" && typeof current === "object" &&
+		Array.isArray(cached) === Array.isArray(current);
+	if (!bothPlainObjects) {
+		differences.push({
+			field: path || "(root)",
+			cached: cached === ABSENT ? "<absent>" : cached,
+			current: current === ABSENT ? "<absent>" : current,
+		});
+		return;
+	}
+
+	const keys = Array.isArray(cached) ?
+		new Set([...cached.keys(), ...current.keys()]) :
+		new Set([...Object.keys(cached), ...Object.keys(current)]);
+	for (const key of keys) {
+		const childPath = Array.isArray(cached) ?
+			`${path}[${key}]` :
+			(path ? `${path}.${key}` : key);
+		const cachedChild = key in Object(cached) ? cached[key] : ABSENT;
+		const currentChild = key in Object(current) ? current[key] : ABSENT;
+		collectLeafDifferences(childPath, cachedChild, currentChild, differences);
+	}
+}
+
+/**
+ * Computes a leaf-level diff between two signature manifests (see
+ * {@link @ui5/project/build/helpers/getBuildSignature.getSignatureManifest}). The manifests are
+ * descended recursively so that a change buried inside a nested config (e.g. a single middleware
+ * option) surfaces as one precise path rather than a dump of the whole enclosing object. Returns
+ * null when the manifests have incompatible structure versions, signaling to the caller that a
+ * meaningful diff cannot be produced.
+ *
+ * @private
+ * @param {object} cached The manifest stored by a previous build
+ * @param {object} current The manifest of the current build
+ * @returns {Array<{field: string, cached: *, current: *}>|null} Differing leaf paths, or null if the
+ *   manifests are structurally incompatible
+ */
+export function diffSignatureManifests(cached, current) {
+	if (!cached || !current || cached.manifestVersion !== current.manifestVersion) {
+		return null;
+	}
+	const differences = [];
+	const fields = new Set([...Object.keys(cached), ...Object.keys(current)]);
+	fields.delete("manifestVersion");
+	for (const field of fields) {
+		const cachedChild = field in cached ? cached[field] : ABSENT;
+		const currentChild = field in current ? current[field] : ABSENT;
+		collectLeafDifferences(field, cachedChild, currentChild, differences);
+	}
+	return differences;
+}
+
+/**
  * @typedef {object} StageMetadata
  * @property {Object<string, @ui5/project/build/cache/index/HashTree~ResourceMetadata>} resourceMetadata
  *   Resource metadata indexed by resource path
@@ -59,6 +138,7 @@ export default class ProjectBuildCache {
 
 	#project;
 	#buildSignature;
+	#signatureManifest;
 	#cacheManager;
 	#cacheMode;
 	#currentProjectReader;
@@ -103,14 +183,19 @@ export default class ProjectBuildCache {
 	 * @param {string} buildSignature Build signature for the current build
 	 * @param {object} cacheManager Cache manager instance for reading/writing cache data
 	 * @param {string} cacheMode Cache mode to use for building UI5 projects
+	 * @param {object} [signatureManifest] Structured, diffable manifest of the named inputs that
+	 *   produced the build signature. Persisted on a successful build and used to diagnose why a
+	 *   later build's cache could not be reused. Optional so callers that don't need diagnostics
+	 *   (e.g. tests) can omit it.
 	 */
-	constructor(project, buildSignature, cacheManager, cacheMode) {
+	constructor(project, buildSignature, cacheManager, cacheMode, signatureManifest) {
 		log.verbose(
 			`ProjectBuildCache for project ${project.getName()} uses build signature ${buildSignature}`);
 		this.#project = project;
 		this.#buildSignature = buildSignature;
 		this.#cacheManager = cacheManager;
 		this.#cacheMode = cacheMode;
+		this.#signatureManifest = signatureManifest;
 	}
 
 	/**
@@ -124,10 +209,11 @@ export default class ProjectBuildCache {
 	 * @param {string} buildSignature Build signature for the current build
 	 * @param {object|null} cacheManager Cache manager instance
 	 * @param {string} cacheMode Cache mode to use for building UI5 projects
+	 * @param {object} [signatureManifest] Structured manifest of the signature's named inputs
 	 * @returns {Promise<@ui5/project/build/cache/ProjectBuildCache>} Initialized cache instance
 	 */
-	static async create(project, buildSignature, cacheManager, cacheMode) {
-		return new ProjectBuildCache(project, buildSignature, cacheManager, cacheMode);
+	static async create(project, buildSignature, cacheManager, cacheMode, signatureManifest) {
+		return new ProjectBuildCache(project, buildSignature, cacheManager, cacheMode, signatureManifest);
 	}
 
 	/**
@@ -1488,9 +1574,11 @@ export default class ProjectBuildCache {
 			this.#combinedIndexState = INDEX_STATES.RESTORING_DEPENDENCY_INDICES;
 		} else {
 			if (this.#cacheMode === Cache.Force) {
-				throw new Error(`Cache is in "Force" mode but no cache found for project ${this.#project.getName()}. ` +
-					`Use "Default", "ReadOnly" or "Off" to rebuild.`);
+				throw new Error(`Cache is in "Force" mode but no cache found for project ` +
+					`${this.#project.getName()}. Use "Default", "ReadOnly" or "Off" to rebuild.` +
+					this.#reportCacheMiss(true));
 			}
+			this.#reportCacheMiss(false);
 			// No index cache found, create new index
 			this.#sourceIndex = await ResourceIndex.create(resources, Date.now());
 			this.#combinedIndexState = INDEX_STATES.INITIAL;
@@ -1498,6 +1586,73 @@ export default class ProjectBuildCache {
 		log.verbose(
 			`Initialized source index for project ${this.#project.getName()} ` +
 			`with signature ${this.#sourceIndex.getSignature()}`);
+	}
+
+	/**
+	 * Diagnoses why no cache exists for the current build signature by diffing the current signature
+	 * manifest against the manifests stored by previous builds of the same project. A different build
+	 * signature is not a source-file change — it means a signature *input* diverged (e.g. `ui5 serve`
+	 * excludes the `generateVersionInfo` task, so its signature differs from `ui5 build`'s and the
+	 * build's cache is never even looked up). The opaque hash cannot reveal this; the manifest can.
+	 *
+	 * @returns {string|null} A human-readable, field-level explanation of the closest mismatch, or
+	 *   null when no diagnosis is possible (no current manifest, no stored manifests, or the closest
+	 *   stored manifest has an incompatible structure).
+	 */
+	#diagnoseSignatureMismatch() {
+		if (!this.#signatureManifest) {
+			return null;
+		}
+		let stored;
+		try {
+			stored = this.#cacheManager.listSignatureManifests(this.#project.getId());
+		} catch (err) {
+			log.verbose(`Could not read signature manifests for cache-miss diagnosis: ${err.message}`);
+			return null;
+		}
+		const candidates = stored.filter((entry) => entry.buildSignature !== this.#buildSignature);
+		if (!candidates.length) {
+			return null;
+		}
+
+		let best = null;
+		for (const {manifest} of candidates) {
+			const differences = diffSignatureManifests(manifest, this.#signatureManifest);
+			if (!differences) {
+				continue; // Incompatible manifest structure, skip
+			}
+			if (!best || differences.length < best.length) {
+				best = differences;
+			}
+		}
+		if (!best || !best.length) {
+			return null;
+		}
+		return best.map(({field, cached, current}) =>
+			`  ${field}:\n    cached:  ${JSON.stringify(cached)}\n    current: ${JSON.stringify(current)}`).join("\n");
+	}
+
+	/**
+	 * Logs the closest-manifest diagnosis for a cache miss, if one is available. In "Force" mode the
+	 * miss is fatal and the reason is returned so the caller can append it to the thrown error; in
+	 * other modes it is logged at verbose level (the miss is handled by a silent rebuild).
+	 *
+	 * @param {boolean} forFatalError Whether the caller is about to throw a Force-mode error
+	 * @returns {string} A trailing explanation to append to an error message, or "" when none
+	 */
+	#reportCacheMiss(forFatalError) {
+		const diagnosis = this.#diagnoseSignatureMismatch();
+		if (!diagnosis) {
+			return "";
+		}
+		const message =
+			`The cache from a previous build of project ${this.#project.getName()} was not reused ` +
+			`because the build signature inputs differ:\n${diagnosis}`;
+		if (forFatalError) {
+			return ` ${message}`;
+		}
+		log.verbose(message);
+		return "";
 	}
 
 	/**
@@ -1605,6 +1760,12 @@ export default class ProjectBuildCache {
 				this.#cacheManager.writeIndexCache(
 					sourceIndexPrepared.projectId, sourceIndexPrepared.buildSignature,
 					sourceIndexPrepared.kind, sourceIndexPrepared.index);
+			}
+			// Persist the diagnostic manifest of the named signature inputs. INSERT OR REPLACE keeps
+			// it in sync with this build signature; a later mismatching build diffs against it.
+			if (this.#signatureManifest) {
+				this.#cacheManager.writeSignatureManifest(
+					this.#project.getId(), this.#buildSignature, this.#signatureManifest);
 			}
 		});
 

--- a/packages/project/lib/build/helpers/BuildContext.js
+++ b/packages/project/lib/build/helpers/BuildContext.js
@@ -77,6 +77,7 @@ class BuildContext {
 		};
 		// eslint-disable-next-line no-unused-vars
 		const {cache: _ignoreMe, ...signatureConfig} = this._buildConfig; // Clones buildConfig omitting the cache mode
+		this._signatureConfig = signatureConfig;
 		this._buildSignatureBase = getBaseSignature(signatureConfig);
 
 		this._taskRepository = taskRepository;
@@ -97,6 +98,17 @@ class BuildContext {
 
 	getBuildConfig() {
 		return this._buildConfig;
+	}
+
+	/**
+	 * The signature-relevant subset of the build configuration (i.e. the build config with the
+	 * cache mode omitted, since the cache mode must not influence the signature). Used both to
+	 * compute the base signature and, verbatim, as an input to the diagnostic signature manifest.
+	 *
+	 * @returns {object} Signature configuration
+	 */
+	getSignatureConfig() {
+		return this._signatureConfig;
 	}
 
 	getTaskRepository() {

--- a/packages/project/lib/build/helpers/ProjectBuildContext.js
+++ b/packages/project/lib/build/helpers/ProjectBuildContext.js
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import TaskUtil from "./TaskUtil.js";
 import TaskRunner from "../TaskRunner.js";
 import TaskDefinitions from "../TaskDefinitions.js";
-import {getProjectSignature} from "./getBuildSignature.js";
+import {getProjectSignature, getSignatureManifest} from "./getBuildSignature.js";
 import ProjectBuildCache from "../cache/ProjectBuildCache.js";
 
 /**
@@ -81,8 +81,14 @@ class ProjectBuildContext {
 		ctx._buildSignature = getProjectSignature(
 			baseSignature, taskSignatures, project, buildContext.getGraph(), buildContext.getTaskRepository());
 
+		// Diagnostic side-channel: the named inputs that produced ctx._buildSignature, persisted so a
+		// later build can diff its inputs against these and explain a cache miss (see getSignatureManifest).
+		const signatureManifest = getSignatureManifest(
+			buildContext.getSignatureConfig(), taskSignatures, project, buildContext.getTaskRepository());
+
 		const cacheMode = buildContext.getBuildConfig().cache;
-		ctx._buildCache = new ProjectBuildCache(project, ctx._buildSignature, cacheManager, cacheMode);
+		ctx._buildCache = new ProjectBuildCache(
+			project, ctx._buildSignature, cacheManager, cacheMode, signatureManifest);
 		return ctx;
 	}
 

--- a/packages/project/lib/build/helpers/getBuildSignature.js
+++ b/packages/project/lib/build/helpers/getBuildSignature.js
@@ -4,6 +4,11 @@ import crypto from "node:crypto";
 // (e.g. after making a change that impacts build contents)
 const BUILD_SIG_VERSION = "0";
 
+// Version of the signature manifest structure itself. The manifest is a diagnostic side-channel
+// (see getSignatureManifest); bump this when its shape changes so an old manifest can be recognized
+// and ignored rather than mis-diffed. Independent of BUILD_SIG_VERSION, which governs the hash.
+const SIGNATURE_MANIFEST_VERSION = 1;
+
 export function getBaseSignature(buildConfig) {
 	const key = BUILD_SIG_VERSION + JSON.stringify(buildConfig);
 	return crypto.createHash("sha256").update(key).digest("hex");
@@ -19,8 +24,9 @@ export function getBaseSignature(buildConfig) {
  * @param {string} taskSignatures
  * @param {@ui5/project/lib/Project} project The project to create the cache integrity for
  * @param {@ui5/project/lib/graph/ProjectGraph} graph The project graph
- * @param {@ui5/builder/tasks/taskRepository} taskRepository The task repository (used to determine the effective
- * versions of ui5-builder and ui5-fs)
+ * @param {@ui5/project/lib/build/helpers/BuildContext~TaskRepository} taskRepository The task repository
+ * (used to determine the effective versions of ui5-builder and ui5-fs)
+ * @returns {string} The project build signature (hex-encoded SHA-256 hash)
  */
 export function getProjectSignature(baseSignature, taskSignatures, project, graph, taskRepository) {
 	const key = baseSignature + taskSignatures + project.getId() + JSON.stringify(project.getConfig()) +
@@ -30,4 +36,35 @@ export function getProjectSignature(baseSignature, taskSignatures, project, grap
 	// Create a hash for all metadata
 	const hash = crypto.createHash("sha256").update(key).digest("hex");
 	return hash;
+}
+
+/**
+ * Collects the **named** inputs that feed the project build signature into a structured, diffable
+ * object. This is a diagnostic side-channel: the build signature is an opaque SHA-256 hash, so when
+ * two builds of the same project produce different signatures (e.g. `ui5 build` vs. `ui5 serve`,
+ * which excludes the `generateVersionInfo` task), the hash alone cannot reveal which input diverged.
+ * Persisting this manifest alongside the signature lets a later build diff its own inputs against the
+ * stored ones and report the exact differing field.
+ *
+ * The values here MUST mirror the inputs hashed by {@link getBaseSignature} and
+ * {@link getProjectSignature}; any input added to those must be added here too, or the diagnosis
+ * will silently miss the cause of a cache miss.
+ *
+ * @private
+ * @param {object} buildConfig The signature-relevant build configuration (cache mode omitted)
+ * @param {string} taskSignatures Concatenated build signatures of the project's tasks
+ * @param {@ui5/project/lib/Project} project The project being built
+ * @param {@ui5/project/lib/build/helpers/BuildContext~TaskRepository} taskRepository The task repository
+ * @returns {object} Structured signature manifest
+ */
+export function getSignatureManifest(buildConfig, taskSignatures, project, taskRepository) {
+	return {
+		manifestVersion: SIGNATURE_MANIFEST_VERSION,
+		buildSigVersion: BUILD_SIG_VERSION,
+		buildConfig,
+		taskSignatures,
+		projectId: project.getId(),
+		projectConfig: project.getConfig(),
+		toolVersions: taskRepository.getVersions(),
+	};
 }

--- a/packages/project/test/lib/build/cache/BuildCacheStorage.js
+++ b/packages/project/test/lib/build/cache/BuildCacheStorage.js
@@ -455,6 +455,46 @@ test("getDatabaseSize: Returns positive database size", (t) => {
 	t.true(size > 0);
 });
 
+// ===== Signature manifest =====
+
+test("listSignatureManifests: Returns empty array when none stored", (t) => {
+	t.deepEqual(t.context.storage.listSignatureManifests("project-a"), []);
+});
+
+test("Signature manifest: Round-trip write and list", (t) => {
+	const manifest = {manifestVersion: 1, buildConfig: {excludedTasks: []}, projectId: "project-a:1.0.0"};
+	t.context.storage.writeSignatureManifest("project-a", "sig-1", manifest);
+	t.deepEqual(t.context.storage.listSignatureManifests("project-a"), [
+		{buildSignature: "sig-1", manifest}
+	]);
+});
+
+test("Signature manifest: Lists all signatures for a project, scoped by project", (t) => {
+	t.context.storage.writeSignatureManifest("project-a", "sig-1", {manifestVersion: 1, v: 1});
+	t.context.storage.writeSignatureManifest("project-a", "sig-2", {manifestVersion: 1, v: 2});
+	t.context.storage.writeSignatureManifest("project-b", "sig-3", {manifestVersion: 1, v: 3});
+
+	const result = t.context.storage.listSignatureManifests("project-a");
+	t.is(result.length, 2);
+	t.deepEqual(
+		result.map((e) => e.buildSignature).sort(),
+		["sig-1", "sig-2"]
+	);
+});
+
+test("Signature manifest: Overwrite replaces data for the same signature", (t) => {
+	t.context.storage.writeSignatureManifest("project-a", "sig-1", {manifestVersion: 1, v: 1});
+	t.context.storage.writeSignatureManifest("project-a", "sig-1", {manifestVersion: 1, v: 2});
+	t.deepEqual(t.context.storage.listSignatureManifests("project-a"), [
+		{buildSignature: "sig-1", manifest: {manifestVersion: 1, v: 2}}
+	]);
+});
+
+test("hasRecords: Returns true when signature manifest table has records", (t) => {
+	t.context.storage.writeSignatureManifest("project-a", "sig-1", {manifestVersion: 1});
+	t.true(t.context.storage.hasRecords());
+});
+
 // ===== Pre-compressed content =====
 
 test("putCompressedContent: Stores pre-compressed data retrievable via readContent", (t) => {

--- a/packages/project/test/lib/build/cache/CacheManager.js
+++ b/packages/project/test/lib/build/cache/CacheManager.js
@@ -71,6 +71,17 @@ test.serial("Result metadata: round-trip via CacheManager", async (t) => {
 	cm.close();
 });
 
+test.serial("Signature manifest: round-trip via CacheManager", async (t) => {
+	const testDir = getUniqueTestDir();
+	const CacheManager = (await import("../../../../lib/build/cache/CacheManager.js")).default;
+	const cm = new CacheManager(path.join(testDir, "buildCache"));
+
+	const manifest = {manifestVersion: 1, buildConfig: {excludedTasks: ["generateVersionInfo"]}};
+	cm.writeSignatureManifest("project-x", "build-sig", manifest);
+	t.deepEqual(cm.listSignatureManifests("project-x"), [{buildSignature: "build-sig", manifest}]);
+	cm.close();
+});
+
 test.serial("Cache miss returns null for all metadata types", async (t) => {
 	const testDir = getUniqueTestDir();
 	const CacheManager = (await import("../../../../lib/build/cache/CacheManager.js")).default;

--- a/packages/project/test/lib/build/cache/ProjectBuildCache.js
+++ b/packages/project/test/lib/build/cache/ProjectBuildCache.js
@@ -1,6 +1,6 @@
 import test from "ava";
 import sinon from "sinon";
-import ProjectBuildCache from "../../../../lib/build/cache/ProjectBuildCache.js";
+import ProjectBuildCache, {diffSignatureManifests} from "../../../../lib/build/cache/ProjectBuildCache.js";
 import ResourceRequestManager from "../../../../lib/build/cache/ResourceRequestManager.js";
 import Cache from "../../../../lib/build/cache/Cache.js";
 
@@ -87,6 +87,8 @@ function createMockCacheManager() {
 		findExistingStageSignatures: sinon.stub().callsFake((projectId, buildSig, stageId, sigs) => sigs),
 		findExistingResultSignatures: sinon.stub().callsFake((projectId, buildSig, sigs) => sigs),
 		findExistingContentIntegrities: sinon.stub().returns(new Set()),
+		writeSignatureManifest: sinon.stub(),
+		listSignatureManifests: sinon.stub().returns([]),
 	};
 }
 
@@ -2376,3 +2378,109 @@ test("validateCache: dependency-set change is general, not specific to the build
 		t.is(cache.getTaskCache(taskName).getDependencyIndexSignatures()[0], expectedDepSignature,
 			"dependency index must refresh for any dependency-globbing task, not just buildThemes");
 	});
+
+// ===== SIGNATURE MANIFEST DIFF (cache-miss diagnosis) =====
+
+test("diffSignatureManifests: Returns empty array for identical manifests", (t) => {
+	const manifest = {manifestVersion: 1, buildConfig: {excludedTasks: []}, projectId: "p"};
+	t.deepEqual(diffSignatureManifests(manifest, {...manifest}), []);
+});
+
+test("diffSignatureManifests: Identifies a scalar leaf change with its dotted path", (t) => {
+	const cached = {manifestVersion: 1, taskSignatures: "aaa"};
+	const current = {manifestVersion: 1, taskSignatures: "bbb"};
+	t.deepEqual(diffSignatureManifests(cached, current), [{
+		field: "taskSignatures",
+		cached: "aaa",
+		current: "bbb",
+	}]);
+});
+
+test("diffSignatureManifests: Drills into nested objects and reports the leaf path", (t) => {
+	// Mirrors the real scenario: a single middleware option added deep inside projectConfig.
+	const cached = {manifestVersion: 1, projectConfig: {server: {customMiddleware: [
+		{name: "proxy", configuration: {secure: false}},
+	]}}};
+	const current = {manifestVersion: 1, projectConfig: {server: {customMiddleware: [
+		{name: "proxy", configuration: {secure: false, prependPath: true}},
+	]}}};
+	t.deepEqual(diffSignatureManifests(cached, current), [{
+		field: "projectConfig.server.customMiddleware[0].configuration.prependPath",
+		cached: "<absent>",
+		current: true,
+	}]);
+});
+
+test("diffSignatureManifests: Reports an added array element by index", (t) => {
+	const cached = {manifestVersion: 1, deps: ["a", "b"]};
+	const current = {manifestVersion: 1, deps: ["a", "b", "c"]};
+	t.deepEqual(diffSignatureManifests(cached, current), [{
+		field: "deps[2]",
+		cached: "<absent>",
+		current: "c",
+	}]);
+});
+
+test("diffSignatureManifests: Distinguishes an absent key from an explicit null/undefined", (t) => {
+	const cached = {manifestVersion: 1, cfg: {}};
+	const current = {manifestVersion: 1, cfg: {opt: null}};
+	t.deepEqual(diffSignatureManifests(cached, current), [{
+		field: "cfg.opt",
+		cached: "<absent>",
+		current: null,
+	}]);
+});
+
+test("diffSignatureManifests: Ignores manifestVersion field in the diff", (t) => {
+	const cached = {manifestVersion: 1, projectId: "p"};
+	const current = {manifestVersion: 1, projectId: "p"};
+	t.deepEqual(diffSignatureManifests(cached, current), []);
+});
+
+test("diffSignatureManifests: Returns null for incompatible manifest versions", (t) => {
+	t.is(diffSignatureManifests({manifestVersion: 1}, {manifestVersion: 2}), null);
+});
+
+test("diffSignatureManifests: Returns null when a manifest is missing", (t) => {
+	t.is(diffSignatureManifests(null, {manifestVersion: 1}), null);
+	t.is(diffSignatureManifests({manifestVersion: 1}, undefined), null);
+});
+
+test("Force mode: 'no cache' error is enriched with the signature-input diff", async (t) => {
+	const project = createMockProject();
+	const cacheManager = createMockCacheManager();
+	// No index cache for the current signature (the build-vs-serve situation), but a manifest from a
+	// previous build with different excludedTasks exists for the same project.
+	cacheManager.readIndexCache.returns(null);
+	cacheManager.listSignatureManifests.returns([{
+		buildSignature: "previous-sig",
+		manifest: {manifestVersion: 1, buildConfig: {excludedTasks: []}},
+	}]);
+
+	const currentManifest = {manifestVersion: 1, buildConfig: {excludedTasks: ["generateVersionInfo"]}};
+	const cache = await ProjectBuildCache.create(
+		project, "current-sig", cacheManager, Cache.Force, currentManifest);
+
+	const err = await t.throwsAsync(() => cache.initSourceIndex());
+	t.regex(err.message, /Force.*mode.*no cache found/i, "keeps the original Force-mode message");
+	t.regex(err.message, /build signature inputs differ/i, "explains a signature-input mismatch");
+	t.regex(err.message, /buildConfig\.excludedTasks\[0\]/, "names the exact differing leaf path");
+	t.true(cacheManager.listSignatureManifests.calledWith("test-project-id"),
+		"queried stored manifests for the project");
+});
+
+test("Force mode: 'no cache' error is not enriched when no prior manifest exists", async (t) => {
+	const project = createMockProject();
+	const cacheManager = createMockCacheManager();
+	cacheManager.readIndexCache.returns(null);
+	cacheManager.listSignatureManifests.returns([]);
+
+	const cache = await ProjectBuildCache.create(
+		project, "current-sig", cacheManager, Cache.Force,
+		{manifestVersion: 1, buildConfig: {excludedTasks: []}});
+
+	const err = await t.throwsAsync(() => cache.initSourceIndex());
+	t.regex(err.message, /Force.*mode.*no cache found/i);
+	t.notRegex(err.message, /build signature inputs differ/i,
+		"degrades to the plain message when there is nothing to diff against");
+});

--- a/packages/project/test/lib/build/helpers/getBuildSignature.js
+++ b/packages/project/test/lib/build/helpers/getBuildSignature.js
@@ -1,0 +1,63 @@
+import test from "ava";
+import {
+	getBaseSignature, getProjectSignature, getSignatureManifest
+} from "../../../../lib/build/helpers/getBuildSignature.js";
+
+function createProject() {
+	return {
+		getId: () => "my.project:1.2.3",
+		getConfig: () => ({metadata: {name: "my.project"}}),
+	};
+}
+
+function createTaskRepository() {
+	return {
+		getVersions: () => ({builderVersion: "5.0.0", fsVersion: "5.0.0"}),
+	};
+}
+
+test("getBaseSignature: Deterministic for equal input", (t) => {
+	const config = {selfContained: false, excludedTasks: []};
+	t.is(getBaseSignature(config), getBaseSignature({...config}));
+});
+
+test("getBaseSignature: Differs when a config field differs", (t) => {
+	const a = getBaseSignature({selfContained: false, excludedTasks: []});
+	const b = getBaseSignature({selfContained: false, excludedTasks: ["generateVersionInfo"]});
+	t.not(a, b);
+});
+
+test("getProjectSignature: Deterministic for equal inputs", (t) => {
+	const project = createProject();
+	const taskRepository = createTaskRepository();
+	const a = getProjectSignature("base", "tasks", project, {}, taskRepository);
+	const b = getProjectSignature("base", "tasks", project, {}, taskRepository);
+	t.is(a, b);
+});
+
+test("getSignatureManifest: Captures the named inputs behind the signature", (t) => {
+	const buildConfig = {selfContained: false, excludedTasks: ["generateVersionInfo"]};
+	const project = createProject();
+	const taskRepository = createTaskRepository();
+
+	const manifest = getSignatureManifest(buildConfig, "task-sigs", project, taskRepository);
+
+	t.is(manifest.manifestVersion, 1);
+	t.deepEqual(manifest.buildConfig, buildConfig);
+	t.is(manifest.taskSignatures, "task-sigs");
+	t.is(manifest.projectId, "my.project:1.2.3");
+	t.deepEqual(manifest.projectConfig, {metadata: {name: "my.project"}});
+	t.deepEqual(manifest.toolVersions, {builderVersion: "5.0.0", fsVersion: "5.0.0"});
+});
+
+test("getSignatureManifest: Reflects the excludedTasks divergence between build and serve", (t) => {
+	const project = createProject();
+	const taskRepository = createTaskRepository();
+
+	const buildManifest = getSignatureManifest(
+		{excludedTasks: []}, "t", project, taskRepository);
+	const serveManifest = getSignatureManifest(
+		{excludedTasks: ["generateVersionInfo"]}, "t", project, taskRepository);
+
+	t.notDeepEqual(buildManifest.buildConfig, serveManifest.buildConfig);
+});


### PR DESCRIPTION
> [!WARNING]
> Draft status. This is just a quick solution to diagnose build cache misses. We need to check how a solid solution would look like, especially with regards to performance and cache data overhead.

The build signature is an opaque SHA-256 of its named inputs (build config, project config, tool versions, task signatures). When two builds of the same project produce different signatures, the hash alone cannot reveal which input diverged, so a cache miss is unexplained.

Persist a structured, diffable manifest of the named signature inputs alongside each build signature. On a cache miss, diff the current manifest against the closest stored one and report the exact differing leaf path (e.g. projectConfig.server.customMiddleware[1].configuration. prependPath). In Force mode the reason is appended to the thrown error; otherwise it is logged at verbose level. Degrades gracefully when no prior manifest exists (old cache DBs, first build).

Adds a signature_manifest table to the build cache storage; additive, so no CACHE_VERSION bump is required.
