### PR TITLE
docs(documentation): Add build script that runs full generation sequence

### DIFF
--- a/internal/documentation/package.json
+++ b/internal/documentation/package.json
@@ -25,6 +25,7 @@
 		"start": "vitepress dev --open",
 		"lint": "eslint .",
 		"dev": "vitepress dev",
+		"build": "npm run jsdoc-generate && npm run generate-cli-doc && npm run build:vitepress && npm run build:assets",
 		"build:vitepress": "vitepress build",
 		"build:assets": "sh -c 'DEST_DIR=${1:-./dist}; cp -r ./docs/images \"$DEST_DIR/images\"' --",
 		"preview": "vitepress preview --port 8080",


### PR DESCRIPTION
build:vitepress requires docs/api/ (jsdoc) and docs/pages/CLI.md (generate-cli-doc) to exist before it runs. Without them the config load crashes with ENOENT. The new build script wires the correct sequence so a fresh clone can produce the docs with one command.
