### PR TITLE
test(server): Force pure-JS polling watcher

### DIFF
--- a/packages/server/test/lib/server/reinitialize.js
+++ b/packages/server/test/lib/server/reinitialize.js
@@ -1,3 +1,4 @@
+import "../../utils/forcePollingWatcher.js";
 import test from "ava";
 import supertest from "supertest";
 import fs from "node:fs/promises";

--- a/packages/server/test/lib/server/reinitializeConcurrency.js
+++ b/packages/server/test/lib/server/reinitializeConcurrency.js
@@ -1,3 +1,4 @@
+import "../../utils/forcePollingWatcher.js";
 import test from "ava";
 import supertest from "supertest";
 import fs from "node:fs/promises";

--- a/packages/server/test/lib/server/reinitializeMissingDependency.js
+++ b/packages/server/test/lib/server/reinitializeMissingDependency.js
@@ -1,3 +1,4 @@
+import "../../utils/forcePollingWatcher.js";
 import test from "ava";
 import supertest from "supertest";
 import fs from "node:fs/promises";

--- a/packages/server/test/utils/forcePollingWatcher.js
+++ b/packages/server/test/utils/forcePollingWatcher.js
@@ -1,0 +1,6 @@
+// Forces the polling watcher for the importing test file. Re-init tests subscribe and unsubscribe
+// many overlapping native @parcel/watcher handles during teardown, hitting a native data race that
+// crashes the worker with an access violation (0xC0000005 on Windows) on exit; see
+// parcel-bundler/watcher#259. Polling avoids the native watcher.
+// Scoped per-file so other server tests still cover the native watcher.
+process.env.UI5_WATCH_MODE = "polling";


### PR DESCRIPTION
Should fix the currently flaky CI tests for the server package on Windows, which crash with an access violation (0xC0000005) in @parcel/watcher during re-init test teardown.
