### PR TITLE
ci: Prevent internal packages from declaring production dependencies

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -33,27 +33,8 @@ jobs:
     - name: Check Node.js engine compatibility
       run: npm run check-engine
 
-    - name: Check package.json "engines" consistency
-      run: |
-        node << 'EOF'
-        const { execSync } = require('child_process');
-        const fs = require('fs');
-
-        const rootPkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-        const workspaces = JSON.parse(execSync('npm query .workspace --json', { encoding: 'utf8' }));
-
-        let hasError = false;
-        workspaces.forEach(pkg => {
-          if (JSON.stringify(pkg.engines) !== JSON.stringify(rootPkg.engines)) {
-            console.error(`❌ ${pkg.location}/package.json "engines" mismatch with root package.json`);
-            hasError = true;
-          }
-        });
-
-        if (hasError) process.exit(1);
-        console.log('✅ All workspace packages "engines" are consistent with root package.json');
-
-        EOF
+    - name: Check package.json workspace consistency
+      run: npm run check-workspaces
 
     - name: Perform ESLint check
       run: npm run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-UI5 CLI v5 — an open, modular toolchain for developing UI5 framework applications. This is a **monorepo** using npm workspaces containing 6 public packages and 2 internal packages. All code uses **ESM** (`"type": "module"`).
+UI5 CLI v5 — an open, modular toolchain for developing UI5 framework applications. This is a **monorepo** using npm workspaces containing 6 public packages and 4 internal packages. All code uses **ESM** (`"type": "module"`).
 
 **Node requirement**: `^22.20.0 || >=24.0.0`
 
@@ -64,6 +64,10 @@ npm run coverage --workspace=@ui5/server  # Single package
 Internal packages:
 - `internal/documentation` — VitePress docs + JSDoc + JSON schema generation
 - `internal/shrinkwrap-extractor` — npm shrinkwrap utilities
+
+### Internal package dependencies
+
+Packages under `internal/*` are private and never published. They MUST declare **all** dependencies as `devDependencies` — declaring a production `"dependencies"` entry is not allowed. Reason: Dependabot derives the commit-message type from prod vs. dev dependency updates (`deps` vs. `build(deps-dev)`) and does not treat internal packages differently, so a production dependency there yields a misleading `deps` commit. A CI check in `.github/workflows/github-ci.yml` ("Check internal packages declare no production dependencies") enforces this.
 
 ## Code Style
 

--- a/internal/benchmark/package.json
+++ b/internal/benchmark/package.json
@@ -17,10 +17,8 @@
 		"coverage": "node --test --experimental-test-coverage 'test/e2e/**/*.js'",
 		"lint": "eslint ."
 	},
-	"dependencies": {
-		"js-yaml": "^4.3.1"
-	},
 	"devDependencies": {
-		"eslint": "^10.7.0"
+		"eslint": "^10.7.0",
+		"js-yaml": "^4.3.1"
 	}
 }

--- a/internal/documentation/package.json
+++ b/internal/documentation/package.json
@@ -35,21 +35,19 @@
 		"schema-generate-gh-pages": "node ./scripts/buildSchema.js gh-pages",
 		"download-packages": "./scripts/downloadPackages.sh"
 	},
-	"dependencies": {
+	"devDependencies": {
+		"@apidevtools/json-schema-ref-parser": "^14.2.1",
 		"@tailwindcss/vite": "^4.3.3",
 		"@types/node": "^25.2.2",
 		"autoprefixer": "^10.5.4",
 		"cssnano": "^7.1.9",
+		"handlebars": "^4.7.9",
+		"jsdoc": "^4.0.5",
 		"markdown-it-implicit-figures": "^0.12.0",
 		"postcss": "^8.5.23",
 		"tailwindcss": "^4.2.2",
+		"traverse": "^0.6.11",
 		"vitepress": "^1.6.4",
 		"vue": "^3.5.40"
-	},
-	"devDependencies": {
-		"@apidevtools/json-schema-ref-parser": "^14.2.1",
-		"handlebars": "^4.7.9",
-		"jsdoc": "^4.0.5",
-		"traverse": "^0.6.11"
 	}
 }

--- a/internal/e2e-tests/package.json
+++ b/internal/e2e-tests/package.json
@@ -12,7 +12,7 @@
 		"test-watch": "node --test --watch 'test/**/*.js'",
 		"lint": "eslint ."
 	},
-	"dependencies": {
+	"devDependencies": {
 		"adm-zip": "^0.6.0",
 		"execa": "^9.6.1"
 	}

--- a/internal/shrinkwrap-extractor/package.json
+++ b/internal/shrinkwrap-extractor/package.json
@@ -37,12 +37,10 @@
 		"node": "^22.22.2 || ^24.15.0 || >=26.0.0",
 		"npm": ">= 8"
 	},
