### PR TITLE
fix: `git checkout` fs-event race during `ui5 serve`

### DIFF
--- a/packages/fs/lib/adapters/FileSystem.js
+++ b/packages/fs/lib/adapters/FileSystem.js
@@ -75,7 +75,13 @@ class FileSystem extends AbstractAdapter {
 			promises.push(new Promise((resolve, reject) => {
 				fs.stat(this._fsBasePath, (err, stat) => {
 					if (err) {
-						reject(err);
+						if (err.code === "ENOENT") {
+							// The base directory was removed concurrently (e.g. mid-'git checkout').
+							// Drop it from the results rather than failing the whole byGlob.
+							resolve(null);
+						} else {
+							reject(err);
+						}
 					} else {
 						resolve(this._createResource({
 							project: this._project,
@@ -119,7 +125,14 @@ class FileSystem extends AbstractAdapter {
 					// Workaround for not getting the stat from the glob
 					fs.stat(fsPath, (err, stat) => {
 						if (err) {
-							reject(err);
+							if (err.code === "ENOENT") {
+								// The file was removed between the glob walk and this stat (e.g. a
+								// concurrent 'git checkout' moving source paths). Drop it from the
+								// results rather than failing the whole byGlob, matching _byPath.
+								resolve(null);
+							} else {
+								reject(err);
+							}
 						} else {
 							resolve(this._createResource({
 								project: this._project,

--- a/packages/fs/test/lib/adapters/FileSystem_read.js
+++ b/packages/fs/test/lib/adapters/FileSystem_read.js
@@ -631,3 +631,76 @@ test("byGlob with a larger number of results", async (t) => {
 		"Resource should have correct path"
 	);
 });
+
+test("byGlob drops a match that vanished between glob and stat (ENOENT)", async (t) => {
+	// A file matched by the glob walk can be removed before the per-match stat runs, e.g. a
+	// concurrent 'git checkout' moving source paths. The stat then fails with ENOENT. byGlob must
+	// drop the vanished match rather than rejecting the whole call.
+	const globbyStub = sinon.stub().callsFake(async () => {
+		return ["/present.js", "/vanished.js"];
+	});
+
+	const fakeStat = {
+		isFile: () => true,
+		isDirectory: () => false
+	};
+
+	const FileSystem = await esmock("../../../lib/adapters/FileSystem.js", {
+		"globby": {
+			globby: globbyStub,
+			isGitIgnored: async () => false
+		},
+		"graceful-fs": {
+			stat: ((filePath, cb) => {
+				if (filePath.endsWith("vanished.js")) {
+					cb({code: "ENOENT"});
+				} else {
+					cb(null, fakeStat);
+				}
+			})
+		}
+	});
+
+	const fsBasePath = fileURLToPath(new URL("../../tmp/virtual/vanish-project/", import.meta.url));
+	const reader = new FileSystem({
+		fsBasePath,
+		virBasePath: "/"
+	});
+
+	const resources = await reader.byGlob("/**/*.js");
+
+	t.is(resources.length, 1, "Only the surviving match is returned");
+	t.is(resources[0].getPath(), "/present.js", "Surviving match has correct path");
+});
+
+test("byGlob rejects on a non-ENOENT stat error", async (t) => {
+	// Only a missing file is tolerated. Any other stat failure (e.g. EACCES) is a genuine error and
+	// must still propagate.
+	const globbyStub = sinon.stub().callsFake(async () => {
+		return ["/present.js"];
+	});
+
+	const FileSystem = await esmock("../../../lib/adapters/FileSystem.js", {
+		"globby": {
+			globby: globbyStub,
+			isGitIgnored: async () => false
+		},
+		"graceful-fs": {
+			stat: ((_filePath, cb) => {
+				const err = new Error("permission denied");
+				err.code = "EACCES";
+				cb(err);
+			})
+		}
+	});
+
+	const fsBasePath = fileURLToPath(new URL("../../tmp/virtual/eacces-project/", import.meta.url));
+	const reader = new FileSystem({
+		fsBasePath,
+		virBasePath: "/"
+	});
+
+	await t.throwsAsync(reader.byGlob("/**/*.js"), {
+		code: "EACCES"
+	}, "Non-ENOENT stat error propagates");
+});

--- a/packages/project/lib/build/BuildServer.js
+++ b/packages/project/lib/build/BuildServer.js
@@ -2,7 +2,7 @@ import EventEmitter from "node:events";
 import {createReaderCollectionPrioritized} from "@ui5/fs/resourceFactory";
 import BuildReader from "./BuildReader.js";
 import WatchHandler from "./helpers/WatchHandler.js";
-import {isAbortError} from "./helpers/abort.js";
+import {isAbortError, isFileNotFoundError} from "./helpers/abort.js";
 import {WATCHER_BURST_SETTLE_MS} from "./helpers/watchUtil.js";
 import RecoveryBudget, {WATCHER_RECOVERY_MAX_ATTEMPTS, WATCHER_RECOVERY_WINDOW_MS} from "./helpers/RecoveryBudget.js";
 import {getLogger} from "@ui5/logger";
@@ -883,7 +883,8 @@ class BuildServer extends EventEmitter {
 							this.#pendingBuildRequest.add(projectName);
 						}
 					}
-				} else if (signal.aborted || this.#resourceChangeQueue.size > 0) {
+				} else if (signal.aborted || this.#resourceChangeQueue.size > 0 ||
+						isFileNotFoundError(err)) {
 					// Task threw while sources were changing (e.g. mid-`git checkout`). The build
 					// state is untrustworthy, but the error itself is very likely spurious: a fresh
 					// build against the settled tree will typically succeed. Re-queue affected
@@ -891,6 +892,14 @@ class BuildServer extends EventEmitter {
 					// the retry, then route through the same defer-and-report path as an abort (see
 					// below): the doomed build must not park the server on `building`/`error`; it
 					// reports SETTLING and retries once the tree is quiet.
+					//
+					// The `signal.aborted || #resourceChangeQueue.size > 0` predicate catches the
+					// case where the watcher event has already landed. A file-not-found error
+					// (ENOENT) is treated as transient even before it does: during a checkout the
+					// file can be gone on disk before its delete event is delivered, so the queue is
+					// still empty at the catch site. The error nature identifies the race that the
+					// timing predicate misses; the deferred retry against the settled tree resolves
+					// it (see isFileNotFoundError).
 					log.warn(
 						`Build failed during concurrent source change — treating as transient: ${err.message}`);
 					transientFailure = true;

--- a/packages/project/lib/build/BuildServer.js
+++ b/packages/project/lib/build/BuildServer.js
@@ -1162,6 +1162,18 @@ class BuildServer extends EventEmitter {
 					log.verbose(`Background cache validation aborted: ${err?.message ?? err}`);
 					return;
 				}
+				if (signal.aborted || this.#resourceChangeQueue.size > 0 ||
+						isFileNotFoundError(err)) {
+					// Validation reads source files, so a `git checkout` moving paths under it can
+					// make a read fail with ENOENT (or land while a source change is queued). This
+					// mirrors the build classifier: the failure is a symptom of the tree moving, not a
+					// genuine cache fault. Leave the projects INITIAL (the finally clause releases any
+					// VALIDATING claim) so the next reader request re-validates or rebuilds against the
+					// settled tree, and do not surface a fatal error.
+					log.warn(`Background cache validation failed during concurrent source change, ` +
+						`treating as transient: ${err?.message ?? err}`);
+					return;
+				}
 				// Non-abort failure: mirror the build error path so consumers (the banner,
 				// integration tests, the yargs fail-handler) can react. The ERROR transition
 				// here doubles as the signal to the finally clause to skip its post-pass

--- a/packages/project/lib/build/helpers/abort.js
+++ b/packages/project/lib/build/helpers/abort.js
@@ -16,3 +16,25 @@ export function isAbortError(err, signal) {
 		err?.name === "SourceChangedDuringBuildError" ||
 		err?.name === "AbortError";
 }
+
+/**
+ * Whether a build error is a filesystem-not-found error, i.e. a source file that
+ * disappeared while the build was reading it. During a `git checkout` the watcher
+ * delivers its change events in coalesced batches, so a file can already be gone on
+ * disk before its delete event lands. A build that reads such a file then fails with
+ * ENOENT while `#resourceChangeQueue` is still empty and the signal is not yet aborted,
+ * which the timing-based classifier would otherwise treat as a genuine, gate-latching
+ * failure. The error nature says otherwise: the tree moved under the build and a retry
+ * against the settled tree resolves it, so it is transient regardless of timing.
+ *
+ * Scoped to `err.code === "ENOENT"`. A missing dependency the build reports through a
+ * message string (e.g. a less import that cannot be resolved) has no such code and may
+ * be a genuine authoring error, so it stays on the deterministic path.
+ *
+ * @param {Error} err
+ * @returns {boolean}
+ */
+export function isFileNotFoundError(err) {
+	return err?.code === "ENOENT";
+}
+

--- a/packages/project/test/lib/build/BuildServer.js
+++ b/packages/project/test/lib/build/BuildServer.js
@@ -948,6 +948,59 @@ test.serial(
 			`No stale report after a failed validation; got: ${seq.join(", ")}`);
 	});
 
+// A validation pass reads source files, so a `git checkout` moving paths under it can make a read
+// fail with ENOENT. That is the checkout race, not a genuine cache fault: it must be treated as
+// transient (no emitted "error", no serve-error), mirroring the build classifier. Regression guard
+// for the isFileNotFoundError branch in the validation catch, the path that otherwise crashed the
+// server process via the yargs fail-handler.
+test.serial(
+	"serve-status: ENOENT during validation is transient, no serve-error", async (t) => {
+		const {BuildServer, sinon, clock} = t.context;
+
+		const rootProject = {getName: () => "root.project"};
+		const libProject = {getName: () => "library.x"};
+		const graph = {
+			getRoot: () => rootProject,
+			getProjects: () => [rootProject, libProject],
+			getTransitiveDependencies: () => ["library.x"],
+			getProject: (name) => name === "root.project" ? rootProject : libProject,
+			traverseDependents: function* () {
+				yield {project: rootProject};
+				yield {project: libProject};
+			},
+		};
+
+		const enoentError = new Error("ENOENT: no such file or directory, open '/gone.properties'");
+		enoentError.code = "ENOENT";
+		const projectBuilder = {
+			closeCacheManager: sinon.stub(),
+			resourcesChanged: sinon.stub(),
+			validateCaches: sinon.stub().rejects(enoentError),
+			build: sinon.stub().callsFake((_opts, perProjectCb) => {
+				perProjectCb("root.project", {getReader: () => ({fakeReader: true})});
+				return Promise.resolve(["root.project"]);
+			}),
+		};
+		const statusEvents = makeStatusRecorder(t);
+
+		const buildServer = await BuildServer.create(graph, projectBuilder, true, [], []);
+		t.teardown(() => buildServer.destroy());
+
+		const errorEvents = [];
+		buildServer.on("error", (err) => errorEvents.push(err));
+
+		await clock.tickAsync(10);
+		// The validation pass rejects; drain until it has released library.x back to a stale report.
+		await drainUntil(clock, statusEvents, (e) => e.status === "serve-stale");
+
+		t.is(errorEvents.length, 0, "ENOENT during validation emits no fatal error event");
+		const seq = statusEvents.map((e) => e.status);
+		t.false(seq.includes("serve-error"),
+			`ENOENT during validation must not surface serve-error; got: ${seq.join(", ")}`);
+		t.true(seq.includes("serve-validating"),
+			`validating emitted before the transient failure; got: ${seq.join(", ")}`);
+	});
+
 // A reader request issued while a project is in VALIDATING must NOT enqueue a build
 // of its own — that would fire #triggerRequestQueue's 10 ms timer, abort the running
 // validation pass, and flicker VALIDATING → BUILDING → VALIDATING for no reason.

--- a/packages/project/test/lib/build/BuildServer.js
+++ b/packages/project/test/lib/build/BuildServer.js
@@ -514,6 +514,53 @@ test.serial(
 	});
 
 test.serial(
+	"serve-status: ENOENT failure with no queued change is treated as transient, not error", async (t) => {
+		const {BuildServer, graph, projectBuilder, sinon, clock} = t.context;
+		const {ABORTED_BUILD_RESTART_SETTLE_MS, BUILD_REQUEST_DEBOUNCE_MS} =
+			BuildServer.__internals__;
+		const statusEvents = makeStatusRecorder(t);
+
+		// A source file vanished mid-`git checkout`: the build reads it and fails with ENOENT before
+		// the watcher's delete event lands, so #resourceChangeQueue is still empty and the signal is
+		// not aborted. The timing predicate alone would classify this as a genuine failure; the
+		// error's ENOENT code routes it through the transient path instead. Regression guard for the
+		// isFileNotFoundError branch.
+		const resolvers = [];
+		projectBuilder.build = sinon.stub().callsFake((_opts, cb) => new Promise((resolve, reject) => {
+			resolvers.push({resolve, reject, cb});
+		}));
+
+		const buildServer = await BuildServer.create(graph, projectBuilder, true, [], []);
+		t.context.buildServer = buildServer;
+		await clock.tickAsync(BUILD_REQUEST_DEBOUNCE_MS);
+		t.is(projectBuilder.build.callCount, 1, "initial build started");
+
+		// No _projectResourceChanged call: the queue stays empty, mirroring the pre-delete-event race.
+		const enoentError = new Error("ENOENT: no such file or directory, open '/gone.js'");
+		enoentError.code = "ENOENT";
+		resolvers[0].reject(enoentError);
+		await clock.tickAsync(0);
+
+		const midSeq = statusEvents.map((e) => e.status);
+		t.false(midSeq.includes("serve-error"),
+			`ENOENT failure must not surface serve-error; got: ${midSeq.join(", ")}`);
+		t.is(statusEvents[statusEvents.length - 1].status, "serve-settling",
+			`ENOENT failure reports settling; got: ${midSeq.join(", ")}`);
+		t.is(projectBuilder.build.callCount, 1, "retry held until the settle window elapses");
+
+		// Once quiet, a single rebuild fires and succeeds.
+		await clock.tickAsync(ABORTED_BUILD_RESTART_SETTLE_MS);
+		t.is(projectBuilder.build.callCount, 2, "single deferred rebuild after the tree settled");
+		resolvers[1].cb("root.project", {getReader: () => ({fakeReader: true})});
+		resolvers[1].resolve(["root.project"]);
+		await drainUntil(clock, statusEvents, (e) => e.status === "serve-ready");
+
+		const seq = statusEvents.map((e) => e.status);
+		t.false(seq.includes("serve-error"),
+			`No serve-error anywhere in the ENOENT cycle; got: ${seq.join(", ")}`);
+	});
+
+test.serial(
 	"serve-status: a pending build re-times to the first-build window on a source change", async (t) => {
 		const {BuildServer, graph, projectBuilder, rootProject, sinon, clock} = t.context;
 		const {FIRST_BUILD_SETTLE_MS, BUILD_REQUEST_DEBOUNCE_MS} = BuildServer.__internals__;

--- a/packages/project/test/lib/build/helpers/abort.js
+++ b/packages/project/test/lib/build/helpers/abort.js
@@ -1,0 +1,40 @@
+import test from "ava";
+import {isAbortError, isFileNotFoundError} from "../../../../lib/build/helpers/abort.js";
+
+test("isAbortError: recognizes abort error names", (t) => {
+	t.true(isAbortError({name: "AbortBuildError"}));
+	t.true(isAbortError({name: "SourceChangedDuringBuildError"}));
+	t.true(isAbortError({name: "AbortError"}));
+});
+
+test("isAbortError: an aborted signal classifies any error as abort", (t) => {
+	t.true(isAbortError(new Error("something else"), {aborted: true}));
+});
+
+test("isAbortError: a non-abort error with a non-aborted signal is not an abort", (t) => {
+	t.false(isAbortError(new Error("boom")));
+	t.false(isAbortError(new Error("boom"), {aborted: false}));
+});
+
+test("isFileNotFoundError: true only for ENOENT", (t) => {
+	const enoent = new Error("ENOENT: no such file or directory, open '/gone.js'");
+	enoent.code = "ENOENT";
+	t.true(isFileNotFoundError(enoent));
+});
+
+test("isFileNotFoundError: false for other fs error codes", (t) => {
+	const eacces = new Error("permission denied");
+	eacces.code = "EACCES";
+	t.false(isFileNotFoundError(eacces));
+});
+
+test("isFileNotFoundError: false for a message-only error without a code", (t) => {
+	// The less compiler reports a missing import as a message string with no `code`, so it must
+	// stay on the deterministic path rather than being retried forever.
+	t.false(isFileNotFoundError(new Error("Could not find file at path '/foo.less'")));
+});
+
+test("isFileNotFoundError: false for null / undefined", (t) => {
+	t.false(isFileNotFoundError(null));
+	t.false(isFileNotFoundError(undefined));
+});


### PR DESCRIPTION
Switching branches while `ui5 serve` runs moves source paths out from under the
server. The watcher coalesces change events, so a file can be gone before its
delete event lands, and a read then fails with `ENOENT`. Three layers treated
that as fatal:

- `@ui5/fs`: a match removed between the glob walk and its stat failed the whole `byGlob`.
  - The stat now resolves to `null` on `ENOENT`, so the missing match is dropped from the results, matching `_byPath`.
- `@ui5/project` build: the classifier decided transient-vs-fatal on timing alone, so a checkout-race build latched `ERRORED` and the server stopped serving.
  - An `ENOENT` failure is now classified as transient regardless of timing, so the build is re-queued instead of latching the error gate.
- `@ui5/project` cache validation: a non-abort error went to `emit("error")`, which the serve command forwards to the yargs fail-handler, killing the process.
  - `ENOENT` is now treated as transient here too, so validation falls back to its initial state instead of terminating the server.

Each fix defers the retry to the settled tree and ships with tests.
