### PR TITLE
build: Add jsconfig.json

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"checkJs": false,
+		"module": "nodenext",
+		"target": "esnext"
+	},
+	"include": [
+		"packages/*/lib/**/*.js",
+		"packages/*/bin/**/*.js",
+		"internal/*/lib/**/*.js"
+	],
+	"exclude": [
+		"node_modules",
+		"**/test/**",
+		"**/coverage/**"
+	]
+}


### PR DESCRIPTION
This configuration file instructs the TypeScript LSP plugin (used in VSCode, Claude Code, etc) not to type check our JS sources. It would otherwise flag our JSDoc as erroneous since it doesn't follow the TypeScript standard.
