### PR TITLE
refactor(server): Rename middleware resource parameters

### DIFF
--- a/internal/documentation/docs/pages/Server.md
+++ b/internal/documentation/docs/pages/Server.md
@@ -71,8 +71,8 @@ A project can also add custom middleware to the server by using the [Custom Serv
 | `cors` | Standard [Express cors middleware](http://expressjs.com/en/resources/middleware/cors.html) |
 | `liveReloadClient` | See chapter [liveReload](#livereload) |
 | `discovery` |  See chapter [discovery](#discovery) |
-| `serveResources` | See chapter [serveResources](#serveresources) |
 | `versionInfo` | See chapter [versionInfo](#versioninfo)  |
+| `serveResources` | See chapter [serveResources](#serveresources) |
 | `nonReadRequests` | See chapter [nonReadRequests](#nonreadrequests)  |
 | `serveIndex` | See chapter [serveIndex](#serveindex)  |
 
@@ -125,6 +125,9 @@ To prevent intermediate proxies from idle-closing the WebSocket, the client send
 
 When the WebSocket connection is lost (e.g. because the server was restarted), the client polls the WebSocket endpoint every second and reloads the page once the server accepts connections again. While the browser tab is hidden, polling pauses until it becomes visible again.
 
+### versionInfo
+Generates and serves the version info file `/resources/sap-ui-version.json`, which is required for several framework functionalities.
+
 ### serveResources
 This middleware resolves requests using the [ui5-fs](https://github.com/SAP/ui5-fs)-file system abstraction.
 
@@ -132,9 +135,6 @@ The following file content transformations are executed:
 
 - Escaping non-ASCII characters in `.properties` translation files based on a project's [configuration](./Configuration.md#encoding-of-properties-files)
 - Enhancing the `manifest.json` with supported locales determined by available `.properties` [translation files](./Builder.md#generation-of-supported-locales)
-
-### versionInfo
-Generates and serves the version info file `/resources/sap-ui-version.json`, which is required for several framework functionalities.
 
 ### nonReadRequests
 Answers all non-read requests (POST, PUT, DELETE, etc.) that have not been answered by any other middleware with the 404 "Not Found" status code . This signals the client that these operations are not supported by the server.

--- a/internal/documentation/docs/pages/extensibility/CustomServerMiddleware.md
+++ b/internal/documentation/docs/pages/extensibility/CustomServerMiddleware.md
@@ -118,6 +118,15 @@ A custom middleware implementation needs to return a function with the following
  *      Reader to access resources of the root project
  * @param {module:@ui5/fs.AbstractReader} parameters.resources.dependencies
  *      Reader to access resources of the project's dependencies.
+ * @param {object} parameters.builtResources Readers for accessing the build output.
+ *      This parameter is only provided to custom middleware extensions
+ *      defining Specification Version 5.0 and later
+ * @param {module:@ui5/fs.AbstractReader} parameters.builtResources.all
+ *      Reader to access the build output of the root project and its dependencies
+ * @param {module:@ui5/fs.AbstractReader} parameters.builtResources.rootProject
+ *      Reader to access the build output of the root project
+ * @param {module:@ui5/fs.AbstractReader} parameters.builtResources.dependencies
+ *      Reader to access the build output of the project's dependencies.
  * @returns {function} Middleware function to use
  */
 export default function({log, middlewareUtil, options, resources}) {
@@ -154,6 +163,15 @@ export default function({log, middlewareUtil, options, resources}) {
  *      Reader to access resources of the root project
  * @param {module:@ui5/fs.AbstractReader} parameters.resources.dependencies
  *      Reader to access resources of the project's dependencies.
+ * @param {object} parameters.builtResources Readers for accessing the build output.
+ *      This parameter is only provided to custom middleware extensions
+ *      defining Specification Version 5.0 and later
+ * @param {module:@ui5/fs.AbstractReader} parameters.builtResources.all
+ *      Reader to access the build output of the root project and its dependencies
+ * @param {module:@ui5/fs.AbstractReader} parameters.builtResources.rootProject
+ *      Reader to access the build output of the root project
+ * @param {module:@ui5/fs.AbstractReader} parameters.builtResources.dependencies
+ *      Reader to access the build output of the project's dependencies.
  * @returns {function} Middleware function to use
  */
 module.exports = function({log, middlewareUtil, options, resources}) {

--- a/internal/documentation/docs/updates/migrate-v5.md
+++ b/internal/documentation/docs/updates/migrate-v5.md
@@ -365,6 +365,10 @@ To see which standard tasks are executed for each project type, check out the [S
 When running `ui5 serve`, [`generateVersionInfo`](../api/module-@ui5_builder_tasks_generateVersionInfo) continues to 
 not run by default. The [`versionInfo`](../pages/Server.md#versioninfo) middleware creates an identical `sap-ui-version.json` output file.
 
+::: info versionInfo middleware order
+The [`versionInfo`](../pages/Server.md#versioninfo) middleware now runs before [`serveResources`](../pages/Server.md#serveresources) rather than after it. Both match a request for `/resources/sap-ui-version.json`, but only `versionInfo` produces that file. Serving it first terminates the request directly and avoids `serveResources` triggering an unnecessary build of all dependencies while trying to locate the missing resource.
+:::
+
 ## Learn More
 
 - [Project: Type `component`](../pages/Project#component)

--- a/packages/server/lib/middleware/MiddlewareManager.js
+++ b/packages/server/lib/middleware/MiddlewareManager.js
@@ -22,16 +22,15 @@ const log = getLogger("server:MiddlewareManager");
  * @alias @ui5/server/internal/MiddlewareManager
  */
 class MiddlewareManager {
-	constructor({graph, rootProject, sources, resources, buildReader, options = {}}) {
-		if (!graph || !rootProject || !resources || !resources.all ||
-			!resources.rootProject || !resources.dependencies) {
+	constructor({graph, rootProject, resources, builtResources, options = {}}) {
+		if (!graph || !rootProject || !builtResources || !builtResources.all ||
+			!builtResources.rootProject || !builtResources.dependencies) {
 			throw new Error("[MiddlewareManager]: One or more mandatory parameters not provided");
 		}
 		this.graph = graph;
 		this.rootProject = rootProject;
-		this.sources = sources;
 		this.resources = resources;
-		this.buildReader = buildReader;
+		this.builtResources = builtResources;
 		this.options = {
 			sendSAPTargetCSP: false,
 			serveCSPReports: false,
@@ -151,6 +150,7 @@ class MiddlewareManager {
 		this.middleware[middlewareName] = {
 			middleware: await Promise.resolve(middlewareCallback({
 				resources: this.resources,
+				builtResources: this.builtResources,
 				middlewareUtil: this.middlewareUtil
 			})),
 			mountPath
@@ -271,8 +271,8 @@ class MiddlewareManager {
 		});
 		await this.addMiddleware("serveResources", {
 			wrapperCallback: ({middleware}) => {
-				return ({resources, middlewareUtil}) => middleware({
-					resources,
+				return ({builtResources, middlewareUtil}) => middleware({
+					builtResources,
 					middlewareUtil,
 					injectLiveReloadClient: this.options.liveReload.active
 				});
@@ -288,8 +288,8 @@ class MiddlewareManager {
 		await this.addMiddleware("nonReadRequests");
 		await this.addMiddleware("serveIndex", {
 			wrapperCallback: ({middleware}) => {
-				return ({resources, middlewareUtil}) => middleware({
-					resources,
+				return ({builtResources, middlewareUtil}) => middleware({
+					builtResources,
 					middlewareUtil,
 					simpleIndex: this.options.simpleIndex
 				});
@@ -345,7 +345,7 @@ class MiddlewareManager {
 			}
 
 			await this.addMiddleware(middlewareName, {
-				customMiddleware: async ({resources, middlewareUtil}) => {
+				customMiddleware: async ({resources, builtResources, middlewareUtil}) => {
 					const params = {
 						resources,
 						options: {
@@ -357,6 +357,9 @@ class MiddlewareManager {
 					if (specVersion.gte("3.0")) {
 						params.options.middlewareName = middlewareName;
 						params.log = getLogger(`server:custom-middleware:${middlewareDef.name}`);
+					}
+					if (specVersion.gte("5.0")) {
+						params.builtResources = builtResources;
 					}
 					const middlewareUtilInterface = middlewareUtil.getInterface(specVersion);
 					if (middlewareUtilInterface) {

--- a/packages/server/lib/middleware/MiddlewareManager.js
+++ b/packages/server/lib/middleware/MiddlewareManager.js
@@ -269,6 +269,9 @@ class MiddlewareManager {
 					getDegradedError: this.options.getDegradedError
 				})
 		});
+		await this.addMiddleware("versionInfo", {
+			mountPath: "/resources/sap-ui-version.json"
+		});
 		await this.addMiddleware("serveResources", {
 			wrapperCallback: ({middleware}) => {
 				return ({builtResources, middlewareUtil}) => middleware({
@@ -280,9 +283,6 @@ class MiddlewareManager {
 		});
 		this.#addLegacyMiddlewarePlaceholder("testRunner");
 		this.#addLegacyMiddlewarePlaceholder("serveThemes");
-		await this.addMiddleware("versionInfo", {
-			mountPath: "/resources/sap-ui-version.json"
-		});
 		// Handle anything but read operations *before* the serveIndex middleware
 		//	as it will reject them with a 405 (Method not allowed) instead of 404 like our old tooling
 		await this.addMiddleware("nonReadRequests");

--- a/packages/server/lib/middleware/discovery.js
+++ b/packages/server/lib/middleware/discovery.js
@@ -14,7 +14,8 @@ const urlPattern = /\/(app_pages|all_libs|all_tests)(?:[?#].*)?$/;
  *
  * @module @ui5/server/middleware/discovery
  * @param {object} parameters Parameters
- * @param {@ui5/server/internal/MiddlewareManager.middlewareResources} parameters.resources Parameters
+ * @param {@ui5/server/internal/MiddlewareManager.middlewareResources} parameters.resources Readers for
+ *   accessing the sources of the root project and its dependencies
  * @returns {Function} Returns a server middleware closure.
  */
 function createMiddleware({resources}) {

--- a/packages/server/lib/middleware/serveIndex.js
+++ b/packages/server/lib/middleware/serveIndex.js
@@ -86,20 +86,21 @@ function createResourceInfos(resources) {
  *
  * @module @ui5/server/middleware/serveIndex
  * @param {object} parameters Parameters
- * @param {object} parameters.resources Contains the resource reader or collection to access project related files
- * @param {@ui5/fs/AbstractReader} parameters.resources.all Resource collection which contains the workspace
+ * @param {object} parameters.builtResources Contains the resource reader or collection to access
+ * the incremental build output
+ * @param {@ui5/fs/AbstractReader} parameters.builtResources.all Resource collection which contains the workspace
  * and the project dependencies
  * @param {boolean} [parameters.simpleIndex=false] Use a simplified view for the server directory listing
  * @param {boolean} [parameters.showHidden=true] Show hidden files in the server directory listing
  * @returns {Function} Returns a server middleware closure.
  */
 
-function createMiddleware({resources, middlewareUtil, simpleIndex = false, showHidden = true}) {
+function createMiddleware({builtResources, middlewareUtil, simpleIndex = false, showHidden = true}) {
 	return function(req, res, next) {
 		const pathname = middlewareUtil.getPathname(req);
 		log.verbose("\n Listing index of " + pathname);
 		const glob = pathname + (pathname.endsWith("/") ? "*" : "/*");
-		resources.all.byGlob(glob, {nodir: false}).then((resources) => {
+		builtResources.all.byGlob(glob, {nodir: false}).then((resources) => {
 			if (!resources || resources.length === 0) { // Not found
 				next();
 				return;

--- a/packages/server/lib/middleware/serveResources.js
+++ b/packages/server/lib/middleware/serveResources.js
@@ -8,17 +8,18 @@ import isFresh from "./helper/isFresh.js";
  *
  * @module @ui5/server/middleware/serveResources
  * @param {object} parameters Parameters
- * @param {@ui5/server/internal/MiddlewareManager.middlewareResources} parameters.resources Parameters
+ * @param {@ui5/server/internal/MiddlewareManager.middlewareResources} parameters.builtResources Readers for
+ *   accessing the incremental build output of the root project and its dependencies
  * @param {object} parameters.middlewareUtil [MiddlewareUtil]{@link @ui5/server/middleware/MiddlewareUtil} instance
  * @param {boolean} [parameters.injectLiveReloadClient=false] Whether to inject the live reload client into HTML
  *   responses
  * @returns {Function} Returns a server middleware closure.
  */
-function createMiddleware({resources, middlewareUtil, injectLiveReloadClient = false}) {
+function createMiddleware({builtResources, middlewareUtil, injectLiveReloadClient = false}) {
 	return async function serveResources(req, res, next) {
 		try {
 			const pathname = middlewareUtil.getPathname(req);
-			const resource = await resources.all.byPath(pathname);
+			const resource = await builtResources.all.byPath(pathname);
 			if (!resource) {
 				// Not found
 				next();

--- a/packages/server/lib/middleware/versionInfo.js
+++ b/packages/server/lib/middleware/versionInfo.js
@@ -8,7 +8,8 @@ const MANIFEST_JSON = "manifest.json";
  *
  * @module @ui5/server/middleware/versionInfo
  * @param {object} parameters Parameters
- * @param {@ui5/server/internal/MiddlewareManager.middlewareResources} parameters.resources Parameters
+ * @param {@ui5/server/internal/MiddlewareManager.middlewareResources} parameters.resources Readers for
+ *   accessing the sources of the root project and its dependencies
  * @param {object} parameters.middlewareUtil [MiddlewareUtil]{@link @ui5/server/middleware/MiddlewareUtil} instance
  * @returns {Function} Returns a server middleware closure.
  */

--- a/packages/server/lib/serve/stack.js
+++ b/packages/server/lib/serve/stack.js
@@ -60,7 +60,7 @@ export async function buildRouter(graph, config, error, getDegradedError) {
 		name: "Server: Reader for sources of all projects",
 		readers: [rootReader, dependencies]
 	});
-	const sources = {
+	const resources = {
 		rootProject: rootReader,
 		dependencies: dependencies,
 		all: combo
@@ -93,7 +93,7 @@ export async function buildRouter(graph, config, error, getDegradedError) {
 	// build-cache handle. If middleware assembly below throws, the caller gets neither the
 	// buildServer nor a close() handle, so destroy it here before rethrowing.
 	try {
-		const resources = {
+		const builtResources = {
 			rootProject: buildServer.getRootReader(),
 			dependencies: buildServer.getDependenciesReader(),
 			all: buildServer.getReader(),
@@ -118,8 +118,8 @@ export async function buildRouter(graph, config, error, getDegradedError) {
 		const middlewareManager = new MiddlewareManager({
 			graph,
 			rootProject,
-			sources,
 			resources,
+			builtResources,
 			options: {
 				sendSAPTargetCSP,
 				serveCSPReports,

--- a/packages/server/test/lib/server/main.js
+++ b/packages/server/test/lib/server/main.js
@@ -211,39 +211,18 @@ test("Get sap-ui-version.json from versionInfo middleware (/resources/sap-ui-ver
 		"libraries": [
 			{
 				name: "library.a",
-				manifestHints: {
-					dependencies: {
-						libs: {
-							"library.d": {}
-						}
-					}
-				},
 				version: "1.0.0",
 				buildTimestamp,
 				scmRevision: ""
 			},
 			{
 				name: "library.b",
-				manifestHints: {
-					dependencies: {
-						libs: {
-							"library.d": {}
-						}
-					}
-				},
 				version: "1.0.0",
 				buildTimestamp,
 				scmRevision: ""
 			},
 			{
 				name: "library.c",
-				manifestHints: {
-					dependencies: {
-						libs: {
-							"library.d": {}
-						}
-					}
-				},
 				version: "1.0.0",
 				buildTimestamp,
 				scmRevision: ""

--- a/packages/server/test/lib/server/main.js
+++ b/packages/server/test/lib/server/main.js
@@ -213,19 +213,40 @@ test("Get sap-ui-version.json from versionInfo middleware (/resources/sap-ui-ver
 				name: "library.a",
 				version: "1.0.0",
 				buildTimestamp,
-				scmRevision: ""
+				scmRevision: "",
+				manifestHints: {
+					dependencies: {
+						libs: {
+							"library.d": {}
+						}
+					}
+				}
 			},
 			{
 				name: "library.b",
 				version: "1.0.0",
 				buildTimestamp,
-				scmRevision: ""
+				scmRevision: "",
+				manifestHints: {
+					dependencies: {
+						libs: {
+							"library.d": {}
+						}
+					}
+				}
 			},
 			{
 				name: "library.c",
 				version: "1.0.0",
 				buildTimestamp,
-				scmRevision: ""
+				scmRevision: "",
+				manifestHints: {
+					dependencies: {
+						libs: {
+							"library.d": {}
+						}
+					}
+				}
 			},
 			{
 				name: "library.d",

--- a/packages/server/test/lib/server/middleware/MiddlewareManager.js
+++ b/packages/server/test/lib/server/middleware/MiddlewareManager.js
@@ -743,14 +743,14 @@ test("addStandardMiddleware: Adds standard middleware in correct order", async (
 		"liveReloadClient",
 		"discovery",
 		"serveBuildError",
-		"serveResources",
 		"versionInfo",
+		"serveResources",
 		"nonReadRequests",
 		"serveIndex"
 	], "Correct order of standard middlewares");
 
 	// Legacy placeholders for removed standard middlewares are inserted directly into the
-	// execution order (not via addMiddleware) between serveResources and versionInfo so that
+	// execution order (not via addMiddleware) between serveResources and nonReadRequests so that
 	// custom middlewares referencing them keep their original slot.
 	t.deepEqual(middlewareManager.middlewareExecutionOrder, [
 		"csp",
@@ -759,13 +759,13 @@ test("addStandardMiddleware: Adds standard middleware in correct order", async (
 		"liveReloadClient",
 		"discovery",
 		"serveBuildError",
+		"versionInfo",
 		"serveResources",
 		"testRunner",
 		"serveThemes",
-		"versionInfo",
 		"nonReadRequests",
 		"serveIndex"
-	], "Legacy placeholders are inserted between serveResources and versionInfo");
+	], "Legacy placeholders are inserted between serveResources and nonReadRequests");
 });
 
 test("addCustomMiddleware: No custom middleware defined", async (t) => {

--- a/packages/server/test/lib/server/middleware/MiddlewareManager.js
+++ b/packages/server/test/lib/server/middleware/MiddlewareManager.js
@@ -25,8 +25,8 @@ test("Missing parameters", (t) => {
 		new MiddlewareManager({
 			graph: {},
 			rootProject: "root project",
-			sources: "sources",
-			resources: {}
+			resources: "sources",
+			builtResources: {}
 		});
 	});
 	t.is(err.message, "[MiddlewareManager]: One or more mandatory parameters not provided",
@@ -38,8 +38,8 @@ test("Correct parameters", (t) => {
 		new MiddlewareManager({
 			graph: {},
 			rootProject: "root project",
-			sources: "sources",
-			resources: {
+			resources: "sources",
+			builtResources: {
 				all: "I",
 				rootProject: "like",
 				dependencies: "ponies"
@@ -52,8 +52,8 @@ test("liveReload option defaults to inactive when no options are passed", (t) =>
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -67,8 +67,8 @@ test("All option defaults are applied when no options are passed", (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -86,8 +86,8 @@ test("liveReload option defaults to inactive when options are passed without liv
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -109,8 +109,8 @@ test("liveReload option is used as passed", (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -127,8 +127,8 @@ test("liveReload option defaults are applied when an empty liveReload object is 
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -145,8 +145,8 @@ test("liveReload option: individual properties are defaulted when partially prov
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -164,8 +164,8 @@ test("applyMiddleware", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "love",
 			dependencies: "ponies"
@@ -197,8 +197,8 @@ test("addMiddleware: Adding already added middleware", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -219,8 +219,8 @@ test("addMiddleware: Adding middleware already added to middlewareExecutionOrder
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -241,8 +241,8 @@ test("addMiddleware: Add middleware", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -266,8 +266,8 @@ test("addMiddleware: Add middleware with beforeMiddleware and mountPath paramete
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -299,8 +299,8 @@ test("addMiddleware: Add middleware with beforeMiddleware=connectUi5Proxy", asyn
 	const middlewareManager = new StubbedMiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -331,7 +331,7 @@ test("addMiddleware: Add middleware with afterMiddleware referencing removed mid
 	const middlewareManager = new StubbedMiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		resources: {
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -369,7 +369,7 @@ test("addMiddleware: Add middleware with beforeMiddleware referencing removed mi
 	const middlewareManager = new StubbedMiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		resources: {
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -406,7 +406,7 @@ test("addMiddleware: Multiple custom middlewares referencing removed middleware"
 	const middlewareManager = new StubbedMiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		resources: {
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -447,7 +447,7 @@ test("addMiddleware: Add middleware with afterMiddleware referencing removed tes
 	const middlewareManager = new StubbedMiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		resources: {
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -485,7 +485,7 @@ test("addMiddleware: Add middleware with beforeMiddleware referencing removed te
 	const middlewareManager = new StubbedMiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		resources: {
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -522,7 +522,7 @@ test("addMiddleware: Order between customs referencing different removed middlew
 	const middlewareManager = new StubbedMiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		resources: {
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -564,7 +564,7 @@ test("applyMiddleware: Legacy placeholders are not mounted on the app", async (t
 			})
 		},
 		rootProject: "root project",
-		resources: {
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -596,8 +596,8 @@ test("addMiddleware: Add middleware with afterMiddleware parameter", async (t) =
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -624,8 +624,8 @@ test("addMiddleware: Add middleware with invalid afterMiddleware parameter", asy
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -651,8 +651,8 @@ test("addMiddleware: Add middleware with wrapperCallback parameter", async (t) =
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -669,7 +669,9 @@ test("addMiddleware: Add middleware with wrapperCallback parameter", async (t) =
 	t.deepEqual(wrapperCallbackStub.getCall(0).args[0], serveIndexMiddlewareInfo,
 		"Wrapper callback got called with correct module");
 	t.is(moduleStub.callCount, 1, "Wrapper callback got called once");
-	t.deepEqual(moduleStub.getCall(0).args[0].resources, {
+	t.is(moduleStub.getCall(0).args[0].resources, "sources",
+		"Wrapper callback got called with the source readers as resources");
+	t.deepEqual(moduleStub.getCall(0).args[0].builtResources, {
 		all: "I",
 		rootProject: "like",
 		dependencies: "ponies"
@@ -691,8 +693,8 @@ test("addMiddleware: Add middleware with async wrapperCallback", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -714,8 +716,8 @@ test("addStandardMiddleware: Adds standard middleware in correct order", async (
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -780,8 +782,8 @@ test("addCustomMiddleware: No custom middleware defined", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph,
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -811,8 +813,8 @@ test("addCustomMiddleware: Unknown custom middleware", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph,
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -850,8 +852,8 @@ test("addCustomMiddleware: Custom middleware got added", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph,
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -905,8 +907,8 @@ test("addCustomMiddleware: Custom middleware with duplicate name", async (t) => 
 	const middlewareManager = new MiddlewareManager({
 		graph,
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -942,8 +944,8 @@ test("addCustomMiddleware: Missing name configuration", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph,
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -975,8 +977,8 @@ test("addCustomMiddleware: Both before- and afterMiddleware configuration", asyn
 	const middlewareManager = new MiddlewareManager({
 		graph,
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -1007,8 +1009,8 @@ test("addCustomMiddleware: Missing before- or afterMiddleware configuration", as
 	const middlewareManager = new MiddlewareManager({
 		graph,
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -1054,8 +1056,8 @@ test("addCustomMiddleware", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph,
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -1072,12 +1074,15 @@ test("addCustomMiddleware", async (t) => {
 	};
 	const res = await customMiddleware({
 		resources: "resources",
+		builtResources: "builtResources",
 		middlewareUtil
 	});
 
 	t.is(res, "ok", "Wrapper callback returned expected value");
-	t.is(specVersionGteStub.callCount, 1, "SpecificationVersion#gte got called once");
+	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
 	t.is(specVersionGteStub.getCall(0).args[0], "3.0",
+		"SpecificationVersion#gte got called with correct arguments");
+	t.is(specVersionGteStub.getCall(1).args[0], "5.0",
 		"SpecificationVersion#gte got called with correct arguments");
 	t.is(middlewareUtil.getInterface.callCount, 1, "middlewareUtil.getInterface got called once");
 	t.is(middlewareUtil.getInterface.getCall(0).args[0], mockSpecificationVersion,
@@ -1093,6 +1098,8 @@ test("addCustomMiddleware", async (t) => {
 		},
 		middlewareUtil: "interfacedMiddlewareUtil"
 	}, "Middleware module got called with correct arguments");
+	t.false("builtResources" in params,
+		"builtResources is not provided to custom middleware below specVersion 5.0");
 	t.not(params.options.configuration, middlewareConfiguration,
 		"Configuration is a clone and not a reference to the project configuration");
 });
@@ -1100,7 +1107,7 @@ test("addCustomMiddleware", async (t) => {
 test("addCustomMiddleware with specVersion 3.0", async (t) => {
 	const {sinon, MiddlewareManager} = t.context;
 	const middlewareModuleStub = sinon.stub().returns("ok");
-	const specVersionGteStub = sinon.stub().returns(true);
+	const specVersionGteStub = sinon.stub().callsFake((version) => version === "3.0");
 	const mockSpecificationVersion = {
 		toString: () => "3.0",
 		gte: specVersionGteStub
@@ -1127,8 +1134,8 @@ test("addCustomMiddleware with specVersion 3.0", async (t) => {
 	const middlewareManager = new MiddlewareManager({
 		graph,
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -1148,18 +1155,22 @@ test("addCustomMiddleware with specVersion 3.0", async (t) => {
 	};
 	const res = await customMiddleware({
 		resources: "resources",
+		builtResources: "builtResources",
 		middlewareUtil
 	});
 
 	t.is(res, "ok", "Wrapper callback returned expected value");
-	t.is(specVersionGteStub.callCount, 1, "SpecificationVersion#gte got called once");
+	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
 	t.is(specVersionGteStub.getCall(0).args[0], "3.0",
+		"SpecificationVersion#gte got called with correct arguments");
+	t.is(specVersionGteStub.getCall(1).args[0], "5.0",
 		"SpecificationVersion#gte got called with correct arguments");
 	t.is(middlewareUtil.getInterface.callCount, 1, "middlewareUtil.getInterface got called once");
 	t.is(middlewareUtil.getInterface.getCall(0).args[0], mockSpecificationVersion,
 		"middlewareUtil.getInterface got called with correct arguments");
 	t.is(middlewareModuleStub.callCount, 1, "Middleware module got called once");
-	t.deepEqual(middlewareModuleStub.getCall(0).args[0], {
+	const params = middlewareModuleStub.getCall(0).args[0];
+	t.deepEqual(params, {
 		resources: "resources",
 		options: {
 			configuration: {
@@ -1170,6 +1181,79 @@ test("addCustomMiddleware with specVersion 3.0", async (t) => {
 		middlewareUtil: "interfacedMiddlewareUtil",
 		log: "group logger"
 	}, "Middleware module got called with correct arguments");
+	t.false("builtResources" in params,
+		"builtResources is not provided to custom middleware below specVersion 5.0");
+});
+
+test("addCustomMiddleware with specVersion 5.0", async (t) => {
+	const {sinon, MiddlewareManager} = t.context;
+	const middlewareModuleStub = sinon.stub().returns("ok");
+	const specVersionGteStub = sinon.stub().returns(true);
+	const mockSpecificationVersion = {
+		toString: () => "5.0",
+		gte: specVersionGteStub
+	};
+	const getExtensionStub = sinon.stub().returns({
+		getSpecVersion: () => mockSpecificationVersion,
+		getMiddleware: () => middlewareModuleStub
+	});
+	const graph = {
+		getRoot: () => {
+			return {
+				getName: () => "my project",
+				getCustomMiddleware: () => [{
+					name: "my custom middleware",
+					beforeMiddleware: "cors",
+					configuration: {
+						"🦊": "🐰"
+					}
+				}]
+			};
+		},
+		getExtension: getExtensionStub
+	};
+	const middlewareManager = new MiddlewareManager({
+		graph,
+		rootProject: "root project",
+		resources: "sources",
+		builtResources: {
+			all: "I",
+			rootProject: "like",
+			dependencies: "ponies"
+		}
+	});
+	const addMiddlewareStub = sinon.stub(middlewareManager, "addMiddleware").resolves();
+	await middlewareManager.addCustomMiddleware();
+
+	t.is(addMiddlewareStub.callCount, 1, "addMiddleware was called once");
+
+	const customMiddleware = addMiddlewareStub.getCall(0).args[1].customMiddleware;
+	const middlewareUtil = {
+		getInterface: sinon.stub().returns("interfacedMiddlewareUtil")
+	};
+	const res = await customMiddleware({
+		resources: "resources",
+		builtResources: "builtResources",
+		middlewareUtil
+	});
+
+	t.is(res, "ok", "Wrapper callback returned expected value");
+	t.is(specVersionGteStub.getCall(1).args[0], "5.0",
+		"SpecificationVersion#gte got called with correct arguments");
+	t.is(middlewareModuleStub.callCount, 1, "Middleware module got called once");
+	const params = middlewareModuleStub.getCall(0).args[0];
+	t.deepEqual(params, {
+		resources: "resources",
+		options: {
+			configuration: {
+				"🦊": "🐰"
+			},
+			middlewareName: "my custom middleware"
+		},
+		middlewareUtil: "interfacedMiddlewareUtil",
+		log: "group logger",
+		builtResources: "builtResources"
+	}, "Middleware module got called with correct arguments including builtResources");
 });
 
 test("addStandardMiddleware: CSP middleware configured correctly (default)", async (t) => {
@@ -1177,8 +1261,8 @@ test("addStandardMiddleware: CSP middleware configured correctly (default)", asy
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -1226,8 +1310,8 @@ test("addStandardMiddleware: CSP middleware configured correctly (enabled)", asy
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -1287,8 +1371,8 @@ test("addStandardMiddleware: CSP middleware configured correctly (custom)", asyn
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -1353,8 +1437,8 @@ test("addStandardMiddleware: liveReloadClient middleware configured correctly (d
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -1382,8 +1466,8 @@ test("addStandardMiddleware: liveReloadClient middleware configured correctly (e
 	const middlewareManager = new MiddlewareManager({
 		graph: {},
 		rootProject: "root project",
-		sources: "sources",
-		resources: {
+		resources: "sources",
+		builtResources: {
 			all: "I",
 			rootProject: "like",
 			dependencies: "ponies"
@@ -1415,8 +1499,8 @@ test("addStandardMiddleware: liveReloadClient middleware configured correctly (e
 		const middlewareManager = new MiddlewareManager({
 			graph: {},
 			rootProject: "root project",
-			sources: "sources",
-			resources: {
+			resources: "sources",
+			builtResources: {
 				all: "I",
 				rootProject: "like",
 				dependencies: "ponies"
@@ -1447,8 +1531,8 @@ test("addStandardMiddleware: serveResources middleware injectLiveReloadClient re
 		const middlewareManager = new MiddlewareManager({
 			graph: {},
 			rootProject: "root project",
-			sources: "sources",
-			resources: {
+			resources: "sources",
+			builtResources: {
 				all: "I",
 				rootProject: "like",
 				dependencies: "ponies"
@@ -1462,7 +1546,7 @@ test("addStandardMiddleware: serveResources middleware injectLiveReloadClient re
 
 		const middlewareModuleStub = sinon.stub().returns("ok");
 		const middlewareWrapper = serveResourcesCall.args[1].wrapperCallback({middleware: middlewareModuleStub});
-		middlewareWrapper({resources: "resources", middlewareUtil: "util"});
+		middlewareWrapper({builtResources: "builtResources", middlewareUtil: "util"});
 		t.is(middlewareModuleStub.getCall(0).args[0].injectLiveReloadClient, false,
 			"injectLiveReloadClient defaults to false");
 	});
@@ -1473,8 +1557,8 @@ test("addStandardMiddleware: serveResources middleware injectLiveReloadClient re
 		const middlewareManager = new MiddlewareManager({
 			graph: {},
 			rootProject: "root project",
-			sources: "sources",
-			resources: {
+			resources: "sources",
+			builtResources: {
 				all: "I",
 				rootProject: "like",
 				dependencies: "ponies"
@@ -1491,7 +1575,7 @@ test("addStandardMiddleware: serveResources middleware injectLiveReloadClient re
 
 		const middlewareModuleStub = sinon.stub().returns("ok");
 		const middlewareWrapper = serveResourcesCall.args[1].wrapperCallback({middleware: middlewareModuleStub});
-		middlewareWrapper({resources: "resources", middlewareUtil: "util"});
+		middlewareWrapper({builtResources: "builtResources", middlewareUtil: "util"});
 		t.is(middlewareModuleStub.getCall(0).args[0].injectLiveReloadClient, true,
 			"injectLiveReloadClient reflects active liveReload option");
 	});

--- a/packages/server/test/lib/server/middleware/serveIndex.js
+++ b/packages/server/test/lib/server/middleware/serveIndex.js
@@ -27,7 +27,7 @@ test.serial("serveIndex default", async (t) => {
 	]);
 	const middleware = serveIndexMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources: {
+		builtResources: {
 			all: readerWriter
 		}
 	});
@@ -93,7 +93,7 @@ test.serial("serveIndex no hidden", async (t) => {
 	]);
 	const middleware = serveIndexMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources: {
+		builtResources: {
 			all: readerWriter
 		},
 		simpleIndex: false,
@@ -148,7 +148,7 @@ test.serial("serveIndex error handling", async (t) => {
 	};
 	const middleware = serveIndexMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources: {
+		builtResources: {
 			all: readerStub
 		}
 	});
@@ -190,7 +190,7 @@ test.serial("serveIndex no details", async (t) => {
 	]);
 	const middleware = serveIndexMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources: {
+		builtResources: {
 			all: readerWriter
 		},
 		simpleIndex: true,

--- a/packages/server/test/lib/server/middleware/serveResources.js
+++ b/packages/server/test/lib/server/middleware/serveResources.js
@@ -34,10 +34,10 @@ test.serial("Serves resource with correct Content-Type and ETag", async (t) => {
 	const buffer = Buffer.from("hello world");
 	const resource = createMockResource({path: "/app/script.js", buffer, integrity: "sha256-xyz"});
 
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources
+		builtResources
 	});
 
 	const req = {url: "/app/script.js", headers: {}};
@@ -63,10 +63,10 @@ test.serial("Injects liveReload tag into HTML right after <head>", async (t) => 
 	const integrity = "sha256-xyz";
 	const resource = createMockResource({path: "/app/index.html", buffer, integrity});
 
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources,
+		builtResources,
 		injectLiveReloadClient: true
 	});
 
@@ -91,10 +91,10 @@ test.serial("Injects liveReload tag after <head> with attributes", async (t) => 
 	const buffer = Buffer.from(html);
 	const resource = createMockResource({path: "/index.html", buffer, integrity: "sha256-xyz"});
 
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources,
+		builtResources,
 		injectLiveReloadClient: true
 	});
 
@@ -113,10 +113,10 @@ test.serial("Injects liveReload tag after <html> when <head> is missing", async 
 	const buffer = Buffer.from(html);
 	const resource = createMockResource({path: "/page.html", buffer, integrity: "sha256-xyz"});
 
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources,
+		builtResources,
 		injectLiveReloadClient: true
 	});
 
@@ -135,10 +135,10 @@ test.serial("Prepends liveReload tag to HTML without <head> or <html>", async (t
 	const buffer = Buffer.from(html);
 	const resource = createMockResource({path: "/page.html", buffer, integrity: "sha256-xyz"});
 
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources,
+		builtResources,
 		injectLiveReloadClient: true
 	});
 
@@ -153,10 +153,10 @@ test.serial("Prepends liveReload tag to HTML without <head> or <html>", async (t
 });
 
 test.serial("Calls next() when resource is not found", async (t) => {
-	const resources = {all: {byPath: sinon.stub().resolves(null)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(null)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources
+		builtResources
 	});
 
 	const req = {url: "/not-found.js", headers: {}};
@@ -175,10 +175,10 @@ test.serial("Returns 304 Not Modified when client cache is fresh", async (t) => 
 	const etagValue = etag(integrity);
 	const resource = createMockResource({integrity});
 
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources
+		builtResources
 	});
 
 	const req = {url: "/foo.js", headers: {"if-none-match": etagValue}};
@@ -195,10 +195,10 @@ test.serial("Returns 304 Not Modified when client cache is fresh", async (t) => 
 
 test.serial("Passes errors to next()", async (t) => {
 	const error = new Error("read failure");
-	const resources = {all: {byPath: sinon.stub().rejects(error)}};
+	const builtResources = {all: {byPath: sinon.stub().rejects(error)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources
+		builtResources
 	});
 
 	const req = {url: "/foo.js", headers: {}};
@@ -213,10 +213,10 @@ test.serial("Passes errors to next()", async (t) => {
 
 test.serial("Does not override existing Content-Type header", async (t) => {
 	const resource = createMockResource({path: "/data.json"});
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources
+		builtResources
 	});
 
 	const req = {url: "/data.json", headers: {}};
@@ -233,10 +233,10 @@ test.serial("Does not override existing Content-Type header", async (t) => {
 test.serial("Uses resource integrity for ETag generation", async (t) => {
 	const integrity = "sha512-uniqueHash";
 	const resource = createMockResource({integrity});
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources
+		builtResources
 	});
 
 	const req = {url: "/foo.js", headers: {}};
@@ -256,10 +256,10 @@ test.serial("HTML: 304 when ETag matches injected ETag", async (t) => {
 	const html = "<html><body></body></html>";
 	const resource = createMockResource({path: "/index.html", buffer: Buffer.from(html), integrity});
 
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = serveResourcesMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources,
+		builtResources,
 		injectLiveReloadClient: true
 	});
 
@@ -284,10 +284,10 @@ test.serial("HTML: 200 when INJECT_SCRIPT_TAG changes invalidates client ETag", 
 	});
 
 	const resource = createMockResource({path: "/index.html", buffer: Buffer.from(html), integrity});
-	const resources = {all: {byPath: sinon.stub().resolves(resource)}};
+	const builtResources = {all: {byPath: sinon.stub().resolves(resource)}};
 	const middleware = mockedMiddleware({
 		middlewareUtil: new MiddlewareUtil({graph: "graph", project: "project"}),
-		resources,
+		builtResources,
 		injectLiveReloadClient: true
 	});
 


### PR DESCRIPTION
Rename the reader bundles passed to middleware so their names match what
they hold: the raw source readers become `resources` (restoring the v4
behavior, and the build output readers become `builtResources`.

Standard middleware receive both bundles. serveResources and serveIndex keep
serving the build output via `builtResources`; discovery and versionInfo read
the raw sources via `resources`. Custom middleware receive `builtResources`
only when they define Specification Version 5.0 or higher.

JIRA: CPOUI5FOUNDATION-1306