-	"dependencies": {
+	"devDependencies": {
 		"@npmcli/arborist": "^9.9.0",
 		"@npmcli/config": "^11.0.1",
+		"eslint": "^10.7.0",
 		"pacote": "^21.5.1"
-	},
-	"devDependencies": {
-		"eslint": "^10.7.0"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,14 +35,12 @@
 		"internal/benchmark": {
 			"name": "@ui5-internal/benchmark",
 			"license": "Apache-2.0",
-			"dependencies": {
-				"js-yaml": "^4.3.1"
-			},
 			"bin": {
 				"ui5-cli-benchmark": "cli.js"
 			},
 			"devDependencies": {
-				"eslint": "^10.7.0"
+				"eslint": "^10.7.0",
+				"js-yaml": "^4.3.1"
 			},
 			"engines": {
 				"node": "^22.22.2 || ^24.15.0 || >=26.0.0",
@@ -53,22 +51,20 @@
 			"name": "@ui5/documentation",
 			"version": "0.0.1",
 			"license": "Apache-2.0",
-			"dependencies": {
+			"devDependencies": {
+				"@apidevtools/json-schema-ref-parser": "^14.2.1",
 				"@tailwindcss/vite": "^4.3.3",
 				"@types/node": "^25.2.2",
 				"autoprefixer": "^10.5.4",
 				"cssnano": "^7.1.9",
+				"handlebars": "^4.7.9",
+				"jsdoc": "^4.0.5",
 				"markdown-it-implicit-figures": "^0.12.0",
 				"postcss": "^8.5.23",
 				"tailwindcss": "^4.2.2",
+				"traverse": "^0.6.11",
 				"vitepress": "^1.6.4",
 				"vue": "^3.5.40"
-			},
-			"devDependencies": {
-				"@apidevtools/json-schema-ref-parser": "^14.2.1",
-				"handlebars": "^4.7.9",
-				"jsdoc": "^4.0.5",
-				"traverse": "^0.6.11"
 			},
 			"engines": {
 				"node": "^22.22.2 || ^24.15.0 || >=26.0.0",
@@ -79,6 +75,7 @@
 			"version": "25.9.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
 			"integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": ">=7.24.0 <7.24.7"
@@ -87,7 +84,7 @@
 		"internal/e2e-tests": {
 			"name": "@ui5-internal/e2e-tests",
 			"license": "Apache-2.0",
-			"dependencies": {
+			"devDependencies": {
 				"adm-zip": "^0.6.0",
 				"execa": "^9.6.1"
 			},
@@ -100,16 +97,14 @@
 			"name": "@ui5/shrinkwrap-extractor",
 			"version": "1.0.0",
 			"license": "Apache-2.0",
-			"dependencies": {
-				"@npmcli/arborist": "^9.9.0",
-				"@npmcli/config": "^11.0.1",
-				"pacote": "^21.5.1"
-			},
 			"bin": {
 				"shrinkwrap-extractor": "cli.js"
 			},
 			"devDependencies": {
-				"eslint": "^10.7.0"
+				"@npmcli/arborist": "^9.9.0",
+				"@npmcli/config": "^11.0.1",
+				"eslint": "^10.7.0",
+				"pacote": "^21.5.1"
 			},
 			"engines": {
 				"node": "^22.22.2 || ^24.15.0 || >=26.0.0",
@@ -126,6 +121,7 @@
 			"version": "1.22.0",
 			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
 			"integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -141,6 +137,7 @@
 			"version": "1.17.7",
 			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
 			"integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
@@ -151,6 +148,7 @@
 			"version": "1.17.7",
 			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
 			"integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/autocomplete-shared": "1.17.7"
@@ -163,6 +161,7 @@
 			"version": "1.17.7",
 			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
 			"integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/autocomplete-shared": "1.17.7"
@@ -176,6 +175,7 @@
 			"version": "1.17.7",
 			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
 			"integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@algolia/client-search": ">= 4.9.1 < 6",
@@ -186,6 +186,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
 			"integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -201,6 +202,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
 			"integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -216,6 +218,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
 			"integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14.0.0"
@@ -225,6 +228,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
 			"integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -240,6 +244,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
 			"integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -255,6 +260,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
 			"integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -270,6 +276,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
 			"integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -285,6 +292,7 @@
 			"version": "1.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
 			"integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -300,6 +308,7 @@
 			"version": "1.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
 			"integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -315,6 +324,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
 			"integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0",
@@ -330,6 +340,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
 			"integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0"
@@ -342,6 +353,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
 			"integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0"
@@ -354,6 +366,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
 			"integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/client-common": "5.56.0"
@@ -866,6 +879,7 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.5.0.tgz",
 			"integrity": "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@commitlint/cli": {
@@ -1215,12 +1229,14 @@
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
 			"integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@docsearch/js": {
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
 			"integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@docsearch/react": "3.8.2",
@@ -1231,6 +1247,7 @@
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
 			"integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/autocomplete-core": "1.17.7",
@@ -1263,6 +1280,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
 			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1274,6 +1292,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
 			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1284,6 +1303,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
 			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1331,6 +1351,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1347,6 +1368,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1363,6 +1385,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1379,6 +1402,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1395,6 +1419,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1411,6 +1436,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1427,6 +1453,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1443,6 +1470,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1459,6 +1487,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1475,6 +1504,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1491,6 +1521,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1507,6 +1538,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1523,6 +1555,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1539,6 +1572,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1555,6 +1589,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1571,6 +1606,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1587,6 +1623,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1603,6 +1640,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1619,6 +1657,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1635,6 +1674,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1651,6 +1691,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1667,6 +1708,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1683,6 +1725,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1925,6 +1968,7 @@
 			"version": "1.2.90",
 			"resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.90.tgz",
 			"integrity": "sha512-zt2o2ZvQpHVvZJARIkZ51RnaHY2oqcPJMvHE+mVnxkSr+c33fnX4gciiXu+wyX5ei+s0qbVX1wD0DWBbaGBYMA==",
+			"dev": true,
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@iconify/types": "*"
@@ -1934,6 +1978,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
 			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@isaacs/cliui": {
@@ -2009,6 +2054,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
 			"integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/@istanbuljs/esm-loader-hook": {
@@ -2095,6 +2141,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -2200,6 +2247,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
 			"integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -2291,6 +2339,7 @@
 			"version": "9.9.0",
 			"resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.9.0.tgz",
 			"integrity": "sha512-tzsb1R8mx0k0drlLDT/9ckEYaQHIaWnUti/ci2IaFoQqdqwfmYrc+90p1+QEZC/ocvqcxBep9P1xKw4FbAGofw==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"@gar/promise-retry": "^1.0.0",
@@ -2339,6 +2388,7 @@
 			"version": "11.5.2",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
 			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -2643,6 +2693,7 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
 			"integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/name-from-folder": "^4.0.0",
@@ -2658,6 +2709,7 @@
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
 			"integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cacache": "^20.0.0",
@@ -2674,6 +2726,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
 			"integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -2722,6 +2775,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
 			"integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"postcss-selector-parser": "^7.0.0"
@@ -3860,6 +3914,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3873,6 +3928,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3886,6 +3942,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3899,6 +3956,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3912,6 +3970,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3925,6 +3984,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3938,6 +3998,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -3954,6 +4015,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -3970,6 +4032,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -3986,6 +4049,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -4002,6 +4066,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -4018,6 +4083,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -4034,6 +4100,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -4050,6 +4117,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -4066,6 +4134,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -4082,6 +4151,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -4098,6 +4168,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -4114,6 +4185,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -4130,6 +4202,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -4146,6 +4219,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4159,6 +4233,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4172,6 +4247,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4185,6 +4261,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4198,6 +4275,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4211,6 +4289,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4221,12 +4300,14 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
 			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@shikijs/core": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
 			"integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/engine-javascript": "2.5.0",
@@ -4241,6 +4322,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
 			"integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/types": "2.5.0",
@@ -4252,6 +4334,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
 			"integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/types": "2.5.0",
@@ -4262,6 +4345,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
 			"integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/types": "2.5.0"
@@ -4271,6 +4355,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
 			"integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/types": "2.5.0"
@@ -4280,6 +4365,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
 			"integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/core": "2.5.0",
@@ -4290,6 +4376,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
 			"integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/vscode-textmate": "^10.0.2",
@@ -4300,6 +4387,7 @@
 			"version": "10.0.2",
 			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
 			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@sigstore/bundle": {
@@ -4475,6 +4563,7 @@
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
 			"integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.5",
@@ -4490,6 +4579,7 @@
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
 			"integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 20"
@@ -4516,6 +4606,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4532,6 +4623,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4548,6 +4640,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4564,6 +4657,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4580,6 +4674,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4596,6 +4691,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -4615,6 +4711,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -4634,6 +4731,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -4653,6 +4751,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -4680,6 +4779,7 @@
 			"cpu": [
 				"wasm32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -4701,6 +4801,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4717,6 +4818,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4730,6 +4832,7 @@
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
 			"integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@tailwindcss/node": "4.3.3",
@@ -4766,6 +4869,7 @@
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
 			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -4783,12 +4887,14 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
 			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/hast": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
 			"integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
@@ -4821,6 +4927,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
 			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
@@ -4836,7 +4943,7 @@
 			"version": "26.1.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
 			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4847,7 +4954,7 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
 			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -4861,12 +4968,14 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
 			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/web-bluetooth": {
 			"version": "0.0.21",
 			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
 			"integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/types": {
@@ -4890,6 +4999,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4907,6 +5017,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4924,6 +5035,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4941,6 +5053,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4958,6 +5071,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4975,6 +5089,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4992,6 +5107,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5009,6 +5125,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5026,6 +5143,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5043,6 +5161,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5060,6 +5179,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5077,6 +5197,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5094,6 +5215,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5111,6 +5233,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5128,6 +5251,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5145,6 +5269,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5162,6 +5287,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5179,6 +5305,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5196,6 +5323,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5213,6 +5341,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5267,6 +5396,7 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
 			"integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/@vercel/nft": {
@@ -5300,6 +5430,7 @@
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
 			"integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.0.0 || >=20.0.0"
@@ -5313,6 +5444,7 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
 			"integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.29.7",
@@ -5326,6 +5458,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
 			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
@@ -5338,6 +5471,7 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
 			"integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vue/compiler-core": "3.5.40",
@@ -5348,6 +5482,7 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
 			"integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.29.7",
@@ -5365,6 +5500,7 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
 			"integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vue/compiler-dom": "3.5.40",
@@ -5375,6 +5511,7 @@
 			"version": "7.7.10",
 			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
 			"integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vue/devtools-kit": "^7.7.10"
@@ -5384,6 +5521,7 @@
 			"version": "7.7.10",
 			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
 			"integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vue/devtools-shared": "^7.7.10",
@@ -5399,6 +5537,7 @@
 			"version": "7.7.10",
 			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
 			"integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"rfdc": "^1.4.1"
@@ -5408,6 +5547,7 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
 			"integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vue/shared": "3.5.40"
@@ -5417,6 +5557,7 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
 			"integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vue/reactivity": "3.5.40",
@@ -5427,6 +5568,7 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
 			"integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vue/reactivity": "3.5.40",
@@ -5439,6 +5581,7 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
 			"integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vue/compiler-ssr": "3.5.40",
@@ -5450,12 +5593,14 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
 			"integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@vueuse/core": {
 			"version": "12.8.2",
 			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
 			"integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/web-bluetooth": "^0.0.21",
@@ -5471,6 +5616,7 @@
 			"version": "12.8.2",
 			"resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
 			"integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vueuse/core": "12.8.2",
@@ -5537,6 +5683,7 @@
 			"version": "12.8.2",
 			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
 			"integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -5546,6 +5693,7 @@
 			"version": "12.8.2",
 			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
 			"integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"vue": "^3.5.13"
@@ -5640,6 +5788,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
 			"integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0"
@@ -5707,6 +5856,7 @@
 			"version": "5.56.0",
 			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
 			"integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/abtesting": "1.22.0",
@@ -6041,6 +6191,7 @@
 			"version": "10.5.4",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
 			"integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6313,6 +6464,7 @@
 			"version": "2.10.43",
 			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
 			"integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
@@ -6325,6 +6477,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.2.tgz",
 			"integrity": "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cmd-shim": "^8.0.0",
@@ -6351,6 +6504,7 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
 			"integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -6473,6 +6627,7 @@
 			"version": "4.28.6",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
 			"integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6699,6 +6854,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
 			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.0.0",
@@ -6711,6 +6867,7 @@
 			"version": "1.0.30001806",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
 			"integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6756,6 +6913,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
 			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -6778,6 +6936,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
 			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -6788,6 +6947,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
 			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -7168,6 +7328,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
 			"integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -7221,6 +7382,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
 			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -7257,6 +7419,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
 			"integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">= 18"
@@ -7649,6 +7812,7 @@
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
 			"integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-what": "^5.2.0"
@@ -7805,6 +7969,7 @@
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
 			"integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
@@ -7833,6 +7998,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
 			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.27.1",
@@ -7858,6 +8024,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
@@ -7870,6 +8037,7 @@
 			"version": "7.1.9",
 			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.9.tgz",
 			"integrity": "sha512-uPR75+5Dk/WJ/YSPR1/YDHdwMM9c5FsaARljfKWgeCKLKOtJ0we21xy/RcCjn53fZnD/f6yYEIZ8pu18+GnbNQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssnano-preset-default": "^7.0.17",
@@ -7890,6 +8058,7 @@
 			"version": "7.0.17",
 			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.17.tgz",
 			"integrity": "sha512-11qO63A+czwguQFJCaTdICvbaxn0pJzz/XghLlv+OT7WyToDxAMR0Xb3/26/l0y0hQJywwNbj/SLSQlGBHE1OA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
@@ -7934,6 +8103,7 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.3.tgz",
 			"integrity": "sha512-ynIREMICLxkxm7e9bCR9sh75s4Q5drICi0ua1yxo5jH2XPBqSKkl4dOh4EbFqtUmnTMhRffHgYL0EKKkMjtJTg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -7946,6 +8116,7 @@
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
 			"integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-tree": "~2.2.0"
@@ -7959,6 +8130,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
 			"integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.0.28",
@@ -7973,12 +8145,14 @@
 			"version": "2.0.28",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
 			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/currently-unhandled": {
@@ -8228,6 +8402,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -8355,6 +8530,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
 			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dequal": "^2.0.0"
@@ -8551,6 +8727,7 @@
 			"version": "1.5.393",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
 			"integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/emittery": {
@@ -8576,6 +8753,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
 			"integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/encodeurl": {
@@ -8616,6 +8794,7 @@
 			"version": "5.24.2",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
 			"integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -8845,6 +9024,7 @@
 			"version": "0.21.5",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
 			"integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -9296,6 +9476,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
 			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/esutils": {
@@ -9337,6 +9518,7 @@
 			"version": "9.6.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
 			"integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/merge-streams": "^4.0.0",
@@ -9718,6 +9900,7 @@
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
 			"integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tabbable": "^6.4.0"
@@ -9819,6 +10002,7 @@
 			"version": "5.3.4",
 			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
 			"integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -9888,6 +10072,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -10045,6 +10230,7 @@
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
 			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@sec-ant/readable-stream": "^0.4.1",
@@ -10383,6 +10569,7 @@
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
 			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
@@ -10406,6 +10593,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
 			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0"
@@ -10419,6 +10607,7 @@
 			"version": "5.5.3",
 			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
 			"integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/hosted-git-info": {
@@ -10518,6 +10707,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
 			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -10605,6 +10795,7 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
 			"integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18.0"
@@ -11264,6 +11455,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
 			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -11350,6 +11542,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
 			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -11478,6 +11671,7 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
 			"integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -11680,6 +11874,7 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
 			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
@@ -11967,6 +12162,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
 			"integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
+			"dev": true,
 			"license": "ISC",
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -12015,12 +12211,14 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
 			"integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/just-diff-apply": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
 			"integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/keyv": {
@@ -12179,6 +12377,7 @@
 			"version": "1.32.0",
 			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
 			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
 			"license": "MPL-2.0",
 			"dependencies": {
 				"detect-libc": "^2.0.3"
@@ -12211,6 +12410,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12231,6 +12431,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12251,6 +12452,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12271,6 +12473,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12291,6 +12494,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12311,6 +12515,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -12334,6 +12539,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -12357,6 +12563,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -12380,6 +12587,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -12403,6 +12611,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12423,6 +12632,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12440,6 +12650,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
 			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
@@ -12555,12 +12766,14 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/log-update": {
@@ -12661,6 +12874,7 @@
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
 			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
@@ -12716,6 +12930,7 @@
 			"version": "8.11.1",
 			"resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
 			"integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/markdown-it": {
@@ -12759,6 +12974,7 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/markdown-it-implicit-figures/-/markdown-it-implicit-figures-0.12.0.tgz",
 			"integrity": "sha512-IeD2V74f3ZBYrZ+bz/9uEGii0S61BYoD2731qsHTgYLlENUrTevlgODScScS1CK44/TV9ddlufGHCYCQueh1rw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -12831,6 +13047,7 @@
 			"version": "13.2.1",
 			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
 			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
@@ -12852,6 +13069,7 @@
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
 			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/mdurl": {
@@ -12940,6 +13158,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
 			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -12960,6 +13179,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
 			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -12976,6 +13196,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
 			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -12997,6 +13218,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
 			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -13013,6 +13235,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
 			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -13250,6 +13473,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
 			"integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/minizlib": {
@@ -13268,6 +13492,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
 			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mkdirp": {
@@ -13292,6 +13517,7 @@
 			"version": "3.3.18",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
 			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -13409,6 +13635,7 @@
 			"version": "2.0.51",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
 			"integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -13562,6 +13789,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
 			"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^4.0.0",
@@ -13578,6 +13806,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
 			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -13964,6 +14193,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
 			"integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex-xs": "^1.0.0",
@@ -14259,6 +14489,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
 			"integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"json-parse-even-better-errors": "^5.0.0",
@@ -14309,6 +14540,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
 			"integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -14470,6 +14702,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
 			"integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/picocolors": {
@@ -14546,6 +14779,7 @@
 			"version": "8.5.23",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
 			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -14574,6 +14808,7 @@
 			"version": "10.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
 			"integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^7.0.0",
@@ -14590,6 +14825,7 @@
 			"version": "7.0.10",
 			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.10.tgz",
 			"integrity": "sha512-yFr6JezOolHLta/buLE71VKPh2mXursp4saVe98/ol8ZnEWhL+racShqPKlvd/DKWLre/39B6HhcMXf7RZ3hxg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@colordx/core": "^5.4.3",
@@ -14608,6 +14844,7 @@
 			"version": "7.0.12",
 			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.12.tgz",
 			"integrity": "sha512-xurKu5qqk4viR3Cp3p4xBR4KfnZm4w4ys6+UBwBmeuBSNkH7+DtLnYOYnOffgtE4yx8sH9S1VZ6RAAvROXzP2Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
@@ -14624,6 +14861,7 @@
 			"version": "7.0.8",
 			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.8.tgz",
 			"integrity": "sha512-CvvS5S9WrXblFXCEJ9nVo+4z+eA7zSC7Z88V1HEJuwlQhlFnYTIjg1xJY+BCUiG2bvICap2tXii4mP22BD108Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^7.1.1"
@@ -14639,6 +14877,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.4.tgz",
 			"integrity": "sha512-VBNn1+EuMZkeGVVtz0gRfbNGtx9IFgAsAV+E2pHtXPrp4qfGBkhTIiAuE/wrb+Y6Pakg9NewAlfTpYIFAWODtw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -14651,6 +14890,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.3.tgz",
 			"integrity": "sha512-M2pyjQCU+/7cMHVtL6bKTHjv0lZnPLMpicgr67Dlth7AbuV9gjVTtUqaRwn6Pp6BwSDspUzhz8SaUrRykJU5Dw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -14663,6 +14903,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.3.tgz",
 			"integrity": "sha512-aNovXo9UsZuRNLzHJtp13lHIvinDPfiXBPePpXkSjCbgp++iU2FqE+YxvjIsg6EdyPZsASFbfu+JcBFVsErXIQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -14675,6 +14916,7 @@
 			"version": "7.0.7",
 			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.7.tgz",
 			"integrity": "sha512-b3mfYUxR388u5Pt0HPcVIUtUDn/k15UfTY9M+ORW+meCR6JLNxoZffiYvXyOYQoRYQNZyX/UFkMCM/mNHxe1qA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
@@ -14691,6 +14933,7 @@
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.11.tgz",
 			"integrity": "sha512-SJUPM18g2BmPhf8BVlbwqWz4aK3pLu6u6xjfwEzra7xL6IBR10sUaiB++EzqcVfadPHrKBSMlNdP+XieykhI+Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
@@ -14709,6 +14952,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.3.tgz",
 			"integrity": "sha512-yilG/VOaNI74IylQvAQQxm3/wZVBkXyYUqNUAdxqwtbWUXPsbK1q8Ms0mL83v+f8YicgcyfYCRZtWACUdYajpA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -14724,6 +14968,7 @@
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.5.tgz",
 			"integrity": "sha512-YraROyQRg3BI1+Hg8E05B/JPdnTm8EDSVu4P2BxdM+CRiOyfmou809+chGIqo6fQqwjPGQ947nbGncSjmTU1WQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@colordx/core": "^5.4.3",
@@ -14741,6 +14986,7 @@
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.9.tgz",
 			"integrity": "sha512-R8itbB8BhlpoYyBm1ou0dD+vJnQ3F6adQipR4UnkCHUwlo+S9WXJaDRg1RHjC8YVAtIdrQzSWvJl40HnGDTKjA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
@@ -14758,6 +15004,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.1.2.tgz",
 			"integrity": "sha512-aQtrEWKwqafNlExcKHQvPGsXR2+vlUqqJtf5XsCQcgsSb5PL4wlujWBYDJuWsP4UnQX1YHDHU8qRlD+1PzTQ+Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.1",
@@ -14776,6 +15023,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.3.tgz",
 			"integrity": "sha512-NoBfZu8PR4c2NlmjvrqQTzCzLY79hwcSRgNQ3ZiNK0ABzf9kYKloE/jNj+/8GQY1wsm8pRRgANk6ydLH8cwo0Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -14788,6 +15036,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.3.tgz",
 			"integrity": "sha512-ldsCX0QIt05pKIOobZtVQ48wXJecr+czw4+e1/YjVhLMqslShgpVxgPtI2CefURR8oyVoYaU/l829MMwExDMLw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -14803,6 +15052,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.4.tgz",
 			"integrity": "sha512-VEvlpeGd3Ju1Hqa/oN4jaP3+ms4laYwkEL9N9u+B6k54PZjXbW1n6wI+aVprf1BQXlCYpS5+1pl/7/vHiKgARg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -14818,6 +15068,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.4.tgz",
 			"integrity": "sha512-6mPKlY/8cSaDHxX502wERADarJsccwlky6yIrOapHH2ZgfoKAV94SbiTKfKEs4EEpdazuc3J72WsqeYk7hp9+Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -14833,6 +15084,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.3.tgz",
 			"integrity": "sha512-HnEQPUchi1eznmDKEYrKUTqrprEq97SrpUYClgUkv7V2zRODD9DFoUsYU+m9ZOetmD5ku7fEMZB/lwy8IT6xVQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -14848,6 +15100,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.3.tgz",
 			"integrity": "sha512-zmEzHdvpZBZu0OKlbJSfgASQvaayyAoVuWtvyr34IJ/LyS+DaOKvvR3EvFJ9RWWtNIx+CMvO125OVophaxNYew==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -14863,6 +15116,7 @@
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.9.tgz",
 			"integrity": "sha512-DRAdWfeh/TjmhLJsw91vdiWCnUod9iwvM7xyS02/nF/sLsCR3A8l3pztrSUrWG8DSBqfX7yEk9FM0USaVJ2mSg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
@@ -14879,6 +15133,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.3.tgz",
 			"integrity": "sha512-CL93wmloq5qsffmFv+bw24MIRbmhHrp53qoh1LDAb/5TtjWEXI/np4xcP/Gw9oWCb2XyWnqHYLDUwiKRoJBA1Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -14894,6 +15149,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.3.tgz",
 			"integrity": "sha512-FdHjjn+Ht5Z2ZRjNOmeCbNq6lq09sUYKpmlF/Aq0XjVNSLTL6fmHlA/3swN2wP2caY9GV/tjSDcIIyS7aN7W0A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -14909,6 +15165,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.4.tgz",
 			"integrity": "sha512-nubSi49hDHQk4E8KIj+IbLY8Bg+8OcSUEhgyolgM+atnOvXjV7EjaR6bac4YGZoFyPa9mWoAF3EaYbWdFkKqVg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssnano-utils": "^5.0.3",
@@ -14925,6 +15182,7 @@
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.9.tgz",
 			"integrity": "sha512-ztTNPdIxXTxtBcG03E9u8v44M4ElXbMIRT7pf2onlquGula0Y83nKKxqM22FA/hMgkfCjN7ohevkVlaNwI8iOQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
@@ -14941,6 +15199,7 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.3.tgz",
 			"integrity": "sha512-FXsnN9ZwcZTT8Yf8cAHA8qIGUXcX6WfLd9JoYhrdDfmvsVhhfqkkv7m4AC3rwFOfz+GzkUa87OCKF9dUcicd+g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -14956,6 +15215,7 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
 			"integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -14969,6 +15229,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.3.tgz",
 			"integrity": "sha512-2QfoFOYMcj8lwcVEf9WeTlkVIAm7u2QvOEhMzkQU3KUhhGX/l8hVV9EtjMv4iq3E9iI3OeeMN0YoMLbGusuigw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
@@ -14985,6 +15246,7 @@
 			"version": "7.0.7",
 			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.7.tgz",
 			"integrity": "sha512-d+sCkaRnSefghOUdH8CMJZV9yUQhj2ojpe8Nw/lA+LV1UOfeleGkLTl6XdCFFSai9UJ+DJPb69FFuqthXYsY8w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^7.1.1"
@@ -15000,6 +15262,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/powershell-utils": {
@@ -15018,6 +15281,7 @@
 			"version": "10.29.7",
 			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
 			"integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -15064,6 +15328,7 @@
 			"version": "9.3.0",
 			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
 			"integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"parse-ms": "^4.0.0"
@@ -15107,6 +15372,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
 			"integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -15116,6 +15382,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
 			"integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+			"dev": true,
 			"license": "ISC",
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -15125,6 +15392,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
 			"integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
+			"dev": true,
 			"license": "ISC",
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -15134,6 +15402,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
 			"integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -15317,6 +15586,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
 			"integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -15480,6 +15750,7 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
 			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"regex-utilities": "^2.3.0"
@@ -15489,6 +15760,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
 			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"regex-utilities": "^2.3.0"
@@ -15498,6 +15770,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
 			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/regexp.prototype.flags": {
@@ -15691,6 +15964,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
 			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/rimraf": {
@@ -15717,6 +15991,7 @@
 			"version": "4.62.2",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
 			"integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.9"
@@ -15912,6 +16187,7 @@
 			"version": "2.17.3",
 			"resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
 			"integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -16119,6 +16395,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
 			"integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/core": "2.5.0",
@@ -16341,6 +16618,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -16360,6 +16638,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
 			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -16600,6 +16879,7 @@
 			"version": "14.0.1",
 			"resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
 			"integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -16835,6 +17115,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
 			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"character-entities-html4": "^2.0.0",
@@ -16920,6 +17201,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
 			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -16959,6 +17241,7 @@
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.11.tgz",
 			"integrity": "sha512-iODNfhXVLqc5LADs+Y6Oh5wJuK5ZcHbVng8aiK3y9pjMQdc5hLrBW0eFU6FtnpNrE6PoEg/MmFTU4waotj5WNg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
@@ -17009,6 +17292,7 @@
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
 			"integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"copy-anything": "^4"
@@ -17101,6 +17385,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
 			"integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^11.1.0",
@@ -17126,6 +17411,7 @@
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
 			"integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=16"
@@ -17135,6 +17421,7 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
 			"integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tagged-tag": {
@@ -17153,12 +17440,14 @@
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
 			"integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
 			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -17438,6 +17727,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
 			"integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -17447,6 +17737,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
 			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -17655,7 +17946,7 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
 			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"bin": {
@@ -17755,6 +18046,7 @@
 			"version": "7.24.6",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
 			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unicorn-magic": {
@@ -17773,6 +18065,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
 			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0"
@@ -17786,6 +18079,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
 			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0"
@@ -17799,6 +18093,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
 			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0"
@@ -17812,6 +18107,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
 			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -17827,6 +18123,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
 			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -17850,6 +18147,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
 			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -17968,6 +18266,7 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
 			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -17982,6 +18281,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
 			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -17996,6 +18296,7 @@
 			"version": "5.4.21",
 			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.21.3",
@@ -18055,6 +18356,7 @@
 			"version": "1.6.4",
 			"resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
 			"integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@docsearch/css": "3.8.2",
@@ -18096,6 +18398,7 @@
 			"version": "3.5.40",
 			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
 			"integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vue/compiler-dom": "3.5.40",
@@ -18458,6 +18761,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
 			"integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"signal-exit": "^4.0.1"
@@ -18688,6 +18992,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
 			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -18710,6 +19015,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
 			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"lint:commit": "commitlint",
 		"unit": "npm run unit --workspaces --if-present",
 		"unit:summary": "node scripts/unit-summary.js",
+		"check-workspaces": "node scripts/check-workspaces.js",
 		"coverage": "npm run coverage --workspaces --if-present",
 		"knip": "knip --config knip.config.js",
 		"check-engine": "check-engine-light .",

--- a/scripts/check-workspaces.js
+++ b/scripts/check-workspaces.js
@@ -1,0 +1,51 @@
+import {execSync} from "node:child_process";
+import {readFileSync} from "node:fs";
+import {resolve} from "node:path";
+
+const rootDir = resolve(import.meta.dirname, "..");
+const rootPkg = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf8"));
+const workspaces = JSON.parse(execSync("npm query .workspace --json", {cwd: rootDir, encoding: "utf8"}));
+
+// Each check receives a workspace package descriptor (as returned by `npm query`) and returns
+// an error message string when the package violates the rule, or a falsy value when it passes.
+const checks = [
+	{
+		name: `All workspace packages "engines" are consistent with root package.json`,
+		check(pkg) {
+			if (JSON.stringify(pkg.engines) !== JSON.stringify(rootPkg.engines)) {
+				return `${pkg.location}/package.json "engines" mismatch with root package.json`;
+			}
+		},
+	},
+	{
+		// Dependabot picks the commit message type ("deps" vs. "build(deps-dev)") from whether an
+		// update targets "dependencies" or "devDependencies". It does not treat our internal,
+		// unpublished (private) packages any differently, so a production dependency there would
+		// produce a misleading "deps" commit. Internal packages are never published, so all their
+		// dependencies belong in "devDependencies".
+		name: "No internal package declares production dependencies",
+		check(pkg) {
+			if (!pkg.location.startsWith("internal/")) return;
+			const prodDeps = Object.keys(pkg.dependencies ?? {});
+			if (prodDeps.length > 0) {
+				return `${pkg.location}/package.json declares production "dependencies" ` +
+					`(${prodDeps.join(", ")}). Internal packages must declare all dependencies as "devDependencies".`;
+			}
+		},
+	},
+];
+
+let hasError = false;
+for (const {name, check} of checks) {
+	const errors = workspaces.map(check).filter(Boolean);
+	if (errors.length > 0) {
+		hasError = true;
+		for (const error of errors) {
+			console.error(`❌ ${error}`);
+		}
+	} else {
+		console.log(`✅ ${name}`);
+	}
+}
+
+process.exitCode = hasError ? 1 : 0;


### PR DESCRIPTION
Add a CI check that fails if any "internal/*" workspace package declares a production "dependencies" entry. All dependencies of these packages must be declared as "devDependencies".

Dependabot derives the commit-message type from whether an update targets "dependencies" or "devDependencies" ("deps" vs. "build(deps-dev)") and does not treat our internal, unpublished packages differently. A production dependency there therefore produces a misleading "deps" commit.

Migrate the existing production dependencies of the benchmark, documentation, e2e-tests and shrinkwrap-extractor internal packages to devDependencies, which is safe as these packages are private and never published.

Consolidate this check and the existing "engines" consistency check into a single reusable scripts/check-workspaces.js (run via "npm run check-workspaces"), replacing the two inline Node heredocs in github-ci.yml with one step.

Document the rule for contributors and agents in AGENTS.md.
