### PR TITLE
ci: Add patterns to github-actions Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,10 @@ updates:
   cooldown:
     default-days: 3
   groups:
-    github-actions-all:
+    github-actions:
       applies-to: version-updates
+      patterns:
+      - "*"
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -28,7 +30,7 @@ updates:
     prefix: "deps"
     prefix-development: "build(deps-dev)"
   groups:
-    npm-in-range:
+    in-range:
       applies-to: version-updates
       update-types:
       - minor


### PR DESCRIPTION
The github-actions group only declared applies-to, which failed Dependabot's group schema validation. Add patterns: ["*"] so the group matches all github-actions updates.

Also rename the update groups for brevity: github-actions-all -> github-actions and npm-in-range -> in-range.
